### PR TITLE
Avoid referencing URLs in feature queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.1
+
+## Bug Fixes
+
+* **css:** Avoid referencing URLs in feature queries
+
 # 2.1.0
 
 ## Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "author": "Mozilla",
   "description": "A design system for Mozilla's websites.",

--- a/src/assets/package/README.md
+++ b/src/assets/package/README.md
@@ -20,7 +20,7 @@ Install package with NPM and add it to your dependencies:
 </tr>
 <tr>
 <td>Version</td>
-<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">2.1.0</a></td>
+<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">2.1.1</a></td>
 </tr>
 </table>
 

--- a/src/assets/package/package.json
+++ b/src/assets/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A design system for Mozilla's websites.",
   "repository": {
     "type": "git",

--- a/src/assets/sass/protocol/components/_hero.scss
+++ b/src/assets/sass/protocol/components/_hero.scss
@@ -219,7 +219,7 @@
 }
 
 
-@supports (mask-image: url('mask.svg')) {
+@supports (mask-size: auto) {
     .mzp-c-hero.mzp-t-firefox {
         &:after {
             background-color: $color-gray-20;


### PR DESCRIPTION
This fixes the bug and also updates Protocol to 2.1.1.

Explanation for posterity: When the CSS is post-processed some scripts will attempt to resolve all instances of `url()` and will throw an error when a referenced file isn't found, potentially breaking a build. While this shouldn't have any effect when `url()` appears in a feature query (the asset isn't actually loaded, the query only tests for support of the property) it causes problems with other kinds of post-processing. Since file paths are somewhat dynamic it can be hard to ensure an asset exists in the right location, so in general we should probably just avoid `url()` references in feature queries and test for a related feature instead.