### PR TITLE
Don't repeat social icons (Fix #317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **css:** Social icon backgrounds no longer repeat (#317)
 * **css:** Define basic styles for dl lists (#295)
 * **css:** Add basic styles for hr elements (#296)
 * **js:** Update ESLint to consume @mozilla-protocol/eslint-config (##85)

--- a/src/assets/sass/protocol/components/_footer.scss
+++ b/src/assets/sass/protocol/components/_footer.scss
@@ -242,6 +242,7 @@
 
         a {
             @include image-replaced;
+            background-repeat: no-repeat;
             border-bottom: 1px solid transparent;
             display: block;
             height: 16px;


### PR DESCRIPTION
## Description

Don't repeat social icons (Fix #317)

- [X] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #317

### Testing

Only effected the instagram icon, I don't think there is one on any of the demo pages but you can swap the class on the link for testing purposes.