### PR TITLE
at2x accepts contain as a single parameter (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Bug Fixes
 
+* **css:** Update at2x to allow background-size: contain (#336)
 * **css:** (breaking) Remove curve under hero component (#311)
 * **css:** (breaking) Move Zilla Slab from default theme to custom theme (#342)
 * **css:** Call Out component is missing display: flex vendor prefixes (#218)

--- a/src/assets/sass/protocol/includes/mixins/_at2x.scss
+++ b/src/assets/sass/protocol/includes/mixins/_at2x.scss
@@ -13,6 +13,11 @@
 @mixin at2x($path, $w: auto, $h: auto) {
     $hr-suffix: '-high-res';
 
+    // Do not set height to auto if width is contain
+    @if $w = 'contain' {
+        $h: #{''};
+    }
+
     // Set a counter and get the length of the image path.
     $position: -1;
     $strpath: '#{$path}';


### PR DESCRIPTION
## Description

When the `at2x` gets `contain` as the second parameter it no longer sets the height to auto, instead it does not add a height value.

- ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #336.

### Testing

This was annoying to figure out so please don't assume it's fine by looking at it, do give the code a test.
