### PR TITLE
Rename '.mzp-c-language-switcher-select' class (Fixes #242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+## Bug Fixes
+
+* **js:** Rename '.mzp-c-language-switcher-select' class (#242)
+
 # 2.4.3
 
 ## Features

--- a/src/assets/js/protocol/protocol-lang-switcher.js
+++ b/src/assets/js/protocol/protocol-lang-switcher.js
@@ -47,7 +47,7 @@ if (typeof Mozilla === 'undefined') {
      * @param {function} Custom callback for analytics.
      */
     LangSwitcher.init = function(callback) {
-        var language = document.querySelectorAll('.mzp-c-language-switcher-select');
+        var language = document.querySelectorAll('.mzp-js-language-switcher-select');
 
         for (var i = 0; i < language.length; i++) {
             language[i].setAttribute('data-previous-language', language[i].value);

--- a/src/patterns/molecules/language-switcher/language-switcher.hbs
+++ b/src/patterns/molecules/language-switcher/language-switcher.hbs
@@ -9,7 +9,7 @@ notes: |
 
 <form class="mzp-c-language-switcher" method="get" action="#">
   <label for="mzp-c-language-switcher-select">Language</label>
-  <select id="mzp-c-language-switcher-select" class="mzp-c-language-switcher-select" name="lang">
+  <select id="mzp-c-language-switcher-select" class="mzp-js-language-switcher-select" name="lang">
     {{#each (data "items")}}
       <option value="{{lang-code}}">{{language}}</option>
     {{/each}}

--- a/tests/unit/protocol-lang-switcher.js
+++ b/tests/unit/protocol-lang-switcher.js
@@ -45,7 +45,7 @@ describe('protocol-lang-switcher.js', function() {
         beforeEach(function () {
             var langSelect = '<form class="mzp-c-language-switcher" method="get" action="#">' +
                                 '<label for="mzp-c-language-switcher-select">Language</label>' +
-                                '<select id="mzp-c-language-switcher-select" class="mzp-c-language-switcher-select" name="lang">' +
+                                '<select id="mzp-c-language-switcher-select" class="mzp-js-language-switcher-select" name="lang">' +
                                     '<option value="en-US" selected>English (US)</option>' +
                                     '<option value="de">Deutsch</option>' +
                                     '<option value="fr">Français</option>' +
@@ -65,7 +65,7 @@ describe('protocol-lang-switcher.js', function() {
         });
 
         function fireChangeEvent(index) {
-            var select = document.querySelector('.mzp-c-language-switcher-select');
+            var select = document.querySelector('.mzp-js-language-switcher-select');
             var evt = document.createEvent('HTMLEvents');
             evt.initEvent('change', false, true);
             select.selectedIndex = index;


### PR DESCRIPTION
Fixes #242