### PR TITLE
Remove double underline from CTA links in dark theme (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * **css:** Article max-width restricted to size of parent container (#422)
 * **css:** Increase contrast on sidebar mobile menu (#407)
+* **css:** Remove double underline from CTA links in dark theme (#374)
 
 # 7.0.2
 

--- a/src/assets/sass/protocol/base/elements/_links.scss
+++ b/src/assets/sass/protocol/base/elements/_links.scss
@@ -50,6 +50,7 @@
         &:link,
         &:visited {
             color: $color-white;
+            text-decoration: none;
         }
     }
 }


### PR DESCRIPTION
## Description

Remove double underline from CTA links in dark theme

- [X] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #374

### Testing

See it in action on the Feature Card demo page: http://localhost:3000/demos/feature-card.html
