### PR TITLE
Add standard header with headline and paragraph (Fixes #152)

### DIFF
--- a/src/assets/sass/protocol/components/_header.scss
+++ b/src/assets/sass/protocol/components/_header.scss
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../includes/lib';
+
+/* -------------------------------------------------------------------------- */
+// Base header class
+
+.mzp-c-header {
+    text-align: center;
+    background-color: $color-gray-20;
+
+    .mzp-c-header-content {
+        max-width: 608px;
+        margin: 0 auto;
+        padding: $padding-2xl $padding-lg;
+    }
+
+    .mzp-c-header-title {
+        @include text-display-md;
+    }
+
+    .mzp-c-header-desc {
+        @include text-body-lg;
+        margin-bottom: 0;
+    }
+}

--- a/src/assets/sass/protocol/protocol-extra.scss
+++ b/src/assets/sass/protocol/protocol-extra.scss
@@ -7,12 +7,13 @@
 $font-path: '../fonts' !default;
 $image-path: '../img' !default;
 
-@import '../protocol/templates/card-layout';
-@import '../protocol/templates/main-with-sidebar';
 @import '../protocol/components/article';
 @import '../protocol/components/billboard';
-@import '../protocol/components/sidebar-menu';
-@import '../protocol/components/card';
 @import '../protocol/components/button';
-@import '../protocol/components/newsletter-form';
+@import '../protocol/components/card';
+@import '../protocol/components/header';
 @import '../protocol/components/modal';
+@import '../protocol/components/newsletter-form';
+@import '../protocol/components/sidebar-menu';
+@import '../protocol/templates/card-layout';
+@import '../protocol/templates/main-with-sidebar';

--- a/src/patterns/molecules/header/collection.yml
+++ b/src/patterns/molecules/header/collection.yml
@@ -1,0 +1,2 @@
+name: Headers
+title: Headers

--- a/src/patterns/molecules/header/header.hbs
+++ b/src/patterns/molecules/header/header.hbs
@@ -1,0 +1,16 @@
+---
+name: Header
+description: A standard header with a headline and description.
+order: 3
+notes: |
+    - Utility classes can be applied to change the background color and text color.
+    - Background color runs full width of the page, and content has a max width of 608px;
+    - Headline should be a maximum of 30 characters, and description a maximum of 100 characters.
+---
+
+<header class="mzp-c-header">
+  <div class="mzp-c-header-content">
+    <h2 class="mzp-c-header-title">A headline with 30 characters</h2>
+    <p class="mzp-c-header-desc">A description with a maximum of 100 characters. That usually means only one or two sentences.</p>
+  </div>
+</header>


### PR DESCRIPTION
Fixes https://github.com/mozilla/protocol/issues/152

Depends on https://github.com/mozilla/protocol/issues/151

Note: I plan on updating this PR with some examples of utility classes and how to use them once https://github.com/mozilla/protocol/issues/151 is merged.