### PR TITLE
Add citation style to blockquote and decrease font size. (#366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # HEAD
 
 * **css:** Text display mixin consistency (#389)
+* **css:** Add citation to blockquote and decrease font size (#366)
 
 # 7.0.0
 

--- a/src/assets/sass/protocol/base/elements/_quotes.scss
+++ b/src/assets/sass/protocol/base/elements/_quotes.scss
@@ -9,7 +9,7 @@ blockquote {
         (border-left, 5px solid $color-gray-20, border-right, 0),
         ));
     @include text-display-sm;
-    margin: $spacing-lg auto $spacing-lg;
+    margin: $spacing-lg auto;
     padding: $spacing-sm $spacing-lg;
     font-weight: bold;
 
@@ -36,9 +36,4 @@ blockquote {
     .mzp-t-mozilla & {
         @include font-mozilla;
     }
-}
-
-[dir='rtl'] {
-    cite:before { content: ''; }
-    cite:after { content: ' —'; }
 }

--- a/src/assets/sass/protocol/base/elements/_quotes.scss
+++ b/src/assets/sass/protocol/base/elements/_quotes.scss
@@ -4,15 +4,23 @@
 
 @import '../../includes/lib';
 
-
 blockquote {
     @include bidi((
         (border-left, 5px solid $color-gray-20, border-right, 0),
         ));
-    @include text-display-md;
-    margin: $spacing-md auto;
+    @include text-display-sm;
+    margin: $spacing-lg auto $spacing-lg;
     padding: $spacing-sm $spacing-lg;
     font-weight: bold;
+
+    cite {
+        @include text-display-xs;
+        color: $color-gray-70;
+
+        &:before {
+            content: '— ';
+        }
+    }
 
     & > :last-child {
         margin-bottom: 0;
@@ -28,4 +36,9 @@ blockquote {
     .mzp-t-mozilla & {
         @include font-mozilla;
     }
+}
+
+[dir='rtl'] {
+    cite:before { content: ''; }
+    cite:after { content: ' —'; }
 }

--- a/src/patterns/atoms/typographic/quotes.hbs
+++ b/src/patterns/atoms/typographic/quotes.hbs
@@ -11,10 +11,12 @@ order: 5
   <p>
     "{{data "specimens.sentence"}}"
   </p>
+  <cite>A. Nonymous</cite>
 </blockquote>
 
 <blockquote class="mzp-t-mozilla">
   <p>
     "{{data "specimens.sentence"}}"
   </p>
+  <cite>A. Nonymous</cite>
 </blockquote>


### PR DESCRIPTION
## Description

- Add citation styles to blockquotes. 
- Decreases font size of blockquotes.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
#366
