### PR TITLE
Update product button theme color (Fixes #380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Features
 
+* **css:** Update product button theme color (#380)
 * **css:** (breaking) Implement Updated Font Stacks (#342)
 
 # 6.0.1

--- a/src/assets/sass/protocol/components/_button.scss
+++ b/src/assets/sass/protocol/components/_button.scss
@@ -92,14 +92,14 @@ a.mzp-c-button.mzp-t-dark {
 
 .mzp-c-button.mzp-t-product,
 a.mzp-c-button.mzp-t-product {
-    background-color: $color-blue-60;
+    background-color: $color-blue-50;
     border-color: transparent;
     color: $color-white;
 
     &:focus,
     &:hover {
         @include transform(none);
-        background-color: $color-blue-70;
+        background-color: $color-blue-60;
         box-shadow: none;
         color: $color-white;
     }
@@ -118,13 +118,13 @@ a.mzp-c-button.mzp-t-product {
 .mzp-c-button.mzp-t-product.mzp-t-secondary,
 a.mzp-c-button.mzp-t-product.mzp-t-secondary {
     background-color: transparent;
-    border-color: $color-blue-60;
-    color: $color-blue-60;
+    border-color: $color-blue-50;
+    color: $color-blue-50;
 
     &:focus,
     &:hover {
         @include transform(none);
-        background-color: $color-blue-70;
+        background-color: $color-blue-60;
         border-color: transparent;
         box-shadow: none;
         color: $color-white;


### PR DESCRIPTION
## Description

Updates the product button theme colors for the upcoming trailhead campaign pages.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#380

### Testing
Both primary and secondary download button themes should reflect the new color.
