### PR TITLE
Add contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A modular design system for Mozilla websites.
 
 https://protocol.mozilla.org/
 
+Protocol is in an *early stage of development* and likely to change a lot in the near future. If you're interested in using it on your project, let us know and we can help you.
+
 ## Getting Started
 
 Protocol is built on the [Node.js](https://nodejs.org/) platform and published to [NPM](https://www.npmjs.com/), so be sure to have both installed before proceeding.

--- a/src/pages/docs/contributing.md
+++ b/src/pages/docs/contributing.md
@@ -1,0 +1,90 @@
+---
+title: Contributing
+order: 2
+---
+
+We've done our best to make the barrier of entry to contributing code
+to Protocol as low as possible. You can even do a lot of stuff directly
+through github without actually installing Protocol locally, but if you
+want to do any complex coding work you'll eventually need to set up a
+local development environment.
+
+<ul class="mzp-u-list-styled">
+    <li>You'll need a Github account.
+        <ul>
+            <li>https://github.com/join</li>
+            <li>https://help.github.com/articles/set-up-git/</li>
+        </ul>
+    </li>
+    <li>You'll need to install Git.
+        <ul>
+            <li>https://git-scm.com/downloads</li>
+            <li>https://git-scm.com/book/en/v2/Getting-Started-Installing-Git</li>
+        </ul>
+    </li>
+    <li>You'll need to install Node and npm.
+        <ul>
+            <li>https://docs.npmjs.com/downloading-and-installing-node-js-and-npm</li>
+        </ul>
+    </li>
+</ul>
+
+With those prerequisites met:
+
+<ol class="mzp-u-list-styled">
+    <li>Fork the [Protocol Github repository](https://github.com/mozilla/protocol/) to your personal account.
+        <ul>
+            <li>https://help.github.com/articles/fork-a-repo/</li>
+        </ul>
+    </li>
+    <li>Clone that remote repo to your computer.
+        <ul>
+            <li>https://help.github.com/articles/cloning-a-repository/</li>
+        </ul>
+    </li>
+    <li>On your computer's command line, navigate to the folder to which you just cloned the Protocol repo.</li>
+    <li>Within that folder, run `npm start`. This will install all the dependencies and launch a local server.</li>
+</ol>
+
+You now have a local instance of the Protocol site running on your
+computer. You can load the site in a browser at http://localhost:3000.
+As you edit files they will update automatically and you can see your
+changes "live" on your local development environment.
+
+<ol class="mzp-u-list-styled">
+    <li>Make whatever edits you need to make, ideally in a fresh branch.
+        <ul>
+            <li>https://git-scm.com/book/en/Git-Branching-Basic-Branching-and-Merging</li>
+            <li>https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/</li>
+        </ul>
+    </li>
+    <li>When you're done, commit your changes and push them to your github remote repository.
+        <ul>
+            <li>https://help.github.com/articles/pushing-to-a-remote/</li>
+        </ul>
+    </li>
+    <li>Submit a pull request from your fork to the Mozilla repo.
+        <ul>
+            <li>https://help.github.com/articles/creating-a-pull-request-from-a-fork/</li>
+        </ul>
+    </li>
+</ol>
+
+You can also make some edits directly on github.com without installing the
+site locally. For that you don't even have to install Git or Node, you just
+need a Github account. This is fine for updating docs or minor tweaks that
+don't need extensive testing or review, but for any serious coding you really
+should have a local instance running so you can see your work as it progresses.
+
+### Reporting Bugs
+
+To report an error you've discovered in Protocol, [submit an issue on Github](https://github.com/mozilla/protocol/issues)
+with a detailed description of the error and steps to reproduce. If possible,
+include a link to a live example and/or a screenshot of the bug in effect. Also
+be sure to mention the browser (and version) and operating system.
+
+You should search for similar issues in case it's already been reported. In
+some cases a bug may have been fixed but the fix may not have been deployed, so
+it's a good idea to search through closed issues as well.
+
+

--- a/src/pages/docs/contributing.md
+++ b/src/pages/docs/contributing.md
@@ -5,45 +5,48 @@ order: 2
 
 We've done our best to make the barrier of entry to contributing code
 to Protocol as low as possible. You can even do a lot of stuff directly
-through github without actually installing Protocol locally, but if you
+through GitHub without actually installing Protocol locally, but if you
 want to do any complex coding work you'll eventually need to set up a
 local development environment.
 
 <ul class="mzp-u-list-styled">
-    <li>You'll need a Github account.
-        <ul>
-            <li>https://github.com/join</li>
-            <li>https://help.github.com/articles/set-up-git/</li>
-        </ul>
-    </li>
-    <li>You'll need to install Git.
-        <ul>
-            <li>https://git-scm.com/downloads</li>
-            <li>https://git-scm.com/book/en/v2/Getting-Started-Installing-Git</li>
-        </ul>
-    </li>
-    <li>You'll need to install Node and npm.
-        <ul>
-            <li>https://docs.npmjs.com/downloading-and-installing-node-js-and-npm</li>
-        </ul>
-    </li>
+  <li>You'll need a GitHub account.
+    <ul>
+      <li>https://github.com/join</li>
+      <li>https://help.github.com/articles/set-up-git/</li>
+    </ul>
+  </li>
+  <li>You'll need to install Git.
+    <ul>
+      <li>https://git-scm.com/downloads</li>
+      <li>https://git-scm.com/book/en/v2/Getting-Started-Installing-Git</li>
+    </ul>
+  </li>
+  <li>You'll need to install Node and npm.
+    <ul>
+      <li>https://docs.npmjs.com/downloading-and-installing-node-js-and-npm</li>
+    </ul>
+  </li>
 </ul>
 
 With those prerequisites met:
 
 <ol class="mzp-u-list-styled">
-    <li>Fork the [Protocol Github repository](https://github.com/mozilla/protocol/) to your personal account.
-        <ul>
-            <li>https://help.github.com/articles/fork-a-repo/</li>
-        </ul>
-    </li>
-    <li>Clone that remote repo to your computer.
-        <ul>
-            <li>https://help.github.com/articles/cloning-a-repository/</li>
-        </ul>
-    </li>
-    <li>On your computer's command line, navigate to the folder to which you just cloned the Protocol repo.</li>
-    <li>Within that folder, run `npm start`. This will install all the dependencies and launch a local server.</li>
+  <li>Fork the [Protocol GitHub repository](https://github.com/mozilla/protocol/)
+      to your personal account.
+    <ul>
+      <li>https://help.github.com/articles/fork-a-repo/</li>
+    </ul>
+  </li>
+  <li>Clone that remote repo to your computer.
+    <ul>
+      <li>https://help.github.com/articles/cloning-a-repository/</li>
+    </ul>
+  </li>
+  <li>On your computer’s command line, navigate to the folder to which you just
+      cloned the Protocol repo.</li>
+  <li>Within that folder, run `npm start`. This will install all the dependencies
+      and launch a local server.</li>
 </ol>
 
 You now have a local instance of the Protocol site running on your
@@ -52,39 +55,40 @@ As you edit files they will update automatically and you can see your
 changes "live" on your local development environment.
 
 <ol class="mzp-u-list-styled">
-    <li>Make whatever edits you need to make, ideally in a fresh branch.
-        <ul>
-            <li>https://git-scm.com/book/en/Git-Branching-Basic-Branching-and-Merging</li>
-            <li>https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/</li>
-        </ul>
-    </li>
-    <li>When you're done, commit your changes and push them to your github remote repository.
-        <ul>
-            <li>https://help.github.com/articles/pushing-to-a-remote/</li>
-        </ul>
-    </li>
-    <li>Submit a pull request from your fork to the Mozilla repo.
-        <ul>
-            <li>https://help.github.com/articles/creating-a-pull-request-from-a-fork/</li>
-        </ul>
-    </li>
+  <li>Make whatever edits you need to make, ideally in a fresh branch.
+    <ul>
+      <li>https://git-scm.com/book/en/Git-Branching-Basic-Branching-and-Merging</li>
+      <li>https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/</li>
+    </ul>
+  </li>
+  <li>When you're done, commit your changes and push them to your GitHub remote repository.
+    <ul>
+      <li>https://help.github.com/articles/pushing-to-a-remote/</li>
+    </ul>
+  </li>
+  <li>Submit a pull request from your fork to the Mozilla repo.
+    <ul>
+      <li>https://help.github.com/articles/creating-a-pull-request-from-a-fork/</li>
+    </ul>
+  </li>
 </ol>
 
-You can also make some edits directly on github.com without installing the
-site locally. For that you don't even have to install Git or Node, you just
-need a Github account. This is fine for updating docs or minor tweaks that
-don't need extensive testing or review, but for any serious coding you really
-should have a local instance running so you can see your work as it progresses.
+You can also [make some edits directly on github.com](https://help.github.com/en/articles/editing-files-in-another-users-repository)
+without installing the site locally. For that you don't even have to install
+Git or Node, you just need a GitHub account. This is fine for updating docs or
+minor tweaks that don’t need extensive testing or review, but for any serious
+coding you really should have a local instance running so you can see your work
+as it progresses.
 
 ### Reporting Bugs
 
-To report an error you've discovered in Protocol, [submit an issue on Github](https://github.com/mozilla/protocol/issues)
+To report an error you’ve discovered in Protocol, [submit an issue on Github](https://github.com/mozilla/protocol/issues)
 with a detailed description of the error and steps to reproduce. If possible,
 include a link to a live example and/or a screenshot of the bug in effect. Also
 be sure to mention the browser (and version) and operating system.
 
-You should search for similar issues in case it's already been reported. In
+You should search for similar issues in case it’s already been reported. In
 some cases a bug may have been fixed but the fix may not have been deployed, so
-it's a good idea to search through closed issues as well.
+it’s a good idea to search through closed issues as well.
 
 

--- a/src/pages/docs/css-guide.md
+++ b/src/pages/docs/css-guide.md
@@ -1,6 +1,6 @@
 ---
 title: CSS Coding Guide
-order: 2
+order: 4
 ---
 
 Coding style can be really personal and everyone has their own opinions
@@ -85,7 +85,7 @@ rule or declaration above it.
 
 ## Format
 
-<ul class="prose">
+<ul class="mzp-u-list-styled">
     <li>One selector per line.</li>
     <li>One declaration per line.</li>
     <li>Order declarations alphabetically (from A to Z).</li>
@@ -145,7 +145,7 @@ be arranged across multiple lines (indented one level from their property).
 
 ### Units
 
-<ul class="prose">
+<ul class="mzp-u-list-styled">
     <li>Use pixels for fixed-width elements.</li>
     <li>Use percentages for fluid-width elements.</li>
     <li>Use rems for `font-size` because it respects user preferences.</li>

--- a/src/pages/docs/naming.md
+++ b/src/pages/docs/naming.md
@@ -1,6 +1,6 @@
 ---
 title: Naming Convention
-order: 1
+order: 2
 ---
 
 For ease of integration and to avoid conflicts with other sites, frameworks,
@@ -12,7 +12,7 @@ naming convention with a set of prefixes to put rules into a few different
 categories:
 
 <ul class="mzp-u-list-styled">
-    <li>`c-` for component names. Expect a lot of this one, e.g. `.mzp-c-card`, `.mzp-c-btn`.</li>
+    <li>`c-` for component names. Expect a lot of this one, e.g. `.mzp-c-card`, `.mzp-c-button`.</li>
     <li>`t-` for theme styles, when a component has one or more alternative styles, e.g. `.mzp-t-dark`, `.mzp-t-firefox`.</li>
     <li>`l-` for layout-related styles, e.g. `.mzp-l-grid-half`, `.mzp-l-grid-third`. These are presentational so should be rare. Prefer mixins.</li>
     <li>`u-` for utility styles, which have a broad scope and can be powerful overrides, e.g. `.mzp-u-inline`, `.mzp-u-no-margin`. These are presentational so should be rare. Prefer mixins.</li>
@@ -50,12 +50,12 @@ purpose, or function, not its presentation.
 
 ```scss
 // NO - Presentational
-.mzp-c-card-large { ... }
-.mzp-c-btn-blue { ... }
+.mzp-c-box { ... }
+.mzp-c-button-blue { ... }
 
 // YES - Meaningful
-.mzp-c-card-featured { ... }
-.mzp-c-btn-primary { ... }
+.mzp-c-card { ... }
+.mzp-c-button-download { ... }
 ```
 
 Notable exceptions are the handful of layout and utility classes (prefixed

--- a/src/pages/index.hbs
+++ b/src/pages/index.hbs
@@ -7,9 +7,11 @@ order: 0
 <div class="mzp-c-article">
   <div class="mzp-c-article-intro">
     <p>Protocol is a design system for Mozilla branded websites. It establishes a common design language, provides reusable coded components, and outlines high level guidelines for content and accessibility.</p>
+
+    <p>Protocol is still in an <strong>early stage of development</strong> and likely to change a lot in the near future. If you're interested in using it on your project, let us know and we can help you.</p>
   </div>
 
-  <p>When design systems are effectively employed, the benefits are exponential:</p>
+  <p>When design systems are effectively employed, the benefits are manifold:</p>
 
   <ul class="mzp-u-list-styled">
     <li>Improved User Experience: Scaled, consistent design patterns and content practices provide users with a familiar experience that allows for less time spent on re-learning interactions, finding pages that serve user needs, and abandoning pages that don’t.</li>

--- a/src/pages/index.hbs
+++ b/src/pages/index.hbs
@@ -6,9 +6,9 @@ order: 0
 
 <div class="mzp-c-article">
   <div class="mzp-c-article-intro">
-    <p>Protocol is a design system for Mozilla branded websites. It establishes a common design language, provides reusable coded components, and outlines high level guidelines for content and accessibility.</p>
+    <p>Protocol is a design system for Mozilla and Firefox websites. It establishes a common design language, provides reusable coded components, and outlines high level guidelines for content and accessibility.</p>
 
-    <p>Protocol is still in an <strong>early stage of development</strong> and likely to change a lot in the near future. If you're interested in using it on your project, let us know and we can help you.</p>
+    <p>Protocol is still in an <strong>early stage of development</strong> and likely to change a lot in the near future. If you’re interested in using Protocol on your project, let us know and we can help you. You can find us in #design-systems on Mozilla’s Slack (for Mozillians) or <a href="https://github.com/mozilla/protocol/issues">file an issue on GitHub</a>.</p>
   </div>
 
   <p>When design systems are effectively employed, the benefits are manifold:</p>
@@ -19,5 +19,5 @@ order: 0
     <li>Clarity: With clearly documented guidelines and governance for design and content creation, we spend less time negotiating the guidelines to create clarity for ourselves and more time creating designs and content that clearly serves our users.</li>
   </ul>
 
-  <p>This project was launched in the Spring of 2018 and is still very much a work in progress. <a href="https://github.com/mozilla/protocol">Follow along on Github</a>.</p>
+  <p><a href="https://github.com/mozilla/protocol">Follow along on GitHub</a>.</p>
 </div>


### PR DESCRIPTION
## Description

Adds a basic contributor guide, mostly with plain-English steps for getting the site installed.

This also adds a note to the front page and readme that clarified Protocol is under development and likely to change, lest someone come along and think it's "complete" when it clearly is missing a bunch of stuff and things are going to be changing soon.