### PR TITLE
Separate newsletter form and newsletter layout styling (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD
 
 * **css:** Fx theme CTAs should use the Metropolis Font (#468)
+* **css:** Separate newsletter form and newsletter layout styling (#444)
 
 # 8.0.0
 

--- a/src/assets/sass/protocol/components/_newsletter-form.scss
+++ b/src/assets/sass/protocol/components/_newsletter-form.scss
@@ -4,10 +4,8 @@
 
 @import '../includes/lib';
 
-.mzp-c-newsletter {
-    margin: 0 auto $spacing-lg;
-    max-width: $content-sm;
-    padding: $spacing-lg 0;
+/* form */
+.mzp-c-newsletter-form {
 
     input[type='email'],
     select {
@@ -23,24 +21,9 @@
         width: 100%;
     }
 
-    // Hide errors and thank you message
-    .mzp-c-form-errors,
-    .mzp-c-newsletter-thanks {
+    // Hide errors
+    .mzp-c-form-errors {
         @include hidden;
-    }
-
-    @media #{$mq-md} {
-        @include clearfix;
-        padding: $spacing-lg;
-        max-width: none;
-    }
-
-    @media #{$mq-lg} {
-        padding: $layout-md $layout-xl;
-    }
-
-    @media #{$mq-xl} {
-        padding: $layout-md $layout-2xl;
     }
 }
 
@@ -54,57 +37,88 @@
     text-align: center;
 }
 
-@media #{$mq-md} {
-    .mzp-c-newsletter-image {
-        @include grid-half;
-        float: left;
-    }
 
-    .mzp-c-newsletter-form,
-    .mzp-c-newsletter-thanks {
-        @include grid-half;
-        float: right;
-        padding-top: $layout-md;
-    }
-
-    @supports (display: grid) {
-        .mzp-c-newsletter {
-            @include grid-column-gap($spacing-xl);
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-
-            &:after { // Remove the clearfix
-                display: none;
-            }
-        }
-
-        .mzp-c-newsletter-image,
-        .mzp-c-newsletter-form,
-        .mzp-c-newsletter-thanks {
-            width: auto;
-            float: none;
-        }
-
-        .mzp-c-newsletter-image {
-            grid-column: 1;
-        }
-
-        .mzp-c-newsletter-form,
-        .mzp-c-newsletter-thanks {
-            grid-column: 2;
-        }
-    }
+/* thanks */
+// Hide thank you message
+.mzp-c-newsletter-thanks {
+    @include hidden;
 }
 
-@media #{$mq-lg} {
-    .mzp-c-newsletter-form,
-    .mzp-c-newsletter-thanks {
-        padding-top: $layout-lg;
-    }
-}
 
 // hide details for JS users
 // (displayed when email field is focused)
 .js .mzp-c-newsletter-details {
     @include hidden;
+}
+
+/* form wrapper with image */
+.mzp-c-newsletter {
+    margin: 0 auto $spacing-lg;
+    max-width: $content-sm;
+    padding: $spacing-lg 0;
+
+    @media #{$mq-md} {
+        & {
+            @include clearfix;
+            padding: $spacing-lg;
+            max-width: none;
+        }
+
+        .mzp-c-newsletter-image {
+            @include grid-half;
+            float: left;
+        }
+
+        .mzp-c-newsletter-form,
+        .mzp-c-newsletter-thanks {
+            @include grid-half;
+            float: right;
+            padding-top: $layout-md;
+        }
+
+        @supports (display: grid) {
+            & {
+                @include grid-column-gap($spacing-xl);
+                display: grid;
+                grid-template-columns: repeat(2, 1fr);
+
+                &:after { // Remove the clearfix
+                    display: none;
+                }
+            }
+
+            .mzp-c-newsletter-image,
+            .mzp-c-newsletter-form,
+            .mzp-c-newsletter-thanks {
+                width: auto;
+                float: none;
+            }
+
+            .mzp-c-newsletter-image {
+                grid-column: 1;
+            }
+
+            .mzp-c-newsletter-form,
+            .mzp-c-newsletter-thanks {
+                grid-column: 2;
+            }
+        }
+    }
+
+    @media #{$mq-lg} {
+        & {
+            padding: $layout-md $layout-xl;
+        }
+
+        .mzp-c-newsletter-form,
+        .mzp-c-newsletter-thanks {
+            padding-top: $layout-lg;
+        }
+    }
+
+    @media #{$mq-xl} {
+        & {
+            padding: $layout-md $layout-2xl;
+        }
+    }
 }


### PR DESCRIPTION
## Description

We should be able to embed the newsletter form in places where we don't want an image next to it. So, I have separated the form formatting from the layout when used with an image.

- edited form styles to work when not nested under .mzp-c-newsletter
- moved all two column/grid styles to only apply when nested under .mzp-c-newsletter

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #444

### Testing

- Display should be identical before and after changes.
- Form should still format properly when not nested under .mzp-c-newsletter (ie, elements should have proper spacing, errors and details should be hidden)
