### PR TITLE
Update @mozilla-protocol/assets to 2.1.1 (#479)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* **assets:** (breaking) Update @mozilla-protocol/assets to 2.1.1 (#479)
+
 ## 8.1.0
 
 * **docs:** Added component issue templates (#379)

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,9 +74,9 @@
       }
     },
     "@mozilla-protocol/assets": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/assets/-/assets-1.0.1.tgz",
-      "integrity": "sha512-DqaPHtx42e0U7ThnJ+cFmMYhJatR8aNmsZyd+7I5ERokzqOT4p6QGZS5+ItoO5splStL507SjPq4piVMfT7iWQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/assets/-/assets-2.1.1.tgz",
+      "integrity": "sha512-ja+EQdMpVRaGW9aRLy84DgU6L/9sYGhFMPkXPuaA7OHFUS+bIDeziG0QJFDf6arNHR5iYXr2bIpujzG6X5FuTA=="
     },
     "@mozilla-protocol/eslint-config": {
       "version": "1.1.0",
@@ -7980,7 +7980,7 @@
     },
     "opn": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@cloudfour/hbs-helpers": "^0.9.0",
-    "@mozilla-protocol/assets": "^1.0.1",
+    "@mozilla-protocol/assets": "^2.1.1",
     "@mozilla-protocol/tokens": "^3.0.0",
     "del": "^3.0.0",
     "drizzle-builder": "0.0.10",

--- a/src/assets/sass/protocol/components/_card.scss
+++ b/src/assets/sass/protocol/components/_card.scss
@@ -64,11 +64,11 @@
     }
 
     &.mzp-has-video .mzp-c-card-tag {
-        background-image: url('#{$image-path}/icons/ui/video.svg');
+        background-image: url('#{$image-path}/icons/video-card.svg');
     }
 
     &.mzp-has-audio .mzp-c-card-tag {
-        background-image: url('#{$image-path}/icons/ui/audio.svg');
+        background-image: url('#{$image-path}/icons/audio-card.svg');
     }
 
     .mzp-c-card-title {

--- a/src/assets/sass/protocol/components/_menu.scss
+++ b/src/assets/sass/protocol/components/_menu.scss
@@ -72,15 +72,15 @@
 
         &:before {
             background:  $url-image-expand-black top left no-repeat;
-            @include background-size(16px, 16px);
+            @include background-size(20px, 20px);
             @include bidi(((right, 8px, left, auto),));
             @include transition(transform 100ms ease-in-out);
             content: '';
-            height: 16px;
+            height: 20px;
             margin-top: -8px;
             position: absolute;
             top: 50%;
-            width: 16px;
+            width: 20px;
         }
     }
 
@@ -209,7 +209,7 @@
     .mzp-c-menu-button-close {
         @include image-replaced;
         @include transition(transform 100ms ease-in-out);
-        background: transparent url('#{$image-path}/icons/ui/close-black.svg') center center no-repeat;
+        background: transparent url('#{$image-path}/icons/close.svg') center center no-repeat;
         border: none;
         cursor: pointer;
         display: none;

--- a/src/assets/sass/protocol/components/_modal.scss
+++ b/src/assets/sass/protocol/components/_modal.scss
@@ -80,7 +80,7 @@ html.mzp-is-noscroll {
 
     .mzp-c-modal-button-close {
         @include image-replaced;
-        background: transparent url('#{$image-path}/icons/ui/close-white.svg') center center no-repeat;
+        background: transparent url('#{$image-path}/icons/close-white.svg') center center no-repeat;
         @include background-size(16px 16px);
         border: none;
         height: 42px;

--- a/src/assets/sass/protocol/components/_navigation.scss
+++ b/src/assets/sass/protocol/components/_navigation.scss
@@ -154,7 +154,7 @@
     @include bidi(((float, right, left),));
     @include bidi(((padding, 0 32px 0 6px, 0 6px 0 32px),));
     background-color: transparent;
-    background-image: url('#{$image-path}/icons/ui/menu-black.svg');
+    background-image: url('#{$image-path}/icons/menu.svg');
     background-repeat: no-repeat;
     border-radius: 4px;
     border: none;

--- a/src/assets/sass/protocol/components/_notification-bar.scss
+++ b/src/assets/sass/protocol/components/_notification-bar.scss
@@ -68,7 +68,8 @@
                 ));
 
         @include image-replaced;
-        background: url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+        background: url("#{$image-path}/icons/close.svg") center center no-repeat;
+        background-size: 20px 20px;
         border: none;
         height: 20px;
         width: 20px;
@@ -86,7 +87,7 @@
                 (float, right, left),
                 (border-radius, 0 4px 4px 0, 4px 0 0 4px),
                 ));
-            background: $color-gray-40 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+            background-color: $color-gray-40;
             position: static;
             padding: 0;
             margin: 0;
@@ -101,7 +102,7 @@
 
         @media #{$mq-sm} {
             .mzp-c-notification-bar-button {
-                background: $color-green-60 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+                background-color: $color-green-60;
             }
         }
     }
@@ -111,7 +112,7 @@
 
         @media #{$mq-sm} {
             .mzp-c-notification-bar-button {
-                background: $color-red-60 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+                background-color: $color-red-60;
             }
         }
     }
@@ -121,7 +122,7 @@
 
         @media #{$mq-sm} {
             .mzp-c-notification-bar-button {
-                background: $color-yellow-40 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+                background-color: $color-yellow-40;
             }
         }
     }
@@ -131,9 +132,11 @@
         color: $color-white;
         font-weight: 600;
 
-        @media #{$mq-sm} {
-            .mzp-c-notification-bar-button {
-                background: $color-blue-70 url("#{$image-path}/icons/ui/close-white.svg") center center no-repeat;
+        .mzp-c-notification-bar-button {
+            background-image: url("#{$image-path}/icons/close-white.svg");
+
+            @media #{$mq-sm} {
+                background-color: $color-blue-70;
             }
         }
     }

--- a/src/assets/sass/protocol/includes/mixins/_details.scss
+++ b/src/assets/sass/protocol/includes/mixins/_details.scss
@@ -31,15 +31,15 @@
 
     &:before {
         background: $url-image-expand-black top left no-repeat;
-        @include background-size(16px, 16px);
+        @include background-size(20px, 20px);
         @include bidi(((right, 8px, left, auto),));
         @include transition(transform 100ms ease-in-out);
         content: '';
-        height: 16px;
+        height: 20px;
         margin-top: -8px;
         position: absolute;
         top: 50%;
-        width: 16px;
+        width: 20px;
     }
 }
 

--- a/src/assets/sass/protocol/includes/mixins/_images.scss
+++ b/src/assets/sass/protocol/includes/mixins/_images.scss
@@ -73,10 +73,10 @@
 // images
 
 // SVGs - xmlns attribute must be first
-// https://github.com/mozilla/protocol-assets/blob/master/icons/ui/expand-white.svg
-$svg-expand-white: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M7 7V1a1 1 0 1 1 2 0v6h6a1 1 0 1 1 0 2H9v6a1 1 0 1 1-2 0V9H1a1 1 0 1 1 0-2h6z" fill="#fff" fill-rule="evenodd"/></svg>';
-// https://github.com/mozilla/protocol-assets/blob/master/icons/ui/expand-black.svg
-$svg-expand-black: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M7 7V1a1 1 0 1 1 2 0v6h6a1 1 0 1 1 0 2H9v6a1 1 0 1 1-2 0V9H1a1 1 0 1 1 0-2h6z" fill="#000" fill-rule="evenodd"/></svg>';
+// https://github.com/mozilla/protocol-assets/blob/master/icons/expand-white.svg
+$svg-expand-white: '<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="#FFF" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"><path d="M12 3.515v16.97M3.515 12h16.97"/></g></svg>';
+// https://github.com/mozilla/protocol-assets/blob/master/icons/expand.svg
+$svg-expand-black: '<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"><path d="M12 3.515v16.97M3.515 12h16.97"/></g></svg>';
 $svg-arrow-down-link: '<svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"><polyline stroke="#0060df" stroke-width="2" points="5 9 12 16 19 9"></polyline></g></svg>';
 $svg-arrow-down-link-hover: '<svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"><polyline stroke="#0250bb" stroke-width="2" points="5 9 12 16 19 9"></polyline></g></svg>';
 $svg-download-link-hover: '<svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round"><g transform="translate(6.000000, 3.000000)" stroke="#0250bb" stroke-width="2"><path d="M0,18 L12,18"></path><polyline stroke-linejoin="round" points="0 8 6 14 12 8"></polyline><path d="M6,0 L6,14"></path></g></g></svg>';


### PR DESCRIPTION
## Description

Describe what this change does.

- ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #479

### Testing

- All icons that were inside the `ui` folder have been moved
- Background-size declarations have been added to places icons are used (new icon files are larger)
- Black icons no longer have `-black` in the file name.