### PR TITLE
Add optional label to navigation mobile menu button. #313

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **css:** Add optional label to navigation mobile menu button (#313)
 * **docs:** Add example menu to menu molecule page (#322)
 * **css:** Define basic styles for dl lists (#295)
 * **css:** Add basic styles for hr elements (#296)

--- a/src/assets/sass/protocol/components/_navigation.scss
+++ b/src/assets/sass/protocol/components/_navigation.scss
@@ -152,7 +152,7 @@
 .mzp-c-navigation-menu-button {
     @include bidi(((background-position, right 6px center, left 6px center ),));
     @include bidi(((float, right, left),));
-    @include bidi(((padding-right, 32px, padding-left, 0),));
+    @include bidi(((padding, 0 32px 0 6px, 0 6px 0 32px),));
     background-color: transparent;
     background-image: url('#{$image-path}/icons/ui/menu-black.svg');
     background-repeat: no-repeat;

--- a/src/assets/sass/protocol/components/_navigation.scss
+++ b/src/assets/sass/protocol/components/_navigation.scss
@@ -150,16 +150,16 @@
 // Mobile Navigation Icon
 
 .mzp-c-navigation-menu-button {
+    @include bidi(((background-position, right 6px center, left 6px center ),));
     @include bidi(((float, right, left),));
-    @include image-replaced;
-    background: transparent url('#{$image-path}/icons/ui/menu-black.svg') center center no-repeat;
+    @include bidi(((padding-right, 32px, padding-left, 0),));
+    background-color: transparent;
+    background-image: url('#{$image-path}/icons/ui/menu-black.svg');
+    background-repeat: no-repeat;
     border-radius: 4px;
     border: none;
-    cursor: pointer;
     display: none;
     height: 32px;
-    padding: 0;
-    width: 32px;
 
     &:hover,
     &:active,
@@ -168,6 +168,15 @@
         background-color: $color-gray-20;
     }
 }
+
+.mzp-c-navigation-menu-button:not(.has-label) {
+    @include bidi(((background-position, center center, center center ),));
+    @include bidi(((padding, 0, 0),));
+    @include image-replaced;
+    cursor: pointer;
+    width: 32px;
+}
+
 
 .js .mzp-c-navigation-menu-button {
     display: block;

--- a/src/pages/demos/navigation.hbs
+++ b/src/pages/demos/navigation.hbs
@@ -423,7 +423,7 @@ styles:
       </article>
     </div>
 
-    {{#embed "patterns.organisms.navigation.navigation" id="in-page-nav-demo"}}
+    {{#embed "patterns.organisms.navigation.navigation" id="in-page-nav-demo" button-label="Sub sections"}}
       {{#content "menu"}}
         {{#embed "patterns.molecules.menu.menu"}}
           {{#content "content"}}

--- a/src/patterns/organisms/navigation/navigation.hbs
+++ b/src/patterns/organisms/navigation/navigation.hbs
@@ -18,7 +18,7 @@ links:
 <div class="mzp-c-navigation">
   <div class="mzp-c-navigation-l-content">
     <div class="mzp-c-navigation-container">
-      <button class="mzp-c-navigation-menu-button{{#if button-label}} has-label{{/if}}" type="button" aria-controls="map-c-navigation-items">{{#if button-label}}{{ button-label }}{{ else }}Menu{{/if}}</button>
+      <button class="mzp-c-navigation-menu-button{{#if button-label}} has-label{{/if}}" type="button" aria-controls="{{ id }}">{{#if button-label}}{{ button-label }}{{ else }}Menu{{/if}}</button>
       {{#if logo}}<div class="mzp-c-navigation-logo"><a href="https://www.mozilla.org/">Mozilla</a></div>{{/if}}
       <div class="mzp-c-navigation-items" id="{{ id }}">
         {{#if download}}

--- a/src/patterns/organisms/navigation/navigation.hbs
+++ b/src/patterns/organisms/navigation/navigation.hbs
@@ -6,6 +6,7 @@ hidepreview: true
 notes: |
   - On wide viewports, navigation content is displayed inline.
   - On small viewports, navigation content is hidden by default and toggled via a menu icon.
+    - Add `has-label` to the button to display the text label with the menu icon.
   - The Mozilla logo is always visible.
   - Navigation can be initialized using `Mzp.Navigation.init(options)`, where `options` is an Object with the following properties.
       - `onNavOpen` [Function] A callback when the small screen navigation icon is clicked to open (optional).
@@ -17,7 +18,7 @@ links:
 <div class="mzp-c-navigation">
   <div class="mzp-c-navigation-l-content">
     <div class="mzp-c-navigation-container">
-      <button class="mzp-c-navigation-menu-button" type="button" aria-controls="{{ id }}">Menu</button>
+      <button class="mzp-c-navigation-menu-button{{#if button-label}} has-label{{/if}}" type="button" aria-controls="map-c-navigation-items">{{#if button-label}}{{ button-label }}{{ else }}Menu{{/if}}</button>
       {{#if logo}}<div class="mzp-c-navigation-logo"><a href="https://www.mozilla.org/">Mozilla</a></div>{{/if}}
       <div class="mzp-c-navigation-items" id="{{ id }}">
         {{#if download}}


### PR DESCRIPTION
## Description

Add optional label to navigation mobile menu button.

<img width="567" alt="screen shot 2019-02-20 at 4 38 36 pm" src="https://user-images.githubusercontent.com/854701/53134911-ff079c00-352d-11e9-9b7f-1b59e05312c1.png">

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #313

### Testing

- RTL
- small and large screens
- label displays when it should, does not when it shouldn't
- no demo for this right now, it makes sense to add it after #309 merges
