### PR TITLE
Details button gets cursor:pointer when hovered (#367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **css:** Details button gets cursor:pointer when hovered (#367)
 * **css:** Add Metropolis as Firefox brand font (#386)
 
 ## Bug Fixes

--- a/src/assets/sass/protocol/includes/mixins/_details.scss
+++ b/src/assets/sass/protocol/includes/mixins/_details.scss
@@ -8,6 +8,7 @@
     .is-summary {
         button {
             color: inherit;
+            cursor: pointer;
             background: transparent;
             font-family: inherit;
             font-weight: inherit;


### PR DESCRIPTION
## Description

Details button gets cursor:pointer when hovered

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #367

### Testing

Hover over the some buttons on the details page, see if the cursor updates. 
