### PR TITLE
Add example menu to menu molecule page (Fix: #322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **docs:** Add example menu to menu molecule page (#322)
 * **css:** Define basic styles for dl lists (#295)
 * **css:** Add basic styles for hr elements (#296)
 * **js:** Update ESLint to consume @mozilla-protocol/eslint-config (##85)

--- a/src/patterns/molecules/menu/menu.hbs
+++ b/src/patterns/molecules/menu/menu.hbs
@@ -1,7 +1,6 @@
 ---
 name: Menu
 description: An expandable menu used in the [Navigation](/patterns/organisms/navigation.html) organism, consisting of [Menu Items](/patterns/molecules/menu.html#menu-item) and an optional [Card](/patterns/molecules/card.html#extra-small-card) molecule.
-hidepreview: true
 order: 1
 notes: |
   - On wide viewports a menu's content is displayed when hovering or focusing on a menu link.
@@ -21,6 +20,9 @@ links:
 <nav class="mzp-c-menu mzp-is-basic">
   <ul class="mzp-c-menu-category-list">
     {{#block "content"}}
+      <li class="mzp-c-menu-category">
+          <a class="mzp-c-menu-title" href="https://www.mozilla.org/">Sample Link</a>
+      </li>
       <li class="mzp-c-menu-category mzp-has-drop-down mzp-js-expandable">
         <a class="mzp-c-menu-title" href="#" aria-haspopup="true" aria-controls="mzp-c-menu-panel-example">Firefox</a>
         <div class="mzp-c-menu-panel mzp-has-card" id="mzp-c-menu-panel-example">
@@ -63,3 +65,18 @@ links:
   </ul>
 </nav>
 
+<script src="{{@root.baseurl}}/assets/protocol/protocol/js/protocol-menu.js"></script>
+
+<script>
+  Mzp.Menu.init({
+      onMenuOpen: function() {
+          console.log('Menu opened');
+      },
+      onMenuClose: function() {
+          console.log('Menu closed');
+      },
+      onMenuButtonClose: function() {
+          console.log('Menu close button clicked');
+      }
+  });
+</script>

--- a/src/patterns/molecules/menu/menu.hbs
+++ b/src/patterns/molecules/menu/menu.hbs
@@ -31,10 +31,10 @@ links:
             <div class="mzp-c-menu-panel-content">
               <ul>
                 <li>
-                  {{#embed "patterns.molecules.menu.menu-item" icon="true"}}{{/embed}}
+                  {{#embed "patterns.molecules.menu.menu-item"}}{{/embed}}
                 </li>
                 <li>
-                  {{#embed "patterns.molecules.menu.menu-item" icon="true"}}{{/embed}}
+                  {{#embed "patterns.molecules.menu.menu-item"}}{{/embed}}
                 </li>
               </ul>
               <ul>


### PR DESCRIPTION
## Description

Adds an example of a menu to the menu page in the docs.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #322 

### Testing

The menu drop down overflows the sample container. I experimented with containing it inside the container but then it ends up really squished. It's buggy but it accurately represents the menu behaviour too. 🤷‍♀️ 
