### PR TITLE
Fix slack failure notifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ def buildSite(destination) {
       try {
         sh "bin/build.sh " + destination
       } catch(err) {
-        sh "bin/slack-notify.sh --stage 'build " + env.BRANCH_NAME + "' --status 'failed'"
+        sh "bin/slack-notify.sh --stage 'build " + env.BRANCH_NAME + "' --status failure"
         throw err
       }
     }
@@ -16,10 +16,10 @@ def syncS3(String bucket) {
         try {
           sh "cd dist && aws s3 sync . s3://" + bucket + " --acl public-read --delete --profile protocol"
         } catch(err) {
-          sh "bin/slack-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status 'failed'"
+          sh "bin/slack-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status failure"
           throw err
         }
-        sh "bin/slack-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status 'shipped'"
+        sh "bin/slack-notify.sh --stage 's3 sync " + env.BRANCH_NAME + "' --status shipped"
     }
 }
 


### PR DESCRIPTION
They were using the sparkels emoji because it was expecting a status of "failure" instead of "failed" and sparkels is the default.