### PR TITLE
Add blockquote mzp-t-firefox theme #303

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # HEAD
 
 # Bug Fixes
+
+* **css:** blockquote needs mzp-t-firefox theme #303
 * **css:** Summary button text over laps icon #331
 * **css:** Make summary and details widget styles into mixins #332
 * **css:** Visited link colour in t-dark themes too dark #335

--- a/src/assets/sass/protocol/base/elements/_quotes.scss
+++ b/src/assets/sass/protocol/base/elements/_quotes.scss
@@ -18,6 +18,9 @@ blockquote {
     & > :last-child {
         margin-bottom: 0;
     }
+
+    .mzp-t-firefox &,
+    &.mzp-t-firefox {
+        @include open-sans;
+    }
 }
-
-


### PR DESCRIPTION
## Description

Over-ride zilla with open sans when a blockquote is on a firefox themed page.

- ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #303

### Testing

Hopefully pretty straight forward.
