### PR TITLE
Use the node:10-alpine issue

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -3,5 +3,5 @@ cd "$(dirname ${BASH_SOURCE[0]})"/..
 
 docker run --rm --label=node \
     -v $(pwd):/app -w /app\
-    node \
+    node:10-alpine \
     npm run-script build


### PR DESCRIPTION
The `node:latest` image that was being used is too variable and broke things when it moved to Node 11.

Fix #262