### PR TITLE
Add bidi control to component previews (Fixes #150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+## Features
+
+* **docs:** Add bidi control to component previews (#150)
+
 # 2.1.1
 
 ## Bug Fixes

--- a/src/assets/js/docs/bidi.js
+++ b/src/assets/js/docs/bidi.js
@@ -1,0 +1,17 @@
+(function() {
+    'use strict';
+
+    // custom bidi toggle for component previews.
+    var toggles = document.querySelectorAll('.protosite-bidi-controls .protosite-bidi-toggle');
+
+    for (var i = 0; i < toggles.length; i++) {
+        toggles[i].addEventListener('click', function(e) {
+            var id = e.target.name;
+            var preview = document.getElementById(id);
+
+            if (preview) {
+                preview.setAttribute('dir', e.target.value);
+            }
+        });
+    }
+})();

--- a/src/assets/sass/docs/site.scss
+++ b/src/assets/sass/docs/site.scss
@@ -289,3 +289,23 @@
         width: 1.5em;
     }
 }
+
+// bidi controls
+.protosite-bidi-controls {
+    @include text-body-sm;
+
+    label {
+        font-weight: normal;
+        display: inline-block;
+    }
+
+    @media #{$mq-lg} {
+        float: right;
+        display: inline-block;
+        text-align: right;
+    }
+}
+
+.protosite-bidi-controls + .protosite-pattern-embed {
+    clear: right;
+}

--- a/src/templates/drizzle/bidi.hbs
+++ b/src/templates/drizzle/bidi.hbs
@@ -1,0 +1,4 @@
+<fieldset class="protosite-bidi-controls">
+  <label>LTR: <input class="protosite-bidi-toggle" type="radio" value="ltr" name="protosite-{{id}}-preview" checked /></label>
+  <label>RTL: <input class="protosite-bidi-toggle" type="radio" value="rtl" name="protosite-{{id}}-preview" /></label>
+</fieldset>

--- a/src/templates/drizzle/item.hbs
+++ b/src/templates/drizzle/item.hbs
@@ -32,9 +32,13 @@
   {{#if data.doclayout}}
     {{{pattern id @root}}}
   {{else}}
+    {{!-- Bidi controls --}}
+    {{#> drizzle.bidi id=(toSlug name)}}
+      {{name}}
+    {{/drizzle.bidi}}
     {{!-- Preview --}}
     <div class="protosite-pattern-embed">
-      <div class="protosite-pattern-preview {{data.previewClass}}">
+      <div class="protosite-pattern-preview {{data.previewClass}}" id="protosite-{{toSlug name}}-preview" dir="ltr">
         {{{pattern id @root}}}
       </div>
       {{!-- Code sample --}}


### PR DESCRIPTION
Fixes #150

Figured it would take less time to implement this than it would to keep manually changing attributes whilst in dev. Already noticed a few minor RTL bugs on various components whilst testing this :)

Super high-tech gif preview:

![rtl](https://user-images.githubusercontent.com/400117/43840084-af2d1e5e-9b17-11e8-81de-bcc6a21585dc.gif)
