### PR TITLE
Bump version to 8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## HEAD
+## 8.1.0
 
 * **docs:** Added component issue templates (#379)
 * **css:** Bold menu titles (#481)
 * **css:** Add Menu List component (#474)
+* **css:** Added Emphasis box (#385)
 * **css:** Fx theme CTAs should use the Metropolis Font (#468)
 * **css:** Separate newsletter form and newsletter layout styling (#444)
 * **css:** Add inline list component (#465)
@@ -13,7 +14,6 @@
 
 * **css:** Adds a narrow content channel (#469)
 * **css:** Add Notification bar component (#383)
-* **css:** Added Emphasis box (#385)
 * **css:** Details button gets cursor:pointer when hovered (#367)
 * **css:** (breaking) Add Metropolis as Firefox brand font (#386)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": true,
   "author": "Mozilla",
   "description": "A design system for Mozilla's websites.",

--- a/src/assets/package/README.md
+++ b/src/assets/package/README.md
@@ -20,7 +20,7 @@ Install package with NPM and add it to your dependencies:
 </tr>
 <tr>
 <td>Version</td>
-<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">8.0.0</a></td>
+<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">8.1.0</a></td>
 </tr>
 </table>
 

--- a/src/assets/package/package.json
+++ b/src/assets/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/core",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "A design system for Mozilla's websites.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Bumps version to 8.1.0 for publishing to NPM

- [ ] ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

N/A

### Testing

I'm following the steps here: https://github.com/mozilla/protocol/tree/master/docs#publishing-to-npm
