### PR TITLE
Make the Menu molecule more resilient to JS errors (Fixes #320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Bug Fixes
 
+* **css:** Use `mzp` namespace for menu and navigation state classes (#324)
 * **js:** (breaking) Make the Menu molecule more resilient to JS errors (#320)
 * **css:** Social icon backgrounds no longer repeat (#317)
 * **css:** Fix billboard overflowing text in IE 10 (#276)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Features
 
-* **css:** Social icon backgrounds no longer repeat (#317)
 * **css:** Define basic styles for dl lists (#295)
 * **css:** Add basic styles for hr elements (#296)
 * **js:** Update ESLint to consume @mozilla-protocol/eslint-config (##85)
@@ -14,6 +13,8 @@
 
 ## Bug Fixes
 
+* **js:** (breaking) Make the Menu molecule more resilient to JS errors (#320)
+* **css:** Social icon backgrounds no longer repeat (#317)
 * **css:** Fix billboard overflowing text in IE 10 (#276)
 
 # 4.0.0

--- a/src/assets/js/protocol/protocol-menu.js
+++ b/src/assets/js/protocol/protocol-menu.js
@@ -30,10 +30,10 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
      */
     Menu.open = function(el, animate) {
         if (animate) {
-            el.classList.add('is-animated');
+            el.classList.add('mzp-is-animated');
         }
 
-        el.classList.add('is-selected');
+        el.classList.add('mzp-is-selected');
 
         _menuOpen = true; // For checking menu state on keyup.
 
@@ -49,14 +49,14 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
      * Note: on small screens more than one menu can be open at the same time.
      */
     Menu.close = function() {
-        var current = document.querySelectorAll('.mzp-c-menu-category.is-selected');
+        var current = document.querySelectorAll('.mzp-c-menu-category.mzp-is-selected');
 
         for (var i = 0; i < current.length; i++) {
             // The following classes must be removed in the correct order
             // to work around a bug in bedrock's classList polyfill for IE9.
             // https://github.com/mozilla/bedrock/issues/6221 :/
-            current[i].classList.remove('is-selected');
-            current[i].classList.remove('is-animated');
+            current[i].classList.remove('mzp-is-selected');
+            current[i].classList.remove('mzp-is-animated');
 
             current[i].querySelector('.mzp-c-menu-title').setAttribute('aria-expanded', false);
         }
@@ -95,7 +95,7 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
      * @param {Object} el - DOM element (`.mzp-c-menu-category.mzp-js-expandable`)
      */
     Menu.toggle = function(el) {
-        var state = el.classList.contains('is-selected') ? true : false;
+        var state = el.classList.contains('mzp-is-selected') ? true : false;
 
         if (!state) {
             Menu.open(el);
@@ -103,8 +103,8 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
             // The following classes must be removed in the correct order
             // to work around a bug in bedrock's classList polyfill for IE9.
             // https://github.com/mozilla/bedrock/issues/6221 :/
-            el.classList.remove('is-selected');
-            el.classList.remove('is-animated');
+            el.classList.remove('mzp-is-selected');
+            el.classList.remove('mzp-is-animated');
             el.querySelector('.mzp-c-menu-title').setAttribute('aria-expanded', false);
 
             if (typeof _options.onMenuClose === 'function') {
@@ -156,7 +156,7 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
          */
         setTimeout(function() {
             // If the menu is open and the newly focused element is not a child, then call close().
-            if (!self.contains(document.activeElement) && self.classList.contains('is-selected')) {
+            if (!self.contains(document.activeElement) && self.classList.contains('mzp-is-selected')) {
                 Menu.close();
             }
         }, 0);

--- a/src/assets/js/protocol/protocol-menu.js
+++ b/src/assets/js/protocol/protocol-menu.js
@@ -297,12 +297,15 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
     };
 
     /**
-     * Enables simplified menu using pure CSS hover states.
+     * Enhances the menu for 1st class JS support.
      */
-    Menu.cssFallback = function() {
-        var menu = document.querySelector('.mzp-c-menu');
-        var currentClassName = menu.className;
-        menu.className = currentClassName.replace(/mzp-c-menu/, 'mzp-c-menu mzp-c-menu-basic');
+    Menu.enhanceJS = function() {
+        var menu = document.querySelectorAll('.mzp-c-menu');
+
+        for (var i = 0; i < menu.length; i++) {
+            menu[i].classList.remove('mzp-is-basic');
+            menu[i].classList.add('mzp-is-enhanced');
+        }
     };
 
     /**
@@ -332,8 +335,7 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
         if (Menu.isSupported()) {
             Menu.handleState();
             Menu.setAria();
-        } else {
-            Menu.cssFallback();
+            Menu.enhanceJS();
         }
     };
 

--- a/src/assets/js/protocol/protocol-navigation.js
+++ b/src/assets/js/protocol/protocol-navigation.js
@@ -23,13 +23,13 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
         e.preventDefault();
 
         // Update button state
-        e.target.classList.toggle('is-active');
+        e.target.classList.toggle('mzp-is-active');
 
         // Update menu state
-        navItems.classList.toggle('is-open');
+        navItems.classList.toggle('mzp-is-open');
 
         // Update aria-expended state on menu.
-        var expanded = navItems.classList.contains('is-open') ? true : false;
+        var expanded = navItems.classList.contains('mzp-is-open') ? true : false;
         navItems.setAttribute('aria-expanded', expanded);
 
         if (expanded) {

--- a/src/assets/sass/protocol/components/_menu.scss
+++ b/src/assets/sass/protocol/components/_menu.scss
@@ -163,7 +163,7 @@
 
 // Enhanced hover interactions with JavaScript enabled.
 .mzp-c-menu.mzp-is-enhanced .mzp-c-menu-category {
-    &.is-selected {
+    &.mzp-is-selected {
         .mzp-c-menu-title:before {
             @include transform(rotate(45deg));
         }
@@ -174,13 +174,13 @@
     }
 
     @media #{$mq-md} {
-        &.is-animated {
+        &.mzp-is-animated {
             .mzp-c-menu-panel,
             .mzp-c-menu-title:after {
                 @include animation(mzp-a-fade-in 80ms ease-in 0ms 1 normal both);
             }
         }
-        &.is-selected {
+        &.mzp-is-selected {
             .mzp-c-menu-title {
                 @include highlighted;
                 z-index: 101;

--- a/src/assets/sass/protocol/components/_menu.scss
+++ b/src/assets/sass/protocol/components/_menu.scss
@@ -123,8 +123,7 @@
 }
 
 // Basic hover interactions with JavaScript disabled or not supported..
-.no-js .mzp-c-menu-category,
-.mzp-c-menu-basic .mzp-c-menu-category {
+.mzp-c-menu.mzp-is-basic .mzp-c-menu-category {
 
     .mzp-c-menu-title:before {
         display: none;
@@ -163,7 +162,7 @@
 }
 
 // Enhanced hover interactions with JavaScript enabled.
-.js .mzp-c-menu-category {
+.mzp-c-menu.mzp-is-enhanced .mzp-c-menu-category {
     &.is-selected {
         .mzp-c-menu-title:before {
             @include transform(rotate(45deg));
@@ -316,8 +315,7 @@
     }
 }
 
-.no-js .mzp-c-menu-panel,
-.mzp-c-menu-basic .mzp-c-menu-panel {
+.mzp-c-menu.mzp-is-basic .mzp-c-menu-panel {
     display: block;
 
     @media #{$mq-md} {

--- a/src/assets/sass/protocol/components/_navigation.scss
+++ b/src/assets/sass/protocol/components/_navigation.scss
@@ -164,7 +164,7 @@
     &:hover,
     &:active,
     &:focus,
-    &.is-active  {
+    &.mzp-is-active  {
         background-color: $color-gray-20;
     }
 }
@@ -186,7 +186,7 @@
     .mzp-c-navigation-items {
         display: none;
 
-        &.is-open {
+        &.mzp-is-open {
             display: block;
         }
 

--- a/src/patterns/molecules/menu/menu.hbs
+++ b/src/patterns/molecules/menu/menu.hbs
@@ -8,8 +8,9 @@ notes: |
   - On small viewports a menu's content is expanded/collapsed when clicking on a menu link.
   - Menu content should consist of two lists of one or more [Menu Items](/patterns/molecules/menu.html#menu-item).
   - An Extra Small Card can also be included inside a menu using the `mzp-has-card` class. Cards are only visible on wide viewports.
-  - A Menu can also feature regular links that do not expand on hover/click by omitting the `mzp-has-drop-down` and  `mzp-js-expandable` classes.
-  - A Menu can be initialized using `Mzp.Menu.init(options)`, where `options` is an Object with the following properties.
+  - A menu can also feature regular links that do not expand on hover/click by omitting the `mzp-has-drop-down` and  `mzp-js-expandable` classes.
+  - A menu with a state class of `mzp-is-basic` is accessible without JavaScript. This state class gets replaced with `mzp-is-enhanced` when JS is executed.
+  - A menu can be initialized using `Mzp.Menu.init(options)`, where `options` is an Object with the following properties.
     - `onMenuOpen` [Function] callback when a menu is opened (optional).
     - `onMenuClose` [Function] callback when a menu is closed (optional).
     - `onMenuButtonClose` [Function] callback when a menu close button is clicked (optional).
@@ -17,7 +18,7 @@ links:
     Navigation Demo: /demos/navigation.html
 ---
 
-<nav class="mzp-c-menu">
+<nav class="mzp-c-menu mzp-is-basic">
   <ul class="mzp-c-menu-category-list">
     {{#block "content"}}
       <li class="mzp-c-menu-category mzp-has-drop-down mzp-js-expandable">

--- a/tests/unit/protocol-menu.js
+++ b/tests/unit/protocol-menu.js
@@ -5,7 +5,7 @@ describe('protocol-menu.js', function() {
     'use strict';
 
     beforeEach(function () {
-        var menu = '<nav class="mzp-c-menu">' +
+        var menu = '<nav class="mzp-c-menu mzp-is-basic">' +
                      '<ul class="mzp-c-menu-category-list">' +
                        '<li class="mzp-c-menu-category mzp-has-drop-down mzp-js-expandable">' +
                           '<a class="mzp-c-menu-title" href="#" aria-haspopup="true" aria-controls="mzp-c-menu-panel-example">Firefox</a>' +
@@ -38,16 +38,17 @@ describe('protocol-menu.js', function() {
             Mzp.Menu.init();
 
             expect(Mzp.Menu.handleState).toHaveBeenCalled();
+            expect(document.querySelector('.mzp-c-menu').classList.contains('mzp-is-enhanced')).toBeTruthy();
         });
 
         it('should fallback to basic CSS when not supported', function() {
             spyOn(Mzp.Menu, 'isSupported').and.returnValue(false);
-            spyOn(Mzp.Menu, 'cssFallback').and.callThrough();
+            spyOn(Mzp.Menu, 'handleState');
 
             Mzp.Menu.init();
 
-            expect(Mzp.Menu.cssFallback).toHaveBeenCalled();
-            expect(document.querySelector('.mzp-c-menu').classList.contains('mzp-c-menu-basic')).toBeTruthy();
+            expect(Mzp.Menu.handleState).not.toHaveBeenCalled();
+            expect(document.querySelector('.mzp-c-menu').classList.contains('mzp-is-basic')).toBeTruthy();
         });
     });
 

--- a/tests/unit/protocol-menu.js
+++ b/tests/unit/protocol-menu.js
@@ -88,14 +88,14 @@ describe('protocol-menu.js', function() {
             item.dispatchEvent(mockEnterEvent);
             jasmine.clock().tick(200);
 
-            expect(item.classList.contains('is-selected')).toBeTruthy();
+            expect(item.classList.contains('mzp-is-selected')).toBeTruthy();
             expect(options.open).toHaveBeenCalled();
 
             mockLeaveEvent.initEvent('mouseleave', true, true);
             item.dispatchEvent(mockLeaveEvent);
             jasmine.clock().tick(200);
 
-            expect(item.classList.contains('is-selected')).toBeFalsy();
+            expect(item.classList.contains('mzp-is-selected')).toBeFalsy();
             expect(options.close).toHaveBeenCalled();
         });
 
@@ -113,7 +113,7 @@ describe('protocol-menu.js', function() {
 
             title.click();
 
-            expect(item.classList.contains('is-selected')).toBeTruthy();
+            expect(item.classList.contains('mzp-is-selected')).toBeTruthy();
             expect(options.open).toHaveBeenCalled();
         });
 
@@ -134,12 +134,12 @@ describe('protocol-menu.js', function() {
             item.dispatchEvent(mockEnterEvent);
             jasmine.clock().tick(200);
 
-            expect(item.classList.contains('is-selected')).toBeTruthy();
+            expect(item.classList.contains('mzp-is-selected')).toBeTruthy();
             expect(options.open).toHaveBeenCalled();
 
             document.querySelector('.mzp-c-menu-button-close').click();
 
-            expect(item.classList.contains('is-selected')).toBeFalsy();
+            expect(item.classList.contains('mzp-is-selected')).toBeFalsy();
             expect(options.buttonClose).toHaveBeenCalled();
             expect(options.close).toHaveBeenCalled();
         });
@@ -172,11 +172,11 @@ describe('protocol-menu.js', function() {
             });
 
             title.click();
-            expect(item.classList.contains('is-selected')).toBeTruthy();
+            expect(item.classList.contains('mzp-is-selected')).toBeTruthy();
             expect(options.open).toHaveBeenCalled();
 
             title.click();
-            expect(item.classList.contains('is-selected')).toBeFalsy();
+            expect(item.classList.contains('mzp-is-selected')).toBeFalsy();
             expect(options.close).toHaveBeenCalled();
         });
     });

--- a/tests/unit/protocol-navigation.js
+++ b/tests/unit/protocol-navigation.js
@@ -45,14 +45,14 @@ describe('protocol-navigation.js', function() {
             });
             button.click();
 
-            expect(menu.classList.contains('is-open')).toBeTruthy();
-            expect(button.classList.contains('is-active')).toBeTruthy();
+            expect(menu.classList.contains('mzp-is-open')).toBeTruthy();
+            expect(button.classList.contains('mzp-is-active')).toBeTruthy();
             expect(options.open).toHaveBeenCalled();
 
             button.click();
 
-            expect(menu.classList.contains('is-open')).toBeFalsy();
-            expect(button.classList.contains('is-active')).toBeFalsy();
+            expect(menu.classList.contains('mzp-is-open')).toBeFalsy();
+            expect(button.classList.contains('mzp-is-active')).toBeFalsy();
             expect(options.close).toHaveBeenCalled();
         });
     });


### PR DESCRIPTION
## Description

This PR makes the menu molecule more resilient to JS errors, by no longer relying on the `js` and `np-js` global class names.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#320

### Testing

- [x] Menu should still work as expected with JS enabled.
- [x] Menu should still work as expected with JS disabled.
- [x] Menu should still function when an unexpected JS error is encountered (I misnamed a function in menu.js locally to recreate the scenario).
