### PR TITLE
add link to github repo in sidebar

### DIFF
--- a/src/templates/drizzle/nav.hbs
+++ b/src/templates/drizzle/nav.hbs
@@ -90,6 +90,11 @@
           {{> nav-item label=data.title}}
         {{/with}}
       </li>
+      <li class="protosite-nav-main-item">
+        <a href="https://github.com/mozilla/protocol" target="_blank" rel="noopener noreferrer">
+          Repo
+        </a>
+      </li>
     </ul>
   </div>
 </nav>


### PR DESCRIPTION
Feel free to reject this. I've been looking at Protocol a bunch today and keep expecting a GH link to be in the sidebar.