### PR TITLE
Use relative paths in pre-compiled CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.2
+
+## Bug Fixes
+
+* **css:** Use relative paths in pre-compiled CSS.
+
 # 0.1.1
 
 ## Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "author": "Mozilla",
   "description": "A design system for Mozilla's websites.",

--- a/src/assets/package/README.md
+++ b/src/assets/package/README.md
@@ -20,7 +20,7 @@ Install package with NPM and add it to your dependencies:
 </tr>
 <tr>
 <td>Version</td>
-<td>[0.1.1](https://github.com/mozilla/protocol/blob/master/CHANGELOG.md)</td>
+<td>[0.1.2](https://github.com/mozilla/protocol/blob/master/CHANGELOG.md)</td>
 </tr>
 </table>
 

--- a/src/assets/package/package.json
+++ b/src/assets/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A design system for Mozilla's websites.",
   "repository": {
     "type": "git",

--- a/src/assets/sass/protocol/protocol.scss
+++ b/src/assets/sass/protocol/protocol.scss
@@ -4,8 +4,8 @@
 
 
 // Default media paths can be overwritten globally.
-$font-path: '/node_modules/@mozilla-protocol/core/protocol/fonts' !default;
-$image-path: '/node_modules/@mozilla-protocol/core/protocol/img' !default;
+$font-path: '../fonts' !default;
+$image-path: '../img' !default;
 
 
 // These are general styles for elements/components that occur on every page.


### PR DESCRIPTION
- Use relative paths in pre-compiled CSS (fixes an issue in bedrock).
- Update version number to 0.1.2