### PR TITLE
Details extend and fix text overlapping button bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # HEAD
 
 # Bug Fixes
-
+* **css:** Summary button text over laps icon #331
+* **css:** Make summary and details widget styles into mixins #332
 * **css:** Visited link colour in t-dark themes too dark #335
 
 # 5.0.0

--- a/src/assets/sass/protocol/base/elements/_details.scss
+++ b/src/assets/sass/protocol/base/elements/_details.scss
@@ -3,51 +3,23 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import '../../includes/lib';
+@import '../../includes/mixins/details';
 
 .mzp-c-details,
 details {
-    .is-summary {
-        button {
-            color: inherit;
-            background: transparent;
-            font-family: inherit;
-            font-weight: inherit;
-            font-size: inherit;
-            text-align: inherit;
-            border: 0;
-            width: 100%;
-            position: relative;
-        }
-    }
-
-    .is-closed[aria-hidden="true"] {
-        display: none;
-    }
+    @include details;
 }
 
 summary,
 details .is-summary button,
 .mzp-c-details .is-summary button {
-    position: relative;
-
-    &:before {
-        background: $url-image-expand-black top left no-repeat;
-        @include background-size(16px, 16px);
-        @include bidi(((right, 8px, left, auto),));
-        @include transition(transform 100ms ease-in-out);
-        content: '';
-        height: 16px;
-        margin-top: -8px;
-        position: absolute;
-        top: 50%;
-        width: 16px;
-    }
+    @include summary;
 }
 
 details[open] summary:before,
 details .is-summary button[aria-expanded=true]:before,
 .mzp-c-details .is-summary button[aria-expanded=true]:before {
-    @include transform(rotate(45deg));
+    @include summary-open;
 }
 
 summary::-webkit-details-marker {

--- a/src/assets/sass/protocol/includes/mixins/_details.scss
+++ b/src/assets/sass/protocol/includes/mixins/_details.scss
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../includes/lib';
+
+@mixin details {
+    .is-summary {
+        button {
+            color: inherit;
+            background: transparent;
+            font-family: inherit;
+            font-weight: inherit;
+            font-size: inherit;
+            text-align: inherit;
+            border: 0;
+            width: 100%;
+            position: relative;
+        }
+    }
+
+    .is-closed[aria-hidden="true"] {
+        display: none;
+    }
+}
+
+@mixin summary {
+    position: relative;
+    @include bidi(((padding-right, $layout-md, padding-left, 0),));
+
+    &:before {
+        background: $url-image-expand-black top left no-repeat;
+        @include background-size(16px, 16px);
+        @include bidi(((right, 8px, left, auto),));
+        @include transition(transform 100ms ease-in-out);
+        content: '';
+        height: 16px;
+        margin-top: -8px;
+        position: absolute;
+        top: 50%;
+        width: 16px;
+    }
+}
+
+@mixin summary-open {
+    @include transform(rotate(45deg));
+}


### PR DESCRIPTION
## Description

- Move details and summary styles into mixins classes
- Add right padding to summary to avoid over-lapping with toggle image
---
- ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #332 Fix #331 

### Testing

- [ ] both kinds of toggles on the details demo page still function
- [ ] long text no longer over-laps the toggle button on both RTL and LTR

