### PR TITLE
Firefox theme CTAs should use the Metropolis Font (#468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* **css:** Fx theme CTAs should use the Metropolis Font (#468)
+
 # 8.0.0
 
 ## Features

--- a/src/assets/sass/protocol/base/elements/_links.scss
+++ b/src/assets/sass/protocol/base/elements/_links.scss
@@ -46,6 +46,10 @@
         border-bottom-color: transparent;
     }
 
+    .mzp-t-firefox & {
+        @include font-firefox;
+    }
+
     .mzp-t-dark & {
         &:link,
         &:visited {

--- a/src/assets/sass/protocol/components/_button.scss
+++ b/src/assets/sass/protocol/components/_button.scss
@@ -35,6 +35,10 @@ a.mzp-c-button {
         border-color: $color-gray-30;
         pointer-events: none;
     }
+
+    .mzp-t-firefox & {
+        @include font-firefox;
+    }
 }
 
 .mzp-c-button.mzp-t-small {

--- a/src/pages/fundamentals/themes.hbs
+++ b/src/pages/fundamentals/themes.hbs
@@ -14,6 +14,11 @@ order: 2
 
 <div class="mzp-t-firefox">
 <h2>Firefox</h2>
-<p>The <code>.mzp-t-firefox</code> class can be applied to the page body and to some organisms to change the text color to <code>$color-off-black</code> and use Metropolis for the display font.</p>
+<p>The <code>.mzp-t-firefox</code> class can be applied to the page body and to some organisms. It will:</p>
+<ul>
+  <li>Change the text color to <code>$color-off-black</code>.</li>
+  <li>Use Metropolis for the display font.</li>
+  <li>Use Metropolis for calls to action.</li>
+</ul>
 <p>You can declare Metropolis as the display font explicitly in the CSS using <code>@include font-firefox;</code>
 </div>


### PR DESCRIPTION
## Description

Change font to Metropolis when cta-links and buttons are under `.mzp-t-firefox`

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #468

### Testing

- Firefox themed cta-links can be found on: http://localhost:3000/demos/feature-card.html
- For the buttons I just added the theme class using dev tools.
