### PR TITLE
Article max-width restricted to size of parent container (#422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+* **css:** Article max-width restricted to size of parent container (#422)
 * **css:** Increase contrast on sidebar mobile menu (#407)
 
 # 7.0.2

--- a/src/assets/sass/protocol/components/_article.scss
+++ b/src/assets/sass/protocol/components/_article.scss
@@ -5,7 +5,8 @@
 @import '../includes/lib';
 
 .mzp-c-article {
-    max-width: $content-md;
+    width: $content-md;
+    max-width: 100%;
 
     // Step down the heading levels
     h2 {


### PR DESCRIPTION
## Description

Article max-width restricted to size of parent container 

### Issue

Fix #422

### Testing

The original problem shows up when a `<pre>` tag is inside the article content.
