### PR TITLE
Remove "[bug]" from issue template title.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Report an error you've discovered
-title: "[bug]"
+title: ""
 labels: 'Bug :beetle:'
 assignees: ''
 


### PR DESCRIPTION
The bug tag is applied automatically, we don't need this info twice.
