### PR TITLE
Use light-links mixin in t-dark theme #335

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+# Bug Fixes
+
+* **css:** Visited link colour in t-dark themes too dark #335
+
 # 5.0.0
 
 ## Features

--- a/src/assets/sass/protocol/base/elements/_links.scss
+++ b/src/assets/sass/protocol/base/elements/_links.scss
@@ -26,10 +26,7 @@
 }
 
 .mzp-t-dark {
-    :link,
-    :link:visited {
-        color: $color-white;
-    }
+    @include light-links;
 }
 
 .mzp-c-cta-link {

--- a/src/assets/sass/protocol/components/_button.scss
+++ b/src/assets/sass/protocol/components/_button.scss
@@ -19,7 +19,7 @@
     display: inline-block;
     font-weight: bold;
     padding: ($padding-md - 2px) ($padding-xl - 2px); //2px extra padding removed to compensate for 2px border.
-    text-decoration: none;
+    text-decoration: none !important;  /* stylelint-disable-line declaration-no-important */
 
     &:focus,
     &:hover {

--- a/src/assets/sass/protocol/components/_button.scss
+++ b/src/assets/sass/protocol/components/_button.scss
@@ -7,7 +7,8 @@
 /* -------------------------------------------------------------------------- */
 // Primary Button
 
-.mzp-c-button {
+.mzp-c-button,
+a.mzp-c-button {
     @include border-box;
     @include text-cta;
     @include transition(background-color 100ms, box-shadow 100ms, color 100ms, transform 100ms);
@@ -40,7 +41,8 @@
     padding: ($padding-sm - 2px) ($padding-md - 2px);
 }
 
-.mzp-c-button.mzp-t-dark  {
+.mzp-c-button.mzp-t-dark,
+a.mzp-c-button.mzp-t-dark {
     background-color: $color-white;
     border-color: $color-white;
     color: $color-black;
@@ -88,7 +90,8 @@
 /* -------------------------------------------------------------------------- */
 // Product Buttons
 
-.mzp-c-button.mzp-t-product {
+.mzp-c-button.mzp-t-product,
+a.mzp-c-button.mzp-t-product {
     background-color: $color-blue-60;
     border-color: transparent;
     color: $color-white;
@@ -112,7 +115,8 @@
     padding: $padding-sm $padding-md;
 }
 
-.mzp-c-button.mzp-t-product.mzp-t-secondary {
+.mzp-c-button.mzp-t-product.mzp-t-secondary,
+a.mzp-c-button.mzp-t-product.mzp-t-secondary {
     background-color: transparent;
     border-color: $color-blue-60;
     color: $color-blue-60;

--- a/src/assets/sass/protocol/includes/_mixins.scss
+++ b/src/assets/sass/protocol/includes/_mixins.scss
@@ -234,9 +234,14 @@
         text-decoration: underline;
     }
 
+    a:visited {
+        opacity: 0.8;
+    }
+
     a:hover,
     a:focus,
     a:active {
+        opacity: 1;
         text-decoration: none;
     }
 }

--- a/src/assets/sass/protocol/includes/_mixins.scss
+++ b/src/assets/sass/protocol/includes/_mixins.scss
@@ -235,13 +235,12 @@
     }
 
     a:visited {
-        opacity: 0.8;
+        color: transparentize($color-white, 0.2);
     }
 
     a:hover,
     a:focus,
     a:active {
-        opacity: 1;
         text-decoration: none;
     }
 }


### PR DESCRIPTION
## Description

Use light-links mixin in `.t-dark` theme links.
Add visited links styles to light-links mixin.

- ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #335 

### Testing

This underlined all child buttons under `.t-dark` themed elements... hence the important. Let me know if you think this is a bad idea I'm a bad person and I should feel bad.
