### PR TITLE
Use handlebars templates for card examples (Fixes #108)

### DIFF
--- a/src/pages/demos/card-layout.hbs
+++ b/src/pages/demos/card-layout.hbs
@@ -24,70 +24,11 @@ styles:
   </header>
 
   <div class="mzp-l-card-hero">
-    <section class="mzp-c-card mzp-c-card-large mzp-has-aspect-16-9">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-has-aspect-1-1">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
+    {{#embed "patterns.molecules.card.large-card"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-has-aspect-1-1"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-has-aspect-3-2"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-has-aspect-3-2"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-has-aspect-3-2"}}{{/embed}}
   </div>
 </div>
 
@@ -102,57 +43,10 @@ styles:
   </header>
 
   <div class="mzp-l-card-quarter">
-    <section class="mzp-c-card mzp-c-card-extra-small has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">Headline that goes onto a second or third line</h2>
-          <p class="mzp-c-card-meta">6 hours ago</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-c-card-extra-small has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">Headline that goes onto a second or third line</h2>
-          <p class="mzp-c-card-meta">6 hours ago</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-c-card-extra-small has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">Headline that goes onto a second or third line</h2>
-          <p class="mzp-c-card-meta">6 hours ago</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-c-card-extra-small has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">Headline that goes onto a second or third line</h2>
-          <p class="mzp-c-card-meta">6 hours ago</p>
-        </div>
-      </a>
-    </section>
+    {{#embed "patterns.molecules.card.extra-small-card"}}{{/embed}}
+    {{#embed "patterns.molecules.card.extra-small-card"}}{{/embed}}
+    {{#embed "patterns.molecules.card.extra-small-card"}}{{/embed}}
+    {{#embed "patterns.molecules.card.extra-small-card"}}{{/embed}}
   </div>
 </div>
 
@@ -167,83 +61,12 @@ styles:
   </header>
 
   <div class="mzp-l-card-third">
-    <section class="mzp-c-card mzp-has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-has-aspect-1-1">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
+    {{#embed "patterns.molecules.card.small-card" class="mzp-has-aspect-3-2"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-has-aspect-1-1"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-has-aspect-3-2"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-has-aspect-3-2"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-has-aspect-3-2"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-has-aspect-3-2"}}{{/embed}}
   </div>
 </div>
 
@@ -257,32 +80,8 @@ styles:
   </header>
 
   <div class="mzp-l-card-half">
-    <section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
-
-    <section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-3-2">
-      <a class="mzp-c-card-block-link" href="#">
-        <div class="mzp-c-card-media-wrapper">
-          <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-        </div>
-        <div class="mzp-c-card-content">
-          <div class="mzp-c-card-tag">Tag</div>
-          <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-          <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-        </div>
-      </a>
-    </section>
-
+    {{#embed "patterns.molecules.card.medium-card"}}{{/embed}}
+    {{#embed "patterns.molecules.card.medium-card"}}{{/embed}}
   </div>
 </div>
 

--- a/src/patterns/molecules/card/collection.yml
+++ b/src/patterns/molecules/card/collection.yml
@@ -1,0 +1,4 @@
+name: Cards
+title: Cards
+labels:
+    - inprogress

--- a/src/patterns/molecules/card/extra-small-card.hbs
+++ b/src/patterns/molecules/card/extra-small-card.hbs
@@ -2,8 +2,6 @@
 name: Extra Small Card
 description: An extra small card with image, headline, description, and link.
 order: 4
-labels:
-    - inprogress
 notes: |
     - The card in this example has a slightly longer title and no description.
     - Optional card meta data is also displayed to show the time an article was published.
@@ -12,15 +10,10 @@ notes: |
     - Headlines should be a maximum of 40 characters, and descriptions a maximum of 140 characters.
 ---
 
-<section class="mzp-c-card mzp-c-card-extra-small has-aspect-3-2">
-  <a class="mzp-c-card-block-link" href="#">
-    <div class="mzp-c-card-media-wrapper">
-      <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-    </div>
-    <div class="mzp-c-card-content">
-      <div class="mzp-c-card-tag">Card tag</div>
-      <h2 class="mzp-c-card-title">Headline that goes onto a second or third line</h2>
-      <p class="mzp-c-card-meta">6 hours ago</p>
-    </div>
-  </a>
-</section>
+{{#embed "patterns.molecules.card.small-card" class="mzp-c-card-extra-small has-aspect-3-2"}}
+  {{#content "content"}}
+    <div class="mzp-c-card-tag">Card tag</div>
+    <h2 class="mzp-c-card-title">Headline that goes onto a second or third line</h2>
+    <p class="mzp-c-card-meta">6 hours ago</p>
+  {{/content}}
+{{/embed}}

--- a/src/patterns/molecules/card/large-card.hbs
+++ b/src/patterns/molecules/card/large-card.hbs
@@ -2,8 +2,6 @@
 name: Large Card
 description: A large card with image, headline, description, and link.
 order: 1
-labels:
-    - inprogress
 notes: |
     - Large sized cards display larger text to other card types, as well as larger images.
     - Large sized cards should contain images with 16:9 or 3:2 aspect ratios only.
@@ -11,15 +9,4 @@ notes: |
     - Headlines should be a maximum of 40 characters, and descriptions a maximum of 140 characters.
 ---
 
-<section class="mzp-c-card mzp-c-card-large mzp-has-aspect-16-9">
-  <a class="mzp-c-card-block-link" href="#">
-    <div class="mzp-c-card-media-wrapper">
-      <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-    </div>
-    <div class="mzp-c-card-content">
-      <div class="mzp-c-card-tag">Card tag</div>
-      <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-      <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-    </div>
-  </a>
-</section>
+{{#embed "patterns.molecules.card.small-card" class="mzp-c-card-large mzp-has-aspect-16-9"}}{{/embed}}

--- a/src/patterns/molecules/card/medium-card.hbs
+++ b/src/patterns/molecules/card/medium-card.hbs
@@ -2,8 +2,6 @@
 name: Medium Card
 description: A medium card with image, headline, description, and link.
 order: 2
-labels:
-    - inprogress
 notes: |
     - Medium sized cards contain larger images but the same sized text as regular cards.
     - Medium sized cards can contain images with 16:9, 3:2 or 1:1 aspect ratios.
@@ -12,15 +10,4 @@ notes: |
     - Headlines should be a maximum of 40 characters, and descriptions a maximum of 140 characters.
 ---
 
-<section class="mzp-c-card mzp-c-card-medium mzp-has-aspect-3-2 mzp-has-video">
-  <a class="mzp-c-card-block-link" href="#">
-    <div class="mzp-c-card-media-wrapper">
-      <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
-    </div>
-    <div class="mzp-c-card-content">
-      <div class="mzp-c-card-tag">Card tag</div>
-      <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
-      <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
-    </div>
-  </a>
-</section>
+{{#embed "patterns.molecules.card.small-card" class="mzp-c-card-medium mzp-has-aspect-3-2 mzp-has-video"}}{{/embed}}

--- a/src/patterns/molecules/card/small-card.hbs
+++ b/src/patterns/molecules/card/small-card.hbs
@@ -2,8 +2,6 @@
 name: Small Card
 description: A small card with image, headline, description, and link.
 order: 3
-labels:
-    - inprogress
 notes: |
     - Small sized cards can contain images with 16:9, 3:2 or 1:1 aspect ratios.
     - The card in this example displays an icon next to the card tag name, to indicate the media type that may be played on click.
@@ -11,15 +9,17 @@ notes: |
     - Headlines should be a maximum of 40 characters, and descriptions a maximum of 140 characters.
 ---
 
-<section class="mzp-c-card mzp-has-aspect-1-1 mzp-has-audio">
+<section class="mzp-c-card {{#if class}}{{class}}{{else}}mzp-has-aspect-1-1 mzp-has-audio{{/if}}">
   <a class="mzp-c-card-block-link" href="#">
     <div class="mzp-c-card-media-wrapper">
       <img class="mzp-c-card-image" src="{{@root.baseurl}}/static/img/card/card-image.png" alt="">
     </div>
     <div class="mzp-c-card-content">
+    {{#block "content"}}
       <div class="mzp-c-card-tag">Card tag</div>
       <h2 class="mzp-c-card-title">This example headline has 40 characters</h2>
       <p class="mzp-c-card-desc">A description with a maximum of 140 characters. That means we usually only have room for one or two sentences. Here is what that looks like.</p>
+    {{/block}}
     </div>
   </a>
 </section>


### PR DESCRIPTION
Makes card component examples more DRY using handlebars templates.