### PR TITLE
Add notification bar component. (Fixes #383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **css:** Add Notification bar component (#383)
 * **css:** Details button gets cursor:pointer when hovered (#367)
 * **css:** Add Metropolis as Firefox brand font (#386)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,6 +186,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -3263,7 +3264,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3281,11 +3283,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3298,15 +3302,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3409,7 +3416,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3419,6 +3427,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3431,17 +3440,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3458,6 +3470,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3530,7 +3543,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3540,6 +3554,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3615,7 +3630,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3645,6 +3661,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3662,6 +3679,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3700,11 +3718,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -5983,7 +6003,8 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "optional": true
     },
     "longest-streak": {
       "version": "2.0.2",

--- a/src/assets/js/protocol/protocol-notification-bar.js
+++ b/src/assets/js/protocol/protocol-notification-bar.js
@@ -45,13 +45,13 @@ Mzp.Notification = (function() { // eslint-disable-line block-scoped-var
 
         // Notification Title
         if (options && options.title){
+
             var notificationTitle = document.createElement('p');
-            notificationTitle.className = 'mzp-c-notification-bar-content';
             notificationTitle.appendChild(title);
 
             // add title to notification
             notification.appendChild(notificationTitle);
-        }else{
+        } else {
             console.log('Notification banner requires title parameter.'); // eslint-disable-line no-console
         }
 
@@ -64,7 +64,7 @@ Mzp.Notification = (function() { // eslint-disable-line block-scoped-var
 
         // Show button & add event listener
         if (options && options.hasDismiss){
-            notificationFragment.childNodes[0].insertAdjacentHTML('beforeend', dismissButton);
+            notificationFragment.childNodes[0].insertAdjacentHTML('afterbegin', dismissButton);
 
             var button = notificationFragment.querySelector('.mzp-c-notification-bar-button');
 

--- a/src/assets/js/protocol/protocol-notification-bar.js
+++ b/src/assets/js/protocol/protocol-notification-bar.js
@@ -44,6 +44,7 @@ Mzp.Notification = (function() { // eslint-disable-line block-scoped-var
         notification.className = 'mzp-c-notification-bar ' + className + ' ' + isSticky;
 
         // Notification Title
+
         if (options && options.title){
 
             var notificationTitle = document.createElement('p');
@@ -51,8 +52,6 @@ Mzp.Notification = (function() { // eslint-disable-line block-scoped-var
 
             // add title to notification
             notification.appendChild(notificationTitle);
-        } else {
-            console.log('Notification banner requires title parameter.'); // eslint-disable-line no-console
         }
 
         // Notification Fragment

--- a/src/assets/js/protocol/protocol-notification-bar.js
+++ b/src/assets/js/protocol/protocol-notification-bar.js
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// create namespace
+if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
+    var Mzp = {};
+}
+
+Mzp.Notification = (function() { // eslint-disable-line block-scoped-var
+    'use strict';
+
+    var options = {};
+
+    /*
+    options: object of optional params:
+        title: title to display inside the notification.
+        className: optional CSS class name to apply to the notification.
+        closeText: 'string to use for close button a11y.
+        hasDismiss: boolean - include or not include dismiss button.
+        isSticky: boolean - determines if notification is absolutely positioned and sticky.
+    */
+
+    var _init = function(origin, opts) {
+        options = opts;
+
+        // Create new notification
+        var title = (options && options.title) ? options.title : '';
+        var className = (options && options.className) ? options.className : '';
+        var closeText = (options && options.closeText) ? options.closeText : '';
+        var isSticky = (options && options.isSticky) ? 'mzp-is-sticky' : '';
+
+        // Notification Fragment
+        var notificationFragment = document.createRange().createContextualFragment(
+            '<aside class="mzp-c-notification-bar ' + className + ' ' + isSticky + '">' +
+            '   <p class="mzp-c-notification-bar-content">' + title + '</p>' +
+            '</aside>'
+        );
+
+        // Dismiss Button
+        var dismissButton = '<button class="mzp-c-notification-bar-button" type="button">' + closeText + '</button>';
+
+        // Show button & add event listener
+        if (options && options.hasDismiss){
+            notificationFragment.childNodes[0].insertAdjacentHTML('beforeend', dismissButton);
+
+            var button = notificationFragment.querySelector('.mzp-c-notification-bar-button');
+
+            button.setAttribute('title', closeText);
+            button.addEventListener('click', function(e) {
+                _closeNotification(e);
+            });
+        }
+
+
+        // Add notification to page
+        document.body.insertBefore(notificationFragment, document.body.childNodes[0]);
+
+        // Remember which element opened the notification for later focus
+        origin.classList.add('mzp-c-notification-origin');
+
+
+        // Execute (optional) open callback
+        if (options && typeof(options.onCreate) === 'function') {
+            options.onCreate();
+        }
+    };
+
+    var _closeNotification = function(e) {
+
+        // remove notification from the page
+        e.currentTarget.parentNode.remove();
+
+        // execute (optional) callback
+        if (options && typeof(options.onDestroy) === 'function') {
+            options.onDestroy();
+        }
+
+        // free up options
+        options = {};
+
+        // restore focus to element that opened the notification
+        var origin = document.querySelector('.mzp-c-notification-origin');
+        origin.focus();
+        origin.classList.remove('mzp-c-notification-origin');
+    };
+
+    return {
+        init: function(origin, opts) {
+            _init(origin, opts);
+        }
+    };
+})(window);

--- a/src/assets/sass/protocol/components/_notification-bar.scss
+++ b/src/assets/sass/protocol/components/_notification-bar.scss
@@ -5,15 +5,46 @@
 @import "../includes/lib";
 
 .mzp-c-notification-bar {
-    @include text-display-xxs;
+    @include text-body-sm;
     background-color: $color-gray-20;
     border-radius: 4px;
     border: 1px;
     box-shadow: 1px 1px 1px rgba(27,31,35,.1);
     font-weight: normal;
     margin: $layout-xs auto 0;
-    max-width: $content-sm;
     text-align: center;
+    position: relative;
+    padding: 10px;
+
+    @media #{$mq-sm} {
+        display: inline-block;
+        padding: 0;
+        min-width: $content-sm;
+        max-width: $content-md;
+    }
+
+    p {
+        margin: 0 15px;
+        @media #{$mq-sm} {
+            float: left;
+            margin: 11px 15px;
+        }
+    }
+
+    a {
+        color: inherit;
+        font-size: inherit;
+        font-weight: 700;
+        margin: 11px 0;
+
+        &:hover {
+            text-decoration: none;
+        }
+
+        @media #{$mq-sm} {
+            float: left;
+        }
+    }
 
     &:after {
         content: "";
@@ -23,28 +54,27 @@
 
     &.mzp-is-sticky {
         left: 0;
-        margin-left: auto;
-        margin-right: auto;
+        margin: 15px 15px 0;
         position: fixed;
         right: 0;
         top: 0;
         z-index: 2;
-
-        .mzp-c-notification-bar-button {
-            width: 20px;
-
-            @media #{$mq-sm}{
-                width: 42px;
-            }
-        }
     }
 
     .mzp-c-notification-bar-button {
-        background: transparent url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+        @include image-replaced;
+        @include bidi((
+            (float, right, left),
+            (border-radius, 0 4px 4px 0, 4px 0 0 4px),
+            ));
+        background: url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
         border: none;
-        float: right;
         height: 20px;
-        padding: 10px;
+        width: 20px;
+        position: absolute;
+        top: 0;
+        right: 0;
+        margin: 5px;
 
         &:hover,
         &:focus {
@@ -52,41 +82,43 @@
         }
 
         @media #{$mq-sm} {
-            @include image-replaced;
-            @include bidi((
-                    (float, right, left),
-                    (border-radius, 0 4px 4px 0, 4px 0 0 4px),
-                ));
             background: $color-gray-40 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
-            border: none;
-            float: right;
-            height: 45px;
+            position: static;
             padding: 0;
-            width: 42px;
+            margin: 0;
+            height: 46px;
+            width: 40px;
+            float: right;
         }
     }
 
     &.mzp-t-success {
         background-color: $color-green-30;
 
-        .mzp-c-notification-bar-button {
-            background: $color-green-60 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+        @media #{$mq-sm} {
+            .mzp-c-notification-bar-button {
+                background: $color-green-60 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+            }
         }
     }
 
     &.mzp-t-error {
         background-color: $color-red-40;
 
-        .mzp-c-notification-bar-button {
-            background: $color-red-60 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+        @media #{$mq-sm} {
+            .mzp-c-notification-bar-button {
+                background: $color-red-60 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+            }
         }
     }
 
     &.mzp-t-warning {
         background-color: $color-yellow-20;
 
-        .mzp-c-notification-bar-button {
-            background: $color-yellow-40 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+        @media #{$mq-sm} {
+            .mzp-c-notification-bar-button {
+                background: $color-yellow-40 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+            }
         }
     }
 
@@ -95,18 +127,10 @@
         color: $color-white;
         font-weight: 600;
 
-        .mzp-c-notification-bar-button {
-            background: $color-blue-70 url("#{$image-path}/icons/ui/close-white.svg") center center no-repeat;
-        }
-    }
-
-    .mzp-c-notification-bar-content {
-        display: inline-block;
-        margin: 10px;
-        width: 80%;
-
         @media #{$mq-sm} {
-            margin-top: 15px;
+            .mzp-c-notification-bar-button {
+                background: $color-blue-70 url("#{$image-path}/icons/ui/close-white.svg") center center no-repeat;
+            }
         }
     }
 }

--- a/src/assets/sass/protocol/components/_notification-bar.scss
+++ b/src/assets/sass/protocol/components/_notification-bar.scss
@@ -10,45 +10,59 @@
     border-radius: 4px;
     border: 1px;
     box-shadow: 1px 1px 1px rgba(27,31,35,.1);
-    margin: $layout-xs auto 0;
-    height: 42px;
     font-weight: normal;
+    margin: $layout-xs auto 0;
     max-width: $content-sm;
     text-align: center;
 
+    &:after {
+        content: "";
+        display: block;
+        clear: both;
+    }
+
     &.mzp-is-sticky {
-        position: fixed;
-        top: 0;
-        z-index: 2;
+        left: 0;
         margin-left: auto;
         margin-right: auto;
-        left: 0;
+        position: fixed;
         right: 0;
+        top: 0;
+        z-index: 2;
+
+        .mzp-c-notification-bar-button {
+            width: 20px;
+
+            @media #{$mq-sm}{
+                width: 42px;
+            }
+        }
     }
 
     .mzp-c-notification-bar-button {
-        @include image-replaced;
-        @include bidi((
-                (float, right, left),
-                (border-radius, 0 4px 4px 0, 4px 0 0 4px),
-            ));
-        background: $color-gray-40
-            url("#{$image-path}/icons/ui/close-black.svg") center center
-            no-repeat;
+        background: transparent url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
         border: none;
-        display: block;
-        height: 42px;
-        min-width: 0;
-        padding: 0;
-        width: 42px;
+        float: right;
+        height: 20px;
+        padding: 10px;
 
         &:hover,
         &:focus {
             cursor: pointer;
         }
 
-        &:focus {
-            outline: 1px dotted $color-white;
+        @media #{$mq-sm} {
+            @include image-replaced;
+            @include bidi((
+                    (float, right, left),
+                    (border-radius, 0 4px 4px 0, 4px 0 0 4px),
+                ));
+            background: $color-gray-40 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+            border: none;
+            float: right;
+            height: 45px;
+            padding: 0;
+            width: 42px;
         }
     }
 
@@ -56,9 +70,7 @@
         background-color: $color-green-30;
 
         .mzp-c-notification-bar-button {
-            background: $color-green-60
-                url("#{$image-path}/icons/ui/close-black.svg") center center
-                no-repeat;
+            background: $color-green-60 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
         }
     }
 
@@ -66,9 +78,7 @@
         background-color: $color-red-40;
 
         .mzp-c-notification-bar-button {
-            background: $color-red-60
-                url("#{$image-path}/icons/ui/close-black.svg") center center
-                no-repeat;
+            background: $color-red-60 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
         }
     }
 
@@ -76,9 +86,7 @@
         background-color: $color-yellow-20;
 
         .mzp-c-notification-bar-button {
-            background: $color-yellow-40
-                url("#{$image-path}/icons/ui/close-black.svg") center center
-                no-repeat;
+            background: $color-yellow-40 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
         }
     }
 
@@ -88,14 +96,17 @@
         font-weight: 600;
 
         .mzp-c-notification-bar-button {
-            background: $color-blue-70
-                url("#{$image-path}/icons/ui/close-white.svg") center center
-                no-repeat;
+            background: $color-blue-70 url("#{$image-path}/icons/ui/close-white.svg") center center no-repeat;
         }
     }
 
     .mzp-c-notification-bar-content {
         display: inline-block;
-        margin-top: $spacing-lg/2;
+        margin: 10px;
+        width: 80%;
+
+        @media #{$mq-sm} {
+            margin-top: 15px;
+        }
     }
 }

--- a/src/assets/sass/protocol/components/_notification-bar.scss
+++ b/src/assets/sass/protocol/components/_notification-bar.scss
@@ -24,7 +24,7 @@
     }
 
     p {
-        display: block;
+        display: inline-block;
         margin: 0 15px;
 
         @media #{$mq-sm} {
@@ -34,6 +34,7 @@
 
     a {
         color: inherit;
+        display: inline-block;
         font-size: inherit;
         font-weight: 700;
 

--- a/src/assets/sass/protocol/components/_notification-bar.scss
+++ b/src/assets/sass/protocol/components/_notification-bar.scss
@@ -17,17 +17,18 @@
     padding: 10px;
 
     @media #{$mq-sm} {
-        display: inline-block;
         padding: 0;
         min-width: $content-sm;
         max-width: $content-md;
+        height: 46px;
     }
 
     p {
+        display: block;
         margin: 0 15px;
+
         @media #{$mq-sm} {
-            float: left;
-            margin: 11px 15px;
+            display: inline;
         }
     }
 
@@ -35,14 +36,9 @@
         color: inherit;
         font-size: inherit;
         font-weight: 700;
-        margin: 11px 0;
 
         &:hover {
             text-decoration: none;
-        }
-
-        @media #{$mq-sm} {
-            float: left;
         }
     }
 
@@ -54,26 +50,29 @@
 
     &.mzp-is-sticky {
         left: 0;
-        margin: 15px 15px 0;
+        margin: 15px;
         position: fixed;
         right: 0;
-        top: 0;
         z-index: 2;
+
+        @media #{$mq-sm} {
+            margin: 15px auto;
+        }
     }
 
     .mzp-c-notification-bar-button {
-        @include image-replaced;
         @include bidi((
-            (float, right, left),
-            (border-radius, 0 4px 4px 0, 4px 0 0 4px),
-            ));
+                    (right, 0, auto),
+                    (left, auto, 0),
+                ));
+
+        @include image-replaced;
         background: url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
         border: none;
         height: 20px;
         width: 20px;
         position: absolute;
         top: 0;
-        right: 0;
         margin: 5px;
 
         &:hover,
@@ -82,11 +81,15 @@
         }
 
         @media #{$mq-sm} {
+            @include bidi((
+                (float, right, left),
+                (border-radius, 0 4px 4px 0, 4px 0 0 4px),
+                ));
             background: $color-gray-40 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
             position: static;
             padding: 0;
             margin: 0;
-            height: 46px;
+            height: 100%;
             width: 40px;
             float: right;
         }

--- a/src/assets/sass/protocol/components/_notification-bar.scss
+++ b/src/assets/sass/protocol/components/_notification-bar.scss
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../includes/lib";
+
+.mzp-c-notification-bar {
+    @include text-display-xxs;
+    background-color: $color-gray-20;
+    border-radius: 4px;
+    border: 1px;
+    box-shadow: 1px 1px 1px rgba(27,31,35,.1);
+    margin: $layout-xs auto 0;
+    height: 42px;
+    font-weight: normal;
+    max-width: $content-sm;
+    text-align: center;
+
+    &.mzp-is-sticky {
+        position: fixed;
+        top: 0;
+        z-index: 2;
+        margin-left: auto;
+        margin-right: auto;
+        left: 0;
+        right: 0;
+    }
+
+    .mzp-c-notification-bar-button {
+        @include image-replaced;
+        @include bidi((
+                (float, right, left),
+                (border-radius, 0 4px 4px 0, 4px 0 0 4px),
+            ));
+        background: $color-gray-40
+            url("#{$image-path}/icons/ui/close-black.svg") center center
+            no-repeat;
+        border: none;
+        display: block;
+        height: 42px;
+        min-width: 0;
+        padding: 0;
+        width: 42px;
+
+        &:hover,
+        &:focus {
+            cursor: pointer;
+        }
+
+        &:focus {
+            outline: 1px dotted $color-white;
+        }
+    }
+
+    &.mzp-t-success {
+        background-color: $color-green-30;
+
+        .mzp-c-notification-bar-button {
+            background: $color-green-60
+                url("#{$image-path}/icons/ui/close-black.svg") center center
+                no-repeat;
+        }
+    }
+
+    &.mzp-t-error {
+        background-color: $color-red-40;
+
+        .mzp-c-notification-bar-button {
+            background: $color-red-60
+                url("#{$image-path}/icons/ui/close-black.svg") center center
+                no-repeat;
+        }
+    }
+
+    &.mzp-t-warning {
+        background-color: $color-yellow-20;
+
+        .mzp-c-notification-bar-button {
+            background: $color-yellow-40
+                url("#{$image-path}/icons/ui/close-black.svg") center center
+                no-repeat;
+        }
+    }
+
+    &.mzp-t-click {
+        background-color: $color-blue-50;
+        color: $color-white;
+        font-weight: 600;
+
+        .mzp-c-notification-bar-button {
+            background: $color-blue-70
+                url("#{$image-path}/icons/ui/close-white.svg") center center
+                no-repeat;
+        }
+    }
+
+    .mzp-c-notification-bar-content {
+        display: inline-block;
+        margin-top: $spacing-lg/2;
+    }
+}

--- a/src/assets/sass/protocol/components/_notification-bar.scss
+++ b/src/assets/sass/protocol/components/_notification-bar.scss
@@ -28,7 +28,7 @@
         margin: 0 15px;
 
         @media #{$mq-sm} {
-            display: inline;
+            line-height: 46px;
         }
     }
 

--- a/src/assets/sass/protocol/protocol-extra.scss
+++ b/src/assets/sass/protocol/protocol-extra.scss
@@ -17,5 +17,6 @@ $image-path: '../img' !default;
 @import '../protocol/components/newsletter-form';
 @import '../protocol/components/picto-card';
 @import '../protocol/components/sidebar-menu';
+@import '../protocol/components/notification-bar';
 @import '../protocol/templates/card-layout';
 @import '../protocol/templates/main-with-sidebar';

--- a/src/patterns/molecules/notification-bar/notification-bar.hbs
+++ b/src/patterns/molecules/notification-bar/notification-bar.hbs
@@ -2,19 +2,29 @@
 name: Notification bar
 description: A notification bar provides contextual feedback messages
 notes: |
-    - Notification bars have a range of different colors
+  A JS example to invoke a notification is provided below.
+
+  The notification JS provides the following options
+    - `origin` [DOM Element] element that triggered the notification
+    - `options` [Object] object of params
+        - `title` [String] message to display in the notification. (Required)
+        - `className` [String] optional CSS class name to apply to the notification.
+        - `onNotificationOpen` [Function] function to fire after notification has been opened.
+        - `onNotificationClose` [Function] function to fire after notification has been closed.
+        - `hasDismiss` [Boolean] include or not include dismiss button.
+        - `closeText` [String] text to use for close button a11y.
+        - `isSticky` [Boolean] determines if notification is absolutely positioned and sticky.
+
+  Inline JavaScript in this example is for demo purposes only. Use external files in production code.
+
+  Notification bars have a range of different colors.
     - `mzp-t-success`
     - `mzp-t-warning`
     - `mzp-t-error`
     - `mzp-t-click`
-    - An optional dismiss button
-    - `mzp-has-dismiss`
-    - And optional stickiness
-    - `mzp-is-sticky`
-order: 5
 ---
 
-<button class="mzp-c-button">Open Notification</button>
+<button class="mzp-c-button mzp-js-notification-trigger">Open Notification</button>
 
 <ul class="notification-demo-list">
   <li>
@@ -63,10 +73,10 @@ order: 5
     for (var i = 0; i < dissmissButtons.length; i++) {
       dissmissButtons[i].addEventListener('click', function(e) {
         e.currentTarget.parentNode.remove();
-      });
+      }, false);
     }
 
-    var notificationButton = document.querySelector('.mzp-c-button');
+    var notificationButton = document.querySelector('.mzp-js-notification-trigger');
 
     notificationButton.addEventListener('click', function (e) {
       e.preventDefault();
@@ -78,10 +88,10 @@ order: 5
         hasDismiss: true,
         isSticky: true,
 
-        onCreate: function () {
+        onNotificationOpen: function () {
           console.log('Notification opened');
         },
-        onDestroy: function () {
+        onNotificationClose: function () {
           console.log('Notification closed');
         }
       });

--- a/src/patterns/molecules/notification-bar/notification-bar.hbs
+++ b/src/patterns/molecules/notification-bar/notification-bar.hbs
@@ -29,36 +29,37 @@ notes: |
 <ul class="notification-demo-list">
   <li>
     <aside class="mzp-c-notification-bar mzp-t-success">
-      <p class="mzp-c-notification-bar-content">Great! You clicked the thing!</p>
       <button class="mzp-c-notification-bar-button" type="button"></button>
+      <p>Great! You clicked the thing!</p>
     </aside>
   </li>
 
   <li>
     <aside class="mzp-c-notification-bar mzp-t-warning">
-      <p class="mzp-c-notification-bar-content">Warning, you're about to do something bad!</p>
       <button class="mzp-c-notification-bar-button" type="button"></button>
+      <p>Warning, you're about to do something bad!</p>
     </aside>
   </li>
 
   <li>
     <aside class="mzp-c-notification-bar mzp-t-error">
-      <p class="mzp-c-notification-bar-content">Whoops. You deleted something.</p>
       <button class="mzp-c-notification-bar-button" type="button"></button>
+      <p>Whoops. You deleted something.</p>
+      <a href="#" class="mzp-c-notification-bar-cta">Undo this action?</a>
     </aside>
   </li>
 
   <li>
     <aside class="mzp-c-notification-bar mzp-t-click">
-      <p class="mzp-c-notification-bar-content">Click this thing.</p>
       <button class="mzp-c-notification-bar-button" type="button"></button>
+      <p>Click this thing.</p>
     </aside>
   </li>
 
   <li>
     <aside class="mzp-c-notification-bar">
-      <p class="mzp-c-notification-bar-content">Default.</p>
       <button class="mzp-c-notification-bar-button" type="button"></button>
+      <p>Default.</p>
     </aside>
   </li>
 </ul>

--- a/src/patterns/molecules/notification-bar/notification-bar.hbs
+++ b/src/patterns/molecules/notification-bar/notification-bar.hbs
@@ -1,0 +1,90 @@
+---
+name: Notification bar
+description: A notification bar provides contextual feedback messages
+notes: |
+    - Notification bars have a range of different colors
+    - `mzp-t-success`
+    - `mzp-t-warning`
+    - `mzp-t-error`
+    - `mzp-t-click`
+    - An optional dismiss button
+    - `mzp-has-dismiss`
+    - And optional stickiness
+    - `mzp-is-sticky`
+order: 5
+---
+
+<button class="mzp-c-button">Open Notification</button>
+
+<ul class="notification-demo-list">
+  <li>
+    <aside class="mzp-c-notification-bar mzp-t-success">
+      <p class="mzp-c-notification-bar-content">Great! You clicked the thing!</p>
+      <button class="mzp-c-notification-bar-button" type="button"></button>
+    </aside>
+  </li>
+
+  <li>
+    <aside class="mzp-c-notification-bar mzp-t-warning">
+      <p class="mzp-c-notification-bar-content">Warning, you're about to do something bad!</p>
+      <button class="mzp-c-notification-bar-button" type="button"></button>
+    </aside>
+  </li>
+
+  <li>
+    <aside class="mzp-c-notification-bar mzp-t-error">
+      <p class="mzp-c-notification-bar-content">Whoops. You deleted something.</p>
+      <button class="mzp-c-notification-bar-button" type="button"></button>
+    </aside>
+  </li>
+
+  <li>
+    <aside class="mzp-c-notification-bar mzp-t-click">
+      <p class="mzp-c-notification-bar-content">Click this thing.</p>
+      <button class="mzp-c-notification-bar-button" type="button"></button>
+    </aside>
+  </li>
+
+  <li>
+    <aside class="mzp-c-notification-bar">
+      <p class="mzp-c-notification-bar-content">Default.</p>
+      <button class="mzp-c-notification-bar-button" type="button"></button>
+    </aside>
+  </li>
+</ul>
+
+<script src="{{@root.baseurl}}/assets/protocol/protocol/js/protocol-notification-bar.js"></script>
+
+<script>
+  (function () {
+    'use strict';
+
+    var dissmissButtons = document.querySelectorAll('.mzp-c-notification-bar-button');
+    for (var i = 0; i < dissmissButtons.length; i++) {
+      dissmissButtons[i].addEventListener('click', function(e) {
+        e.currentTarget.parentNode.remove();
+      });
+    }
+
+    var notificationButton = document.querySelector('.mzp-c-button');
+
+    notificationButton.addEventListener('click', function (e) {
+      e.preventDefault();
+
+      Mzp.Notification.init(e.target, {
+        title: 'This is the title',
+        className: 'mzp-t-warning',
+        closeText: 'Close notification',
+        hasDismiss: true,
+        isSticky: true,
+
+        onCreate: function () {
+          console.log('Notification opened');
+        },
+        onDestroy: function () {
+          console.log('Notification closed');
+        }
+      });
+    }, false);
+  })();
+</script>

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -27,11 +27,13 @@ module.exports = function(config) {
             '../dist/assets/protocol/protocol/js/protocol-lang-switcher.js',
             '../dist/assets/protocol/protocol/js/protocol-menu.js',
             '../dist/assets/protocol/protocol/js/protocol-navigation.js',
+            '../dist/assets/protocol/protocol/js/protocol-notification-bar.js',
             // tests
             'unit/protocol-details.js',
             'unit/protocol-lang-switcher.js',
             'unit/protocol-menu.js',
-            'unit/protocol-navigation.js'
+            'unit/protocol-navigation.js',
+            'unit/protocol-notification-bar.js'
         ],
 
 

--- a/tests/unit/protocol-notification-bar.js
+++ b/tests/unit/protocol-notification-bar.js
@@ -1,0 +1,54 @@
+/* global describe, beforeEach, it, spyOn */
+
+describe('protocol-notification.js', function() {
+
+    'use strict';
+
+    beforeEach(function () {
+        var details =
+            '<button class="mzp-c-button">Open Notification</button>';
+
+        document.documentElement.insertAdjacentHTML('afterbegin', details);
+    });
+
+    describe('interactions', function () {
+
+        var options = {
+            open: function () {}, // eslint-disable-line no-empty-function
+            close: function () {} // eslint-disable-line no-empty-function
+        };
+
+        beforeEach(function () {
+            spyOn(options, 'open');
+            spyOn(options, 'close');
+
+            var button = document.querySelector('.mzp-c-button');
+
+            button.addEventListener('click', function (e) {
+                e.preventDefault();
+
+                Mzp.Notification.init(button, {
+                    hasDismiss: true,
+                    onCreate: options.open,
+                    onDestroy: options.close
+                });
+            });
+        });
+
+        it('opens as expected', function() {
+            var button = document.querySelector('.mzp-c-button');
+            button.click();
+            expect(options.open).toHaveBeenCalled();
+        });
+
+        it('closes as expected', function() {
+            var button = document.querySelector('.mzp-c-button');
+            button.click();
+
+            var dismissButton = document.querySelector('.mzp-c-notification-bar-button');
+            dismissButton.click();
+            expect(options.close).toHaveBeenCalled();
+        });
+
+    });
+});

--- a/tests/unit/protocol-notification-bar.js
+++ b/tests/unit/protocol-notification-bar.js
@@ -39,6 +39,9 @@ describe('protocol-notification.js', function() {
             var button = document.querySelector('.mzp-c-button');
             button.click();
             expect(options.open).toHaveBeenCalled();
+
+            var notification = document.querySelector('.mzp-c-notification-bar');
+            expect(notification).toBeTruthy();
         });
 
         it('closes as expected', function() {
@@ -48,6 +51,9 @@ describe('protocol-notification.js', function() {
             var dismissButton = document.querySelector('.mzp-c-notification-bar-button');
             dismissButton.click();
             expect(options.close).toHaveBeenCalled();
+
+            var notification = document.querySelector('.mzp-c-notification-bar');
+            expect(notification).toBeFalsy();
         });
 
     });

--- a/tests/unit/protocol-notification-bar.js
+++ b/tests/unit/protocol-notification-bar.js
@@ -33,11 +33,11 @@ describe('protocol-notification.js', function() {
                     onNotificationClose: options.close
                 });
             });
+
+            button.click();
         });
 
         it('opens as expected', function() {
-            var button = document.querySelector('.mzp-c-button');
-            button.click();
             expect(options.open).toHaveBeenCalled();
 
             var notification = document.querySelector('.mzp-c-notification-bar');
@@ -45,15 +45,12 @@ describe('protocol-notification.js', function() {
         });
 
         it('closes as expected', function() {
-            var button = document.querySelector('.mzp-c-button');
-            button.click();
-
             var dismissButton = document.querySelector('.mzp-c-notification-bar-button');
             dismissButton.click();
             expect(options.close).toHaveBeenCalled();
 
             var notification = document.querySelector('.mzp-c-notification-bar');
-            expect(notification).toBeFalsy();
+            expect(notification).toEqual(null);
         });
 
     });

--- a/tests/unit/protocol-notification-bar.js
+++ b/tests/unit/protocol-notification-bar.js
@@ -29,8 +29,8 @@ describe('protocol-notification.js', function() {
 
                 Mzp.Notification.init(button, {
                     hasDismiss: true,
-                    onCreate: options.open,
-                    onDestroy: options.close
+                    onNotificationOpen: options.open,
+                    onNotificationClose: options.close
                 });
             });
         });

--- a/tests/unit/protocol-notification-bar.js
+++ b/tests/unit/protocol-notification-bar.js
@@ -37,6 +37,13 @@ describe('protocol-notification.js', function() {
             button.click();
         });
 
+        afterEach(function(){
+            var node = document.querySelector('.mzp-c-notification-bar');
+            if (node) {
+                node.parentNode.removeChild(node);
+            }
+        });
+
         it('opens as expected', function() {
             expect(options.open).toHaveBeenCalled();
 

--- a/tests/unit/protocol-notification-bar.js
+++ b/tests/unit/protocol-notification-bar.js
@@ -11,6 +11,13 @@ describe('protocol-notification.js', function() {
         document.documentElement.insertAdjacentHTML('afterbegin', details);
     });
 
+    afterEach(function(){
+        var node = document.querySelector('.mzp-c-button');
+        if (node) {
+            node.parentNode.removeChild(node);
+        }
+    });
+
     describe('interactions', function () {
 
         var options = {


### PR DESCRIPTION
## Description

Adds the notification bar component used on /thanks and /whatsnew

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#383
https://github.com/mozilla/bedrock/issues/7468

### Testing
https://demo2--mozilla-protocol.netlify.com/patterns/molecules/notification-bar.html

- Supports different styles:
  - Success
  - Warning
  - Error
  - Click

- Dismiss is optional.

