### PR TITLE
Update protocol/assets v1.0.1, protocol/tokens v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,14 +56,14 @@
       }
     },
     "@mozilla-protocol/assets": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/assets/-/assets-0.0.5.tgz",
-      "integrity": "sha512-eXVuWELOmnjT1jcNzJOIpLy88dbfpFq2e2jCoHqUKFMUaM6Kza+Rx0Db2GbbBhV40eexUYK+kx80PyXnaBH4FA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/assets/-/assets-1.0.1.tgz",
+      "integrity": "sha512-DqaPHtx42e0U7ThnJ+cFmMYhJatR8aNmsZyd+7I5ERokzqOT4p6QGZS5+ItoO5splStL507SjPq4piVMfT7iWQ=="
     },
     "@mozilla-protocol/tokens": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/tokens/-/tokens-1.3.1.tgz",
-      "integrity": "sha512-y4LimmK+zcLhvrccnvfuJXGK3TEKzVt471b843aZhJQ+LIg+naBcJE1fwl/OCno0sQauOuqfp+M8F0mKIKE7CA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/tokens/-/tokens-2.0.0.tgz",
+      "integrity": "sha512-P6BqcJTZ0vr7tCqYNJ/ZZE65D2GJ2nac5mDFywop1RVdk1GozyLQRgTlsvjuWldGFtGKwQGSS0/el0ElOgJ5UQ=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@cloudfour/hbs-helpers": "^0.9.0",
-    "@mozilla-protocol/assets": "^0.0.5",
-    "@mozilla-protocol/tokens": "^1.3.1",
+    "@mozilla-protocol/assets": "^1.0.1",
+    "@mozilla-protocol/tokens": "^2.0.0",
     "drizzle-builder": "0.0.10",
     "eslint": "^5.1.0",
     "gulp": "^3.9.1",

--- a/src/assets/sass/demos/card.scss
+++ b/src/assets/sass/demos/card.scss
@@ -10,5 +10,5 @@
 @import '../docs/protocol-extra';
 
 .mzp-t-dark {
-    background-color: $color-gray-90;
+    background-color: $color-gray-60;
 }

--- a/src/assets/sass/demos/type-scale.scss
+++ b/src/assets/sass/demos/type-scale.scss
@@ -33,7 +33,7 @@ hr {
 
 .label {
     @include text-body-sm;
-    color: $color-gray-90;
+    color: $color-gray-60;
     margin: 1em 0 .5em;
 }
 
@@ -46,7 +46,7 @@ hr {
     .scale-sample:after {
         @include open-sans;
         @include text-body-sm;
-        color: $color-gray-90;
+        color: $color-gray-60;
         font-weight: normal;
         margin-left: 10px;
     }

--- a/src/assets/sass/protocol/base/elements/_forms.scss
+++ b/src/assets/sass/protocol/base/elements/_forms.scss
@@ -42,7 +42,7 @@ input[type='time'] {
     @include border-box;
     background: $color-white;
     border-radius: 3px;
-    border: 1px solid $color-gray-90;
+    border: 1px solid $color-gray-60;
     display: inline-block;
     line-height: 1.25;
     padding: .25em $spacing-sm;
@@ -61,7 +61,7 @@ input[type='time'] {
 
         &:hover,
         &:focus {
-            border-color: $color-gray-90;
+            border-color: $color-gray-60;
         }
     }
 }
@@ -84,7 +84,7 @@ fieldset li {
 
 .mzp-c-fieldnote {
     @include text-body-sm;
-    color: $color-gray-90;
+    color: $color-gray-60;
     display: block;
     font-weight: normal;
 }

--- a/src/assets/sass/protocol/components/_call-out.scss
+++ b/src/assets/sass/protocol/components/_call-out.scss
@@ -12,7 +12,7 @@
     text-align: center;
 
     &.mzp-t-dark {
-        background-color: $color-gray-90;
+        background-color: $color-gray-60;
         color: $color-white;
 
         .mzp-c-call-out-desc {
@@ -83,7 +83,7 @@
     background-color: $color-gray-20;
 
     &.mzp-t-dark {
-        background-color: $color-gray-90;
+        background-color: $color-gray-60;
         color: $color-white;
 
         .mzp-c-call-out-desc {

--- a/src/assets/sass/protocol/components/_card.scss
+++ b/src/assets/sass/protocol/components/_card.scss
@@ -47,7 +47,7 @@
     .mzp-c-card-tag {
         @include open-sans;
         @include text-body-sm;
-        color: $color-gray-90;
+        color: $color-gray-60;
         font-weight: normal;
         margin-bottom: $margin-xs;
     }
@@ -113,7 +113,7 @@
 
     .mzp-c-card-meta {
         @include text-body-xs;
-        color: $color-gray-90;
+        color: $color-gray-60;
         margin: $margin-lg 0 0;
     }
 

--- a/src/assets/sass/protocol/components/_modal.scss
+++ b/src/assets/sass/protocol/components/_modal.scss
@@ -81,8 +81,8 @@ html.mzp-is-noscroll {
 
     .mzp-c-modal-button-close {
         @include image-replaced;
-        background: transparent url('#{$image-path}/icons/ui/close.svg') center center no-repeat;
-        @include background-size(30px 30px);
+        background: transparent url('#{$image-path}/icons/ui/close-white.svg') center center no-repeat;
+        @include background-size(16px 16px);
         border: none;
         height: 42px;
         min-width: 0;

--- a/src/assets/sass/protocol/components/_sidebar-menu.scss
+++ b/src/assets/sass/protocol/components/_sidebar-menu.scss
@@ -25,7 +25,7 @@
             (margin-right, $spacing-xs, 0),
             (margin-left, 0, $spacing-xs),
         ));
-        color: $color-gray-90;
+        color: $color-gray-60;
         display: inline;
 
         &:after {
@@ -119,7 +119,7 @@
             right: 0;
             top: 0;
             font-size: 1.5em;
-            color: $color-gray-90;
+            color: $color-gray-60;
         }
     }
 

--- a/src/assets/sass/protocol/includes/_variables.scss
+++ b/src/assets/sass/protocol/includes/_variables.scss
@@ -12,7 +12,3 @@ $font-zilla-slab: 'Zilla Slab', 'Open Sans', X-LocaleSpecific, sans-serif;
 $base-font-stack: $font-open-sans;
 $base-font-size: 100%;
 $base-line-height: 1.5;
-
-
-// TODO this should be in our tokens https://github.com/mozilla/protocol-tokens/issues/22
-$mq-high-res: 'only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 1.5dppx), only screen and (min-resolution: 144dpi)';


### PR DESCRIPTION
Notable updates:
- The close icon for the modal has changed (to be consistent with the close icon for the navigation). It should still display correctly.
- The token value for `$color-gray-90` has been corrected, so existing occurences should be updated to `$color-gray-60`.
- We now have a `$mq-high-res` token, so we can remove it from `_variables.scss`.