### PR TITLE
Fix at2x error and publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.0.1
+
+# Bug Fixes
+
+* **css:** Error in at2x mixin #368
+
 # 6.0.0
 
 # Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": true,
   "author": "Mozilla",
   "description": "A design system for Mozilla's websites.",

--- a/src/assets/package/README.md
+++ b/src/assets/package/README.md
@@ -20,7 +20,7 @@ Install package with NPM and add it to your dependencies:
 </tr>
 <tr>
 <td>Version</td>
-<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">6.0.0</a></td>
+<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">6.0.1</a></td>
 </tr>
 </table>
 

--- a/src/assets/package/package.json
+++ b/src/assets/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/core",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A design system for Mozilla's websites.",
   "repository": {
     "type": "git",

--- a/src/assets/sass/protocol/includes/mixins/_at2x.scss
+++ b/src/assets/sass/protocol/includes/mixins/_at2x.scss
@@ -14,7 +14,7 @@
     $hr-suffix: '-high-res';
 
     // Do not set height to auto if width is contain
-    @if $w = 'contain' {
+    @if $w == 'contain' {
         $h: #{''};
     }
 


### PR DESCRIPTION
## Description

Fixes a bug in at2x mixin and publishes version 6.0.1.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #368

### Testing

I found it useful to  copy the mixin into code pen and try the 4 following combinations to make sure the right thing is being output:

- no size attributes, should output auto
- just a width (height should be auto)
- width and height
- just contain (should be no height: auto).
