### PR TITLE
Ensure documented publishing steps include updating dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+## Bug Fixes
+
+* **npm:** Ensure `npm test` always updates dependencies before running `gulp build`.
+
 # 2.2.0
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "gulp --dev",
     "build": "npm run prestart && gulp build",
     "test": "gulp js:test",
-    "pretest": "gulp build",
+    "pretest": "npm run build",
     "docs": "doctoc --title \"### Contents\" --maxlevel 2 docs/README.md",
     "prepublishOnly": "gulp build"
   },


### PR DESCRIPTION
It occured to me that there was a hole in our publishing steps for NPM, which did not cover someone's local NPM dependencies being out of date. This could result in unintentional publishing of a version of protocol-assets to protocol-tokens which does not match up to the version number in `package.json` for the `master` branch. This could happen quite easily when switching between feature branches, for example.

This PR updates the NPM `pretest` script to always do an `npm install` before `npm test` is run, so the `./dist` folder should always include the expected assets.