### PR TITLE
Menu styles tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Features
 
 * **css:** Rename download button theme to product button theme (#273)
+* **css:** Navigation items that are links without menus get hover styles (#304)
+* **css:** Let menu item titles not be links (#307)
 * **gulp:** Update to Gulp 4.0 (#285)
 
 # 4.0.0

--- a/src/assets/sass/protocol/components/_menu-item.scss
+++ b/src/assets/sass/protocol/components/_menu-item.scss
@@ -34,17 +34,28 @@ $icon-size: 24px;
         }
     }
 
-    &.mzp-has-icon .mzp-c-menu-item-link {
-        @include bidi(((padding-left, $icon-size + $spacing-lg, padding-right, 0),));
-        position: relative;
+    .mzp-c-menu-item-head {
+        display: block;
 
-        .mzp-c-menu-item-icon {
-            @include bidi(((left, $spacing-sm, right, auto),));
-            height: $icon-size;
-            margin: 0;
-            position: absolute;
-            top: $spacing-sm;
-            width: $icon-size;
+        .mzp-c-menu-item-title {
+            border-bottom: 2px solid transparent;
+        }
+    }
+
+    &.mzp-has-icon {
+        .mzp-c-menu-item-head,
+        .mzp-c-menu-item-link {
+            @include bidi(((padding-left, $icon-size + $spacing-lg, padding-right, 0),));
+            position: relative;
+
+            .mzp-c-menu-item-icon {
+                @include bidi(((left, $spacing-sm, right, auto),));
+                height: $icon-size;
+                margin: 0;
+                position: absolute;
+                top: $spacing-sm;
+                width: $icon-size;
+            }
         }
     }
 
@@ -111,7 +122,8 @@ $icon-size: 24px;
             box-shadow: 0 0 0 4px $color-gray-20;
         }
 
-        .mzp-c-menu-item-link {
+        .mzp-c-menu-item-link,
+        .mzp-c-menu-item-head {
             padding: $spacing-sm;
         }
 

--- a/src/assets/sass/protocol/components/_menu.scss
+++ b/src/assets/sass/protocol/components/_menu.scss
@@ -135,8 +135,8 @@
             display: none;
         }
 
-        .mzp-has-drop-down:hover,
-        .mzp-has-drop-down:focus {
+        &.mzp-has-drop-down:hover,
+        &.mzp-has-drop-down:focus {
             .mzp-c-menu-title {
                 @include highlighted;
                 z-index: 1001;
@@ -148,7 +148,7 @@
             }
         }
 
-        .mzp-has-drop-down:focus-within {
+        &.mzp-has-drop-down:focus-within {
             .mzp-c-menu-title {
                 @include highlighted;
                 z-index: 1001;

--- a/src/assets/sass/protocol/components/_menu.scss
+++ b/src/assets/sass/protocol/components/_menu.scss
@@ -97,8 +97,11 @@
 
         .mzp-c-menu-title {
             border-bottom: none;
-            cursor: default;
             padding: 0 $spacing-sm $spacing-lg;
+
+            &.mzp-has-drop-down {
+                cursor: default;
+            }
         }
 
         &.mzp-has-drop-down .mzp-c-menu-title:before {
@@ -132,8 +135,8 @@
             display: none;
         }
 
-        &:hover,
-        &:focus {
+        .mzp-has-drop-down:hover,
+        .mzp-has-drop-down:focus {
             .mzp-c-menu-title {
                 @include highlighted;
                 z-index: 1001;
@@ -145,7 +148,7 @@
             }
         }
 
-        &:focus-within {
+        .mzp-has-drop-down:focus-within {
             .mzp-c-menu-title {
                 @include highlighted;
                 z-index: 1001;

--- a/src/pages/demos/navigation.hbs
+++ b/src/pages/demos/navigation.hbs
@@ -17,9 +17,8 @@ styles:
               <div class="mzp-c-menu-panel-content">
                 <ul>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/firefox.png"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/firefox.png" link="https://www.mozilla.org/firefox/"}}
                       {{#content "title"}}Firefox Desktop Browser{{/content}}
-                      {{#content "link"}}https://www.mozilla.org/firefox/{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Get the browser that’s fast for good for Windows, Mac OS or Linux.</p>
                       {{/content}}
@@ -35,9 +34,8 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://www.mozilla.org/firefox/mobile"}}
                       {{#content "title"}}Firefox Mobile Browser{{/content}}
-                      {{#content "link"}}https://www.mozilla.org/firefox/mobile/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M7 1h10a3 3 0 0 1 3 3v16a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V4a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1H7zm3 16a1 1 0 0 1 0-2h4a1 1 0 0 1 0 2h-4z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Firefox for Android and iOS – and Firefox Focus for extra privacy.</p>
@@ -57,9 +55,8 @@ styles:
                 </ul>
                 <ul>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://www.mozilla.org/firefox/pocket/"}}
                       {{#content "title"}}Pocket by Firefox{{/content}}
-                      {{#content "link"}}https://www.mozilla.org/firefox/pocket/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="22" xmlns="http://www.w3.org/2000/svg"><path d="M12 21.5c-6.627 0-12-5.373-12-12v-6a3 3 0 0 1 3-3h18a3 3 0 0 1 3 3v6c0 6.627-5.373 12-12 12zm5.977-15.048a1.485 1.485 0 0 0-1.087.479l-4.923 4.924-4.835-4.851A1.476 1.476 0 0 0 6 6.452a1.5 1.5 0 0 0-1.071 2.55l-.024.016 4.94 4.96 1.06 1.06a1.5 1.5 0 0 0 2.121 0l1.06-1.06 4.964-4.96a1.5 1.5 0 0 0-1.073-2.566z" fill="#FF4056" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Save, read and get fueled by content that fascinates you.</p>
@@ -68,9 +65,8 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://www.mozilla.org/firefox/accounts/features/"}}
                       {{#content "title"}}Firefox Accounts{{/content}}
-                      {{#content "link"}}https://www.mozilla.org/firefox/accounts/features/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M21 21a1 1 0 0 1-2 0v-2a3 3 0 0 0-3-3H8a3 3 0 0 0-3 3v2a1 1 0 0 1-2 0v-2a5 5 0 0 1 5-5h8a5 5 0 0 1 5 5v2zm-9-9a5 5 0 1 1 0-10 5 5 0 0 1 0 10zm0-2a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Move from device to device easily with a Firefox Account.</p>
@@ -79,9 +75,8 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://www.mozilla.org/firefox/enterprise/" }}
                       {{#content "title"}}Firefox Enterprise{{/content}}
-                      {{#content "link"}}https://www.mozilla.org/firefox/enterprise/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M20.289 15.5a1 1 0 0 1 1.842.78A11 11 0 1 1 7.6 1.912a1 1 0 0 1 .8 1.834A9 9 0 1 0 20.289 15.5zM23 12a1 1 0 0 1-1 1H12a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1 11 11 0 0 1 11 11zm-4.636-6.364A9 9 0 0 0 13 3.056V11h7.944a9 9 0 0 0-2.58-5.364z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">A managed version of Firefox for businesses and organizations.</p>
@@ -90,9 +85,8 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://www.amazon.com/Mozilla-Firefox-for-Fire-TV/dp/B078B5YMPD"}}
                       {{#content "title"}}Firefox for Fire TV{{/content}}
-                      {{#content "link"}}https://www.amazon.com/Mozilla-Firefox-for-Fire-TV/dp/B078B5YMPD{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M3 3h18a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H3a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1H3zm13.496 6.132a1 1 0 0 1 0 1.736l-7 4A1 1 0 0 1 8 16V8a1 1 0 0 1 1.496-.868l7 4zM10 9.723v4.554L13.984 12 10 9.723z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Watch videos and browse the internet with Firefox for Amazon Fire TV.</p>
@@ -121,9 +115,8 @@ styles:
               <div class="mzp-c-menu-panel-content">
                 <ul>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://voice.mozilla.org/"}}
                       {{#content "title"}}Common Voice{{/content}}
-                      {{#content "link"}}https://voice.mozilla.org/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M13 19.945V23a1 1 0 0 1-2 0v-3.055C6.5 19.448 3 15.633 3 11a1 1 0 0 1 2 0 7 7 0 0 0 14 0 1 1 0 0 1 2 0c0 4.633-3.5 8.448-8 8.945zM12 0a5 5 0 0 1 5 5v6a5 5 0 0 1-10 0V5a5 5 0 0 1 5-5zm0 2a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Donate your voice to help make voice recognition open to everyone.</p>
@@ -132,9 +125,8 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://mixedreality.mozilla.org/"}}
                       {{#content "title"}}Virtual Reality{{/content}}
-                      {{#content "link"}}https://mixedreality.mozilla.org/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 7c0-2.882 5.647-5 12-5s12 2.118 12 5v10h-2c0-.322-.803-.857-2.493-1.28-1.871-.468-4.52-.72-7.507-.72s-5.636.252-7.507.72C2.803 16.143 2 16.678 2 17H0V7zm22 0c0-.42-.911-1.18-2.601-1.814C17.416 4.443 14.759 4 12 4c-2.76 0-5.416.443-7.399 1.186C2.911 5.82 2 6.58 2 7v7.462C4.06 13.458 7.589 13 12 13s7.94.458 10 1.462V7zM9 22c-4.481 0-9-2.26-9-5V7c0-1.333 2-1.333 2 0 0 .313.735 1.071 1.97 1.727C5.45 9.513 7.29 10 9 10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1zM8 11.955c-2.214-.195-4.455-1.009-6-2.088V17c0 1.14 2.85 2.673 6 2.955v-8zM15 22a1 1 0 0 1-1-1V11a1 1 0 0 1 1-1c1.71 0 3.55-.487 5.03-1.273C21.266 8.07 22 7.313 22 7c0-1.333 2-1.333 2 0v10c0 2.74-4.519 5-9 5zm1-10.045v8c3.15-.282 6-1.815 6-2.955V9.867c-1.545 1.08-3.786 1.893-6 2.088z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Experience WebVR with Firefox.</p>
@@ -145,9 +137,8 @@ styles:
                 </ul>
                 <ul>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://iot.mozilla.org/"}}
                       {{#content "title"}}Internet of Things (IoT){{/content}}
-                      {{#content "link"}}https://iot.mozilla.org/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M3.055 13a9.008 9.008 0 0 0 6.671 7.71A16.331 16.331 0 0 1 7.053 13H3.055zm0-2H7.05a16.3 16.3 0 0 1 2.676-7.71A9.008 9.008 0 0 0 3.055 11zm17.89 0a9.008 9.008 0 0 0-6.671-7.71A16.331 16.331 0 0 1 16.947 11h3.998zm0 2H16.95a16.3 16.3 0 0 1-2.676 7.71A9.008 9.008 0 0 0 20.945 13zm-11.89-2h5.887A14.3 14.3 0 0 0 12 3.55 14.288 14.288 0 0 0 9.055 11zm5.89 2H9.058A14.3 14.3 0 0 0 12 20.45 14.288 14.288 0 0 0 14.945 13zM12 23C5.925 23 1 18.075 1 12S5.925 1 12 1s11 4.925 11 11-4.925 11-11 11z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Make devices connected to the internet safe, secure and interoperable.</p>
@@ -156,9 +147,8 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://hubs.mozilla.com/"}}
                       {{#content "title"}}Hubs{{/content}}
-                      {{#content "link"}}https://hubs.mozilla.com/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M13 21.387l7.445-3.723A1 1 0 0 0 21 16.77V7.618l-8 4v9.769zm-2 .005v-9.774l-8-4v9.149c-.003.38.21.729.547.899L11 21.392zm8.759-15.39l-7.315-3.657a.999.999 0 0 0-.887 0L4.241 6.001 12 9.882l7.759-3.88zM13.335.555l8 4A3 3 0 0 1 23 7.24v9.53a3 3 0 0 1-1.663 2.684l-8 4a3 3 0 0 1-2.684 0L2.65 19.453A2.997 2.997 0 0 1 1 16.76V7.24a3 3 0 0 1 1.663-2.684L10.665.554a3 3 0 0 1 2.67 0z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Meet people in experimental Mixed Reality chatrooms using Firefox.</p>
@@ -187,9 +177,8 @@ styles:
               <div class="mzp-c-menu-panel-content">
                 <ul>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/developer.png"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/developer.png" link="https://www.mozilla.org/firefox/developer/"}}
                       {{#content "title"}}Developer Edition{{/content}}
-                      {{#content "link"}}https://www.mozilla.org/firefox/developer/{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Firefox, built just for developers.</p>
                       {{/content}}
@@ -197,9 +186,8 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/beta.png"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/beta.png" link="https://www.mozilla.org/firefox/channel/desktop/#beta"}}
                       {{#content "title"}}Firefox Beta{{/content}}
-                      {{#content "link"}}https://www.mozilla.org/firefox/channel/desktop/#beta{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Test soon-to-be-released features in our most stable pre-release build.</p>
                       {{/content}}
@@ -207,9 +195,8 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/nightly.png"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/nightly.png" link="https://www.mozilla.org/firefox/channel/desktop/#nightly"}}
                       {{#content "title"}}Firefox Nightly{{/content}}
-                      {{#content "link"}}https://www.mozilla.org/firefox/channel/desktop/#nightly{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Preview the latest build of Firefox and help us make it the best.</p>
                       {{/content}}
@@ -219,9 +206,8 @@ styles:
                 </ul>
                 <ul>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://www.mozilla.org/developer/"}}
                       {{#content "title"}}Developer Innovations{{/content}}
-                      {{#content "link"}}https://www.mozilla.org/developer/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M2.382 8H1a1 1 0 0 1-.857-1.514C3.013 1.7 7.079-.154 11.403.512 14.755 1.028 18 3.19 18 5c0 .83.097.955.98 1.286.349.13 2.105.688 2.336.765 1.888.63 2.548 2.23 2.165 4.145-.262 1.308-1.04 2.777-1.774 3.511-.901.902-1.592.902-3.377.49-.611-.141-.957-.197-1.33-.197-2.657 0-4 2.15-4 7a1 1 0 0 1-1 1c-2.897 0-5.77-1.077-8.6-3.2a1 1 0 0 1-.294-1.247L4.382 16H3a1 1 0 0 1-.894-1.447L3.382 12H2a1 1 0 0 1-.894-1.447L2.382 8zm8.64 12.95C11.255 15.803 13.239 13 17 13c.564 0 1.03.075 1.78.248 1.103.254 1.303.254 1.513.045.453-.453 1.042-1.565 1.226-2.49.204-1.017-.03-1.586-.835-1.854-.186-.062-2.001-.639-2.405-.79C16.652 7.549 16 6.71 16 5c0-.524-2.406-2.128-4.902-2.512-3.051-.47-5.905.58-8.204 3.512H4a1 1 0 0 1 .894 1.447L3.618 10H5a1 1 0 0 1 .894 1.447L4.618 14H6a1 1 0 0 1 .894 1.447l-1.618 3.237c1.937 1.324 3.85 2.075 5.747 2.267z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Developer projects that help keep the internet open and accessible for all.</p>
@@ -237,9 +223,8 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://developer.mozilla.org/"}}
                       {{#content "title"}}Resources{{/content}}
-                      {{#content "link"}}https://developer.mozilla.org/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><g fill="#000" fill-rule="nonzero"><path d="M11.553 1.106a1 1 0 0 1 .894 0l10 5a1 1 0 0 1 0 1.788l-10 5a1 1 0 0 1-.894 0l-10-5a1 1 0 0 1 0-1.788l10-5zM12 3.118L4.236 7 12 10.882 19.764 7 12 3.118zM12 20.882l9.553-4.776a1 1 0 0 1 .894 1.788l-10 5a1 1 0 0 1-.894 0l-10-5a1 1 0 0 1 .894-1.788L12 20.882z"/><path d="M21.553 11.106a1 1 0 0 1 .894 1.788l-10 5a1 1 0 0 1-.894 0l-10-5a1 1 0 0 1 .894-1.788L12 15.882l9.553-4.776z"/></g></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Resources for developers, by developers.</p>
@@ -277,9 +262,8 @@ styles:
               <div class="mzp-c-menu-panel-content">
                 <ul>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://www.mozilla.org/about/"}}
                       {{#content "title"}}Mozilla{{/content}}
-                      {{#content "link"}}https://www.mozilla.org/about/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M6 6.706V6H2v2h2v8H2v2h7v-2H6v-6c.667-1.333 1.5-2 2.5-2s1.833.667 2.5 2v8h5v-2h-3v-6c.667-1.333 1.5-2 2.5-2s1.833.667 2.5 2v8h4v-2h-2v-6c-.667-2.667-2.167-4-4.5-4-1.52 0-2.687.566-3.5 1.699C11.187 6.566 10.02 6 8.5 6c-.98 0-1.814.235-2.5.706zM8.5 4c1.324 0 2.507.327 3.5.97.993-.643 2.176-.97 3.5-.97 3.308 0 5.563 2.004 6.44 5.515l.06.239V14h2v6H0v-6h2v-4H0V4h8c.164.005.331 0 .5 0zM16 14v-3.484a1.845 1.845 0 0 0-.374-.454c-.068-.055-.088-.062-.126-.062-.038 0-.058.007-.126.062-.111.09-.239.239-.374.454V14h1zm-7 0v-3.484a1.845 1.845 0 0 0-.374-.454C8.558 10.007 8.538 10 8.5 10c-.038 0-.058.007-.126.062-.111.09-.239.239-.374.454V14h1z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Learn about Mozilla.</p>
@@ -297,9 +281,8 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://careers.mozilla.org/"}}
                       {{#content "title"}}Careers{{/content}}
-                      {{#content "link"}}https://careers.mozilla.org/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M10.95 21.02H8.772L6.11 22.796A2 2 0 0 1 3 21.13v-4.596a2 2 0 0 1 .89-1.664L7 12.798V9.52a10 10 0 0 1 1.264-4.866l1.989-3.571a2 2 0 0 1 3.494 0l1.99 3.571A10 10 0 0 1 17 9.52v3.28l3.11 2.072a2 2 0 0 1 .89 1.664v4.596a2 2 0 0 1-3.11 1.665l-2.662-1.776H12.95V23a1 1 0 0 1-2 0v-1.98zm2-2H15v-9.5a8 8 0 0 0-1.01-3.894L12 2.056l-1.99 3.57A8 8 0 0 0 9 9.52v9.501h1.95V17a1 1 0 1 1 2 0v2.02zM7 15.202l-2 1.333v4.596l2-1.333v-4.596zm10 4.596l2 1.333v-4.596l-2-1.333v4.596zM12 10a1 1 0 1 1 0-2 1 1 0 0 1 0 2z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Work for a mission-driven organization that builds purpose-driven products.</p>
@@ -310,9 +293,8 @@ styles:
                 </ul>
                 <ul>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://www.mozilla.org/contribute/"}}
                       {{#content "title"}}Get involved{{/content}}
-                      {{#content "link"}}https://www.mozilla.org/contribute/{{/content}}
                       {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M17.804 22.307a4.816 4.816 0 0 0-.998-.251c-.15-.416-.295-.815-.436-1.196 1.44-1.234 3.63-3.839 3.63-6.784 0-2.438-2.13-4.234-6.388-5.388-2.406-.422-4.34.585-5.802 3.023-2.194 3.657-6.875.708-3.218 5.827 2.824 3.954 7.123 4.542 9.451 4.313l.101.475c-.806.31-1.501.843-2.086 1.597-3.155-.33-6.817-2.035-9.094-5.222-2.467-3.454-2.33-5.695.775-6.642-.016.005.61-.18.775-.233.246-.08.444-.16.62-.248.406-.205.707-.473.96-.896 1.87-3.115 4.6-4.537 7.864-3.964l.177.04C19.163 8.12 22 10.513 22 14.076c0 3.146-2.023 6.387-4.196 8.23zm.475-1.942c1.65.562 3.058 1.774 4.221 3.635H20c-1-1.333-2.333-2-4-2-1.667 0-3 .667-4 2H9.5c.732-1.17 1.56-2.085 2.485-2.742l-.292-1.07c-1.592-.358-2.743-1.462-3.179-3.203-.63-2.524.455-4.78 2.895-6.491a2.5 2.5 0 0 1 3.891 1.568c.992-.01 1.914.53 2.398 1.498.637 1.275.28 2.227-.723 3.324l.041.085.068.152c.34.85.739 1.931 1.195 3.244zm-4.552-.002A7.024 7.024 0 0 1 16.051 20c-.3-.802-.575-1.514-.824-2.136-.454-.91-.454-1.591 0-2.046.682-.682.854-1.02.682-1.363-.172-.345-.682-.682-1.364 0-.404.404-.809-.271-1.213-2.026a.5.5 0 0 0-.774-.298c-1.813 1.271-2.514 2.728-2.103 4.369.333 1.334 1.278 1.934 2.834 1.8l.438 2.063zM17.5 24h2-2zm-4.768 0H14.5h-1.768zM3.5 5c0-.685.187-1.309.605-1.823.133-.164.268-.297.409-.409C4.738 1.075 6.162 0 8 0c2.037 0 3.66.964 4.11 3.085.095.446.118.9.071 1.344L14 8.018c-1.333-.012-2.5.149-3.5.482-1 .333-2 1-3 2L6.366 8.018C4.708 7.725 3.5 6.865 3.5 5zm4.26 1.14L9 8.5l2.5-1-1.41-2.81c.123-.368.151-.777.064-1.19C9.9 2.316 9 2 8 2s-1.625.501-1.5 1.5c.125 1-1 .343-1 1.5 0 .86 1.297 1.124 2.26 1.14z" fill="#020202" fill-rule="nonzero"/></svg>{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Join the fight for a healthy internet.</p>
@@ -334,6 +316,63 @@ styles:
                     <p class="mzp-c-card-desc">An event for advocates of a healthy Internet on Oct. 26-28 in London.</p>
                   {{/content}}
                 {{/embed}}
+              </div>
+            </div>
+          </div>
+        </li>
+        <li class="mzp-c-menu-category mzp-has-drop-down mzp-js-expandable">
+          <a class="mzp-c-menu-title" href="https://www.mozilla.org/about/" aria-haspopup="true" aria-controls="mzp-c-menu-panel-sample">Sample</a>
+          <div class="mzp-c-menu-panel mzp-has-card" id="mzp-c-menu-panel-sample">
+            <div class="mzp-c-menu-panel-container">
+              <button class="mzp-c-menu-button-close" type="button" aria-controls="mzp-c-menu-panel-about">Close Sample menu</button>
+              <div class="mzp-c-menu-panel-content">
+                <ul>
+                  <li>
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true"}}
+                      {{#content "title"}}Sample heading with icon no link{{/content}}
+                      {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M6 6.706V6H2v2h2v8H2v2h7v-2H6v-6c.667-1.333 1.5-2 2.5-2s1.833.667 2.5 2v8h5v-2h-3v-6c.667-1.333 1.5-2 2.5-2s1.833.667 2.5 2v8h4v-2h-2v-6c-.667-2.667-2.167-4-4.5-4-1.52 0-2.687.566-3.5 1.699C11.187 6.566 10.02 6 8.5 6c-.98 0-1.814.235-2.5.706zM8.5 4c1.324 0 2.507.327 3.5.97.993-.643 2.176-.97 3.5-.97 3.308 0 5.563 2.004 6.44 5.515l.06.239V14h2v6H0v-6h2v-4H0V4h8c.164.005.331 0 .5 0zM16 14v-3.484a1.845 1.845 0 0 0-.374-.454c-.068-.055-.088-.062-.126-.062-.038 0-.058.007-.126.062-.111.09-.239.239-.374.454V14h1zm-7 0v-3.484a1.845 1.845 0 0 0-.374-.454C8.558 10.007 8.538 10 8.5 10c-.038 0-.058.007-.126.062-.111.09-.239.239-.374.454V14h1z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
+                      {{#content "desc"}}
+                        <p class="mzp-c-menu-item-desc">Learn about Mozilla.</p>
+                      {{/content}}
+                      {{#content "list"}}
+                        <ul class="mzp-c-menu-item-list">
+                          <li><a href="https://www.mozilla.org/about/">About Mozilla</a></li>
+                          <li><a href="https://www.mozilla.org/about/leadership/">Leadership</a></li>
+                          <li><a href="https://www.mozilla.org/foundation/">Mozilla Foundation</a></li>
+                          <li><a href="https://blog.mozilla.org/press/">Press Center</a></li>
+                          <li><a href="https://www.mozilla.org/mission/">Mozilla Mission</a></li>
+                          <li><a href="https://www.mozilla.org/contact/">Contact</a></li>
+                        </ul>
+                      {{/content}}
+                    {{/embed}}
+                  </li>
+                  <li>
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" link="https://careers.mozilla.org/"}}
+                      {{#content "title"}}Careers{{/content}}
+                      {{#content "icon"}}<svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M10.95 21.02H8.772L6.11 22.796A2 2 0 0 1 3 21.13v-4.596a2 2 0 0 1 .89-1.664L7 12.798V9.52a10 10 0 0 1 1.264-4.866l1.989-3.571a2 2 0 0 1 3.494 0l1.99 3.571A10 10 0 0 1 17 9.52v3.28l3.11 2.072a2 2 0 0 1 .89 1.664v4.596a2 2 0 0 1-3.11 1.665l-2.662-1.776H12.95V23a1 1 0 0 1-2 0v-1.98zm2-2H15v-9.5a8 8 0 0 0-1.01-3.894L12 2.056l-1.99 3.57A8 8 0 0 0 9 9.52v9.501h1.95V17a1 1 0 1 1 2 0v2.02zM7 15.202l-2 1.333v4.596l2-1.333v-4.596zm10 4.596l2 1.333v-4.596l-2-1.333v4.596zM12 10a1 1 0 1 1 0-2 1 1 0 0 1 0 2z" fill="#000" fill-rule="nonzero"/></svg>{{/content}}
+                      {{#content "desc"}}
+                        <p class="mzp-c-menu-item-desc">Work for a mission-driven organization that builds purpose-driven products.</p>
+                      {{/content}}
+                      {{#content "list"}}{{/content}}
+                    {{/embed}}
+                  </li>
+                </ul>
+                <ul>
+                  <li>
+                    {{#embed "patterns.molecules.menu.menu-item"}}
+                      {{#content "title"}}Sample heading no icon no link{{/content}}
+                      {{#content "desc"}}
+                        <p class="mzp-c-menu-item-desc">Join the fight for a healthy internet.</p>
+                      {{/content}}
+                      {{#content "list"}}
+                        <ul class="mzp-c-menu-item-list">
+                          <li><a href="https://www.mozilla.org/contribute/events/">Events</a></li>
+                          <li><a href="https://donate.mozilla.org/">Donate</a></li>
+                        </ul>
+                      {{/content}}
+                    {{/embed}}
+                  </li>
+                </ul>
               </div>
             </div>
           </div>

--- a/src/patterns/molecules/menu/menu-item.hbs
+++ b/src/patterns/molecules/menu/menu-item.hbs
@@ -11,7 +11,7 @@ notes: |
 ---
 
 <section class="mzp-c-menu-item {{#if icon}}mzp-has-icon{{/if}} {{#if class}}{{class}}{{/if}}">
-  <a class="mzp-c-menu-item-link" href="{{#block "link"}}#{{/block}}">
+  {{#if link}}<a class="mzp-c-menu-item-link" href="{{link}}">{{else}}<div class="mzp-c-menu-item-head">{{/if}}
     {{#if icon}}
       {{#block "icon"}}
         <img src="{{@root.baseurl}}{{#if image}}{{image}}{{else}}/static/img/navigation/icons/accounts.svg{{/if}}" class="mzp-c-menu-item-icon" width="24" height="24" alt="">
@@ -23,7 +23,7 @@ notes: |
       This is a short description with only a single sentence and no more.
     </p>
     {{/block}}
-  </a>
+  {{#if link}}</a>{{else}}</div>{{/if}}
   {{#block "list"}}
   <ul class="mzp-c-menu-item-list">
     <li><a href="#">Secondary link</a></li>


### PR DESCRIPTION
* Navigation items that are links without menus get hover styles (#304)
* Let menu item titles not be links (#307)
* Updates Navigation demo with menu that is example the above 2 cases
  * moved links onto the menu-item templates as attributes