### PR TITLE
[fix #198] Update base button style, add dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# HEAD
+# 2.2.1
+
+## Features
+
+* **css:** Update base button style, add dark theme (#198)
 
 ## Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "private": true,
   "author": "Mozilla",
   "description": "A design system for Mozilla's websites.",

--- a/src/assets/sass/docs/site.scss
+++ b/src/assets/sass/docs/site.scss
@@ -154,6 +154,11 @@
         border-top: 1px solid rgba(0, 0, 0, .2);
         margin: 30px -20px -10px;
     }
+
+    .mzp-t-dark {
+        background-color: $color-gray-60;
+        padding: $spacing-lg;
+    }
 }
 
 .protosite-pattern-code {

--- a/src/assets/sass/protocol/components/_button.scss
+++ b/src/assets/sass/protocol/components/_button.scss
@@ -7,22 +7,28 @@
 .mzp-c-button {
     @include border-box;
     @include text-cta;
-    transition: background-color 100ms, border-color 100ms, color 100ms;
     background-color: $color-black;
-    border-radius: 2px;
+    border-radius: 3px;
     border: 2px solid $color-black;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, .1);
     color: $color-white;
     cursor: pointer;
     display: inline-block;
     font-weight: bold;
     padding: $padding-md $padding-lg;
     text-decoration: none;
+    transition: background-color 100ms, border-color 100ms, color 100ms;
 
     &:hover,
     &:focus {
         background-color: $color-white;
+        box-shadow: 4px 4px 0 0 $color-black;
         color: $color-black;
+        transition: box-shadow 100ms;
+    }
+
+    &:active {
+        box-shadow: 2px 2px 0 0 $color-black;
+        transition: box-shadow 0ms;
     }
 }
 
@@ -33,8 +39,8 @@
 
     &:hover,
     &:focus {
-        background-color: $color-gray-80;
-        color: $color-white;
+        background: $color-white;
+        color: $color-black;
     }
 }
 

--- a/src/patterns/atoms/buttons/dark.hbs
+++ b/src/patterns/atoms/buttons/dark.hbs
@@ -1,0 +1,19 @@
+---
+name: Basic button, dark theme
+description: |
+  Light colored buttons for dark backgrounds.
+---
+
+<div class="mzp-t-dark">
+  <button class="mzp-c-button">
+  {{#block "content"}}
+    Call to Action
+  {{/block}}
+  </button>
+
+  <a href="#" class="mzp-c-button">
+  {{#block "content"}}
+    Call to Action
+  {{/block}}
+  </a>
+</div>


### PR DESCRIPTION
Updates our base button style to match what we've been using in bedrock. This could conflict with sites using Protocol in production so this also bumps the version to 2.2.1.

Demo: https://demo1--mozilla-protocol.netlify.com/patterns/atoms/buttons.html