### PR TITLE
Add Picto Card component (Fixes #154, #155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **css:** Add Picto Card component (#154, #155)
 * **css:** Add Call Out component (#153)
 * **css:** Update button styles (#167)
 * **css:** Add custom .mzp-t-firefox global theme class (#169)

--- a/src/assets/sass/demos/card.scss
+++ b/src/assets/sass/demos/card.scss
@@ -8,3 +8,7 @@
 @import '../protocol/includes/lib';
 @import '../docs/protocol';
 @import '../docs/protocol-extra';
+
+.mzp-t-dark {
+    background-color: $color-gray-90;
+}

--- a/src/assets/sass/protocol/components/_card.scss
+++ b/src/assets/sass/protocol/components/_card.scss
@@ -166,3 +166,95 @@
     }
 }
 
+/* -------------------------------------------------------------------------- */
+// A small card with an icon and no link.
+
+.mzp-c-card-picto {
+    color: $color-black;
+    padding: $padding-xl 0;
+    text-align: center;
+
+    .mzp-c-card-picto-content {
+        padding-top: 56px + $padding-lg;
+        position: relative;
+
+        &:before {
+            background: $color-gray-20;
+            content: '';
+            height: 56px;
+            left: 50%;
+            margin-left: -28px;
+            position: absolute;
+            top: 0;
+            width: 56px;
+        }
+    }
+
+    .mzp-c-card-picto-title {
+        @include text-display-xs;
+    }
+
+    .mzp-c-card-picto-desc {
+        @include text-body-md;
+        color: $color-gray-70;
+        margin-bottom: 0;
+    }
+
+    // dark theme color styling
+    .mzp-t-dark & {
+        color: $color-white;
+
+        .mzp-c-card-picto-desc {
+            color: $color-gray-30;
+        }
+    }
+
+    @media #{$mq-md} {
+        padding: $padding-2xl 0;
+
+        .mzp-c-card-picto-content {
+            margin: 0 auto;
+            max-width: 240px;
+            padding: (56px + $padding-lg) $padding-lg 0;
+        }
+    }
+}
+
+.mzp-c-card-picto.mzp-c-card-picto-compact {
+    @include bidi(((text-align, left, right),));
+
+    .mzp-c-card-picto-title {
+        @include text-display-sm;
+    }
+
+    .mzp-c-card-picto-content {
+        @include bidi((
+            (clear, left, right),
+            (padding-left, 56px + $padding-lg, padding-right, 0),
+        ));
+        padding-top: 0;
+        position: relative;
+
+        &:before {
+            @include bidi((
+                (left, 0, auto),
+                (right, auto, 0),
+            ));
+            background: $color-gray-20;
+            content: '';
+            height: 56px;
+            margin: 0;
+            position: absolute;
+            top: 0;
+            width: 56px;
+        }
+    }
+
+    @media #{$mq-md} {
+        .mzp-c-card-picto-content {
+            max-width: 320px;
+        }
+    }
+}
+
+

--- a/src/assets/sass/protocol/templates/_card-layout.scss
+++ b/src/assets/sass/protocol/templates/_card-layout.scss
@@ -159,6 +159,23 @@
 }
 
 /* -------------------------------------------------------------------------- */
+// 3 picto card layout
+// On small screens cards stack vertically and span full container width.
+// On medium screens cards span 1 third width.
+.mzp-l-card-third {
+    @media #{$mq-md} {
+        @include clearfix;
+
+        .mzp-c-card-picto {
+            width: 33.3%;
+            @include bidi((
+                (float, left, right),
+            ));
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------- */
 // 2 card layout
 // On small screens cards stack vertically and span full container width.
 // On medium to large sized screens cards span half width.
@@ -186,6 +203,23 @@
 
     .mzp-l-card-half .mzp-c-card {
         width: calc(50% - (#{$margin-xl} - (#{$margin-xl} / 2)));
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+// 2 picto card layout
+// On small screens cards stack vertically and span full container width.
+// On medium screens cards span 1 third width.
+.mzp-l-card-half {
+    @media #{$mq-md} {
+        @include clearfix;
+
+        .mzp-c-card-picto {
+            width: 50%;
+            @include bidi((
+                (float, left, right),
+            ));
+        }
     }
 }
 

--- a/src/pages/demos/card-picto-layout.hbs
+++ b/src/pages/demos/card-picto-layout.hbs
@@ -1,0 +1,38 @@
+---
+title: Pitco Card Layout Demo
+layout: blank
+styles:
+  - card
+---
+
+<div class="mzp-l-content">
+  <header>
+    <h1>Picto Card Layout Demo</h1>
+  </header>
+</div>
+
+<div class="mzp-l-card-third mzp-l-content">
+  {{#embed "patterns.molecules.card.picto-card"}}{{/embed}}
+  {{#embed "patterns.molecules.card.picto-card"}}{{/embed}}
+  {{#embed "patterns.molecules.card.picto-card"}}{{/embed}}
+</div>
+
+<div class="mzp-t-dark">
+  <div class="mzp-l-card-third mzp-l-content">
+    {{#embed "patterns.molecules.card.picto-card"}}{{/embed}}
+    {{#embed "patterns.molecules.card.picto-card"}}{{/embed}}
+    {{#embed "patterns.molecules.card.picto-card"}}{{/embed}}
+  </div>
+</div>
+
+<div class="mzp-l-card-half mzp-l-content">
+  {{#embed "patterns.molecules.card.picto-card-compact"}}{{/embed}}
+  {{#embed "patterns.molecules.card.picto-card-compact"}}{{/embed}}
+</div>
+
+<div class="mzp-t-dark">
+  <div class="mzp-l-card-half mzp-l-content">
+    {{#embed "patterns.molecules.card.picto-card-compact"}}{{/embed}}
+    {{#embed "patterns.molecules.card.picto-card-compact"}}{{/embed}}
+  </div>
+</div>

--- a/src/patterns/molecules/card/extra-small-card.hbs
+++ b/src/patterns/molecules/card/extra-small-card.hbs
@@ -8,6 +8,9 @@ notes: |
     - Extra small sized cards should contain images with either 16:9, 3:2 aspect ratios.
     - Recommended image width is 410px.
     - Headlines should be a maximum of 40 characters, and descriptions a maximum of 140 characters.
+links:
+    Card Layout Class: /patterns/templates/card-layout.html
+    Card Layout Demo: /demos/card-layout.html
 ---
 
 {{#embed "patterns.molecules.card.small-card" class="mzp-c-card-extra-small has-aspect-3-2"}}

--- a/src/patterns/molecules/card/large-card.hbs
+++ b/src/patterns/molecules/card/large-card.hbs
@@ -7,6 +7,9 @@ notes: |
     - Large sized cards should contain images with 16:9 or 3:2 aspect ratios only.
     - Recommended image width is 825px.
     - Headlines should be a maximum of 40 characters, and descriptions a maximum of 140 characters.
+links:
+    Card Layout Class: /patterns/templates/card-layout.html
+    Card Layout Demo: /demos/card-layout.html
 ---
 
 {{#embed "patterns.molecules.card.small-card" class="mzp-c-card-large mzp-has-aspect-16-9"}}{{/embed}}

--- a/src/patterns/molecules/card/medium-card.hbs
+++ b/src/patterns/molecules/card/medium-card.hbs
@@ -8,6 +8,9 @@ notes: |
     - The card in this example displays an icon next to the card tag name, to indicate the media type that may be played on click.
     - Recommended image width is 582px.
     - Headlines should be a maximum of 40 characters, and descriptions a maximum of 140 characters.
+links:
+    Card Layout Class: /patterns/templates/card-layout.html
+    Card Layout Demo: /demos/card-layout.html
 ---
 
 {{#embed "patterns.molecules.card.small-card" class="mzp-c-card-medium mzp-has-aspect-3-2 mzp-has-video"}}{{/embed}}

--- a/src/patterns/molecules/card/picto-card-compact.hbs
+++ b/src/patterns/molecules/card/picto-card-compact.hbs
@@ -1,0 +1,17 @@
+---
+name: Picto Card (compact)
+description: A more compact version of a Picto Card with a horizontally aligned icon.
+order: 6
+notes: |
+    - Horizontally aligned icon allows for a larger title and slightly longer description (max 100 characters).
+links:
+    Card Layout Class: /patterns/templates/card-layout.html
+    Picto Card Layout Demo: /demos/card-picto-layout.html
+---
+
+{{#embed "patterns.molecules.card.picto-card" class="mzp-c-card-picto-compact"}}
+  {{#content "content"}}
+    <h2 class="mzp-c-card-picto-title">A headline with 30 characters</h2>
+    <p class="mzp-c-card-picto-desc">A description with a maximum of 100 characters. That usually means only one or two sentences.</p>
+  {{/content}}
+{{/embed}}

--- a/src/patterns/molecules/card/picto-card.hbs
+++ b/src/patterns/molecules/card/picto-card.hbs
@@ -1,0 +1,23 @@
+---
+name: Picto Card
+description: A card with a pictographic icon, headline, and description.
+order: 5
+notes: |
+    - This card type should be arranged in groups of two or three using the `.mzp-l-card-half` and `.mzp-l-card-third` layout classes.
+    - Icons are presentational so should be applied as CSS background images via a `.mzp-c-card-picto-content::before` pseudo class.
+    - Headlines should be a maximum of 30 characters, and descriptions a maximum of 60 characters.
+    - A .`mzp-t-dark` theme color is supported for use on different color backgrounds.
+    - Icon size is 56px x 56px.
+links:
+    Card Layout Class: /patterns/templates/card-layout.html
+    Picto Card Layout Demo: /demos/card-picto-layout.html
+---
+
+<section class="mzp-c-card-picto {{#if class}}{{class}}{{/if}}">
+  <div class="mzp-c-card-picto-content">
+  {{#block "content"}}
+    <h2 class="mzp-c-card-picto-title">A headline with 30 characters</h2>
+    <p class="mzp-c-card-picto-desc">A short description with a maximum of about 60 characters.</p>
+  {{/block}}
+  </div>
+</section>

--- a/src/patterns/molecules/card/small-card.hbs
+++ b/src/patterns/molecules/card/small-card.hbs
@@ -7,6 +7,9 @@ notes: |
     - The card in this example displays an icon next to the card tag name, to indicate the media type that may be played on click.
     - Recommended image width is 410px.
     - Headlines should be a maximum of 40 characters, and descriptions a maximum of 140 characters.
+links:
+    Card Layout Class: /patterns/templates/card-layout.html
+    Card Layout Demo: /demos/card-layout.html
 ---
 
 <section class="mzp-c-card {{#if class}}{{class}}{{else}}mzp-has-aspect-1-1 mzp-has-audio{{/if}}">

--- a/src/patterns/templates/card-layout/card-layout.hbs
+++ b/src/patterns/templates/card-layout/card-layout.hbs
@@ -4,8 +4,6 @@ description: |
   A layout class for displaying card components in different arrangements.
 
   All cards stack vertically on small screens but can adapt to different grid formations on wider screens.
-
-  See [the card layout demo page](/demos/card-layout.html) for a full list of example card layouts and the [card molecule page](/patterns/molecules/card.html) for a list of different card types.
 notes: |
   This layout template only sets up the basic grid for each type of layout.
 tips: |
@@ -16,6 +14,9 @@ tips: |
     - `mzp-l-card-quarter`
   - These CSS classes can be applied to any suitable parent element e.g. `<main>`, `<section>`, `<div>`.
   - The grid layout is reversed in right to left (RTL) languages.
+links:
+    Card Layout Demo: /demos/card-layout.html
+    Picto Card Layout Demo: /demos/card-picto-layout.html
 ---
 
 <div class="mzp-l-content mzp-l-card-third">


### PR DESCRIPTION
Fixes #154, #155.

- Adds a new Picto Card component with compact variation (happy to choose a different name, but I thought this sounded better than something like "Icon Card").
- Updates card layout classes to support groups of 2 & 3 Picto Cards.

Demo:
- https://mozilla-protocol.netlify.com/patterns/molecules/card.html#picto-card
- https://mozilla-protocol.netlify.com/patterns/molecules/card.html#picto-card-compact
- https://mozilla-protocol.netlify.com/patterns/molecules/card.html