### PR TITLE
Link text correctly in Typography Docs

### DIFF
--- a/src/pages/fundamentals/typography.hbs
+++ b/src/pages/fundamentals/typography.hbs
@@ -56,7 +56,7 @@ styles:
 
 <h3 id="typeface-sharp-sans">Firefox Sharp Sans</h3>
 <p>Sharp Sans is a closed license font licensed for use on some Firefox Marketing sites.</p>
-<p>Contact the websites team for more information on how to use this font with Protocol if you believe your use is covered by the license. If you can't find us in the phonebook you can [open an issue on the Protocol repo](https://github.com/mozilla/protocol/issues/new).</p>
+<p>Contact the websites team for more information on how to use this font with Protocol if you believe your use is covered by the license. If you can't find us in the phonebook you can <a href="https://github.com/mozilla/protocol/issues/new">open an issue on the Protocol repo</a>.</p>
 
 <h2 id="styles">Styles</h2>
 


### PR DESCRIPTION
Fixes #398 
