### PR TITLE
Stop concatenating Protocol JS modules (Fixes #89)

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -59,12 +59,6 @@ module.exports = {
         }
     },
     concatJS: {
-        protocol: {
-            src: [
-                `${src}/js/protocol/*.js`
-            ],
-            dest: `${dest}/protocol/protocol/js/`
-        },
         docs: {
             src: [
                 `${src}/js/docs/**/*.js`

--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -3,7 +3,6 @@
       <link rel="stylesheet" href="{{@root.baseurl}}/assets/docs/css/protocol.css">
       <link rel="stylesheet" href="{{@root.baseurl}}/assets/docs/css/site.css">
       <link rel="stylesheet" href="{{@root.baseurl}}/assets/docs/css/prism.css">
-      <script src="{{@root.baseurl}}/assets/protocol/protocol/js/protocol.js"></script>
   {{/content}}
 
   {{#content "body"}}


### PR DESCRIPTION
I don't think there's much to be gained by a monolith JS file (I can't think why mozilla sites would use it). It's also causing unintended errors, like this:

<img width="1203" alt="screen shot 2018-05-17 at 18 03 26" src="https://user-images.githubusercontent.com/400117/40192563-a7233e0c-59fc-11e8-80f2-a5eecfedba63.png">
