### PR TITLE
Update @mozilla-protocol/assets to 3.0.0 (#479)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## HEAD
+
+* **assets:** (breaking) Update @mozilla-protocol/assets to 3.0.0 (#479)
+
+### Migration Tips
+  * Browser logo is for Firefox 70+
+  * Browser logos have new names and directories
+    * e.g. `logos/firefox/firefox.png` → `logos/firefox/browser/logo-lg.png`
+    * Logos are also slightly larger, check height & width are declared
+  * UI icons have moved up a directory `/icons/ui/` → `/icons/`
+  * Remove `-black` from file names for black icons
+  * Focus theme has been removed
+
 ## 8.1.0
 
 * **docs:** Added component issue templates (#379)

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,9 +74,9 @@
       }
     },
     "@mozilla-protocol/assets": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/assets/-/assets-1.0.1.tgz",
-      "integrity": "sha512-DqaPHtx42e0U7ThnJ+cFmMYhJatR8aNmsZyd+7I5ERokzqOT4p6QGZS5+ItoO5splStL507SjPq4piVMfT7iWQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/assets/-/assets-3.0.0.tgz",
+      "integrity": "sha512-AaL0O04gFHdrbLoJ0hq4GhDo0DWVIL9KdbL/V5TSc+MgeyujMLfpcab+Byh621FptiwblrtK7h8KX/I9PoYVOw=="
     },
     "@mozilla-protocol/eslint-config": {
       "version": "1.1.0",
@@ -7980,7 +7980,7 @@
     },
     "opn": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@cloudfour/hbs-helpers": "^0.9.0",
-    "@mozilla-protocol/assets": "^1.0.1",
+    "@mozilla-protocol/assets": "^3.0.0",
     "@mozilla-protocol/tokens": "^3.0.0",
     "del": "^3.0.0",
     "drizzle-builder": "0.0.10",

--- a/src/assets/sass/protocol/components/_call-out.scss
+++ b/src/assets/sass/protocol/components/_call-out.scss
@@ -36,8 +36,7 @@
     &.mzp-t-product-firefox,
     &.mzp-t-product-beta,
     &.mzp-t-product-developer,
-    &.mzp-t-product-nightly,
-    &.mzp-t-product-focus {
+    &.mzp-t-product-nightly {
         .mzp-c-call-out-title {
             @include background-size(64px 64px);
             background-position: top center;
@@ -47,23 +46,19 @@
     }
 
     &.mzp-t-product-firefox .mzp-c-call-out-title {
-        @include at2x('#{$image-path}/logos/firefox/firefox.png', 64px, 64px);
+        @include at2x('#{$image-path}/logos/firefox/browser/logo-lg.png', 64px, 64px);
     }
 
     &.mzp-t-product-beta .mzp-c-call-out-title {
-        @include at2x('#{$image-path}/logos/firefox/beta.png', 64px, 64px);
+        @include at2x('#{$image-path}/logos/firefox/browser/beta/logo-lg.png', 64px, 64px);
     }
 
     &.mzp-t-product-developer .mzp-c-call-out-title {
-        @include at2x('#{$image-path}/logos/firefox/developer.png', 64px, 64px);
+        @include at2x('#{$image-path}/logos/firefox/browser/developer/logo-lg.png', 64px, 64px);
     }
 
     &.mzp-t-product-nightly .mzp-c-call-out-title {
-        @include at2x('#{$image-path}/logos/firefox/nightly.png', 64px, 64px);
-    }
-
-    &.mzp-t-product-focus .mzp-c-call-out-title {
-        @include at2x('#{$image-path}/logos/firefox/focus.png', 64px, 64px);
+        @include at2x('#{$image-path}/logos/firefox/browser/nightly/logo-lg.png', 64px, 64px);
     }
 
     @media #{$mq-md} {
@@ -111,8 +106,7 @@
     &.mzp-t-product-firefox ,
     &.mzp-t-product-beta,
     &.mzp-t-product-developer,
-    &.mzp-t-product-nightly,
-    &.mzp-t-product-focus {
+    &.mzp-t-product-nightly {
         .mzp-c-call-out-content {
             @include border-box;
             @include background-size(64px 64px);
@@ -123,23 +117,19 @@
     }
 
     &.mzp-t-product-firefox .mzp-c-call-out-content {
-        @include at2x('#{$image-path}/logos/firefox/firefox.png', 64px, 64px);
+        @include at2x('#{$image-path}/logos/firefox/browser/logo-lg.png', 64px, 64px);
     }
 
     &.mzp-t-product-beta .mzp-c-call-out-content {
-        @include at2x('#{$image-path}/logos/firefox/beta.png', 64px, 64px);
+        @include at2x('#{$image-path}/logos/firefox/browser/beta/logo-lg.png', 64px, 64px);
     }
 
     &.mzp-t-product-developer .mzp-c-call-out-content {
-        @include at2x('#{$image-path}/logos/firefox/developer.png', 64px, 64px);
+        @include at2x('#{$image-path}/logos/firefox/browser/developer/logo-lg.png', 64px, 64px);
     }
 
     &.mzp-t-product-nightly .mzp-c-call-out-content {
-        @include at2x('#{$image-path}/logos/firefox/nightly.png', 64px, 64px);
-    }
-
-    &.mzp-t-product-focus .mzp-c-call-out-content {
-        @include at2x('#{$image-path}/logos/firefox/focus.png', 64px, 64px);
+        @include at2x('#{$image-path}/logos/firefox/browser/nightly/logo-lg.png', 64px, 64px);
     }
 
     @media #{$mq-md} {
@@ -155,8 +145,7 @@
         &.mzp-t-product-firefox,
         &.mzp-t-product-beta,
         &.mzp-t-product-developer,
-        &.mzp-t-product-nightly,
-        &.mzp-t-product-focus {
+        &.mzp-t-product-nightly {
             .mzp-c-call-out-content {
                 @include bidi((
                     (background-position, left center, right center),

--- a/src/assets/sass/protocol/components/_card.scss
+++ b/src/assets/sass/protocol/components/_card.scss
@@ -64,11 +64,11 @@
     }
 
     &.mzp-has-video .mzp-c-card-tag {
-        background-image: url('#{$image-path}/icons/ui/video.svg');
+        background-image: url('#{$image-path}/icons/video-card.svg');
     }
 
     &.mzp-has-audio .mzp-c-card-tag {
-        background-image: url('#{$image-path}/icons/ui/audio.svg');
+        background-image: url('#{$image-path}/icons/audio-card.svg');
     }
 
     .mzp-c-card-title {

--- a/src/assets/sass/protocol/components/_hero.scss
+++ b/src/assets/sass/protocol/components/_hero.scss
@@ -23,8 +23,7 @@
     &.mzp-t-product-firefox,
     &.mzp-t-product-beta,
     &.mzp-t-product-developer,
-    &.mzp-t-product-nightly,
-    &.mzp-t-product-focus {
+    &.mzp-t-product-nightly {
         .mzp-c-hero-title {
             @include background-size(80px 80px);
             background-position: top center;
@@ -56,23 +55,19 @@
 
     // Product logos
     .mzp-t-product-firefox & {
-        @include at2x('#{$image-path}/logos/firefox/firefox.png', 80px, 80px);
+        @include at2x('#{$image-path}/logos/firefox/browser/logo-lg.png', 80px, 80px);
     }
 
     .mzp-t-product-beta & {
-        @include at2x('#{$image-path}/logos/firefox/beta.png', 80px, 80px);
+        @include at2x('#{$image-path}/logos/firefox/browser/beta/logo-lg.png', 80px, 80px);
     }
 
     .mzp-t-product-developer & {
-        @include at2x('#{$image-path}/logos/firefox/developer.png', 80px, 80px);
+        @include at2x('#{$image-path}/logos/firefox/browser/developer/logo-lg.png', 80px, 80px);
     }
 
     .mzp-t-product-nightly & {
-        @include at2x('#{$image-path}/logos/firefox/nightly.png', 80px, 80px);
-    }
-
-    .mzp-t-product-focus & {
-        @include at2x('#{$image-path}/logos/firefox/focus.png', 80px, 80px);
+        @include at2x('#{$image-path}/logos/firefox/browser/nightly/logo-lg.png', 80px, 80px);
     }
 }
 
@@ -116,8 +111,7 @@
             &.mzp-t-product-firefox,
             &.mzp-t-product-beta,
             &.mzp-t-product-developer,
-            &.mzp-t-product-nightly,
-            &.mzp-t-product-focus {
+            &.mzp-t-product-nightly {
                 .mzp-c-hero-title {
                     @include bidi(((background-position, left top, right top),));
                     padding-top: (80px + $spacing-2xl);

--- a/src/assets/sass/protocol/components/_menu.scss
+++ b/src/assets/sass/protocol/components/_menu.scss
@@ -72,15 +72,15 @@
 
         &:before {
             background:  $url-image-expand-black top left no-repeat;
-            @include background-size(16px, 16px);
+            @include background-size(20px, 20px);
             @include bidi(((right, 8px, left, auto),));
             @include transition(transform 100ms ease-in-out);
             content: '';
-            height: 16px;
+            height: 20px;
             margin-top: -8px;
             position: absolute;
             top: 50%;
-            width: 16px;
+            width: 20px;
         }
     }
 
@@ -209,7 +209,7 @@
     .mzp-c-menu-button-close {
         @include image-replaced;
         @include transition(transform 100ms ease-in-out);
-        background: transparent url('#{$image-path}/icons/ui/close-black.svg') center center no-repeat;
+        background: transparent url('#{$image-path}/icons/close.svg') center center no-repeat;
         border: none;
         cursor: pointer;
         display: none;

--- a/src/assets/sass/protocol/components/_modal.scss
+++ b/src/assets/sass/protocol/components/_modal.scss
@@ -80,7 +80,7 @@ html.mzp-is-noscroll {
 
     .mzp-c-modal-button-close {
         @include image-replaced;
-        background: transparent url('#{$image-path}/icons/ui/close-white.svg') center center no-repeat;
+        background: transparent url('#{$image-path}/icons/close-white.svg') center center no-repeat;
         @include background-size(16px 16px);
         border: none;
         height: 42px;

--- a/src/assets/sass/protocol/components/_navigation.scss
+++ b/src/assets/sass/protocol/components/_navigation.scss
@@ -154,7 +154,7 @@
     @include bidi(((float, right, left),));
     @include bidi(((padding, 0 32px 0 6px, 0 6px 0 32px),));
     background-color: transparent;
-    background-image: url('#{$image-path}/icons/ui/menu-black.svg');
+    background-image: url('#{$image-path}/icons/menu.svg');
     background-repeat: no-repeat;
     border-radius: 4px;
     border: none;

--- a/src/assets/sass/protocol/components/_notification-bar.scss
+++ b/src/assets/sass/protocol/components/_notification-bar.scss
@@ -68,7 +68,8 @@
                 ));
 
         @include image-replaced;
-        background: url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+        background: url("#{$image-path}/icons/close.svg") center center no-repeat;
+        background-size: 20px 20px;
         border: none;
         height: 20px;
         width: 20px;
@@ -86,7 +87,7 @@
                 (float, right, left),
                 (border-radius, 0 4px 4px 0, 4px 0 0 4px),
                 ));
-            background: $color-gray-40 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+            background-color: $color-gray-40;
             position: static;
             padding: 0;
             margin: 0;
@@ -101,7 +102,7 @@
 
         @media #{$mq-sm} {
             .mzp-c-notification-bar-button {
-                background: $color-green-60 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+                background-color: $color-green-60;
             }
         }
     }
@@ -111,7 +112,7 @@
 
         @media #{$mq-sm} {
             .mzp-c-notification-bar-button {
-                background: $color-red-60 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+                background-color: $color-red-60;
             }
         }
     }
@@ -121,7 +122,7 @@
 
         @media #{$mq-sm} {
             .mzp-c-notification-bar-button {
-                background: $color-yellow-40 url("#{$image-path}/icons/ui/close-black.svg") center center no-repeat;
+                background-color: $color-yellow-40;
             }
         }
     }
@@ -131,9 +132,11 @@
         color: $color-white;
         font-weight: 600;
 
-        @media #{$mq-sm} {
-            .mzp-c-notification-bar-button {
-                background: $color-blue-70 url("#{$image-path}/icons/ui/close-white.svg") center center no-repeat;
+        .mzp-c-notification-bar-button {
+            background-image: url("#{$image-path}/icons/close-white.svg");
+
+            @media #{$mq-sm} {
+                background-color: $color-blue-70;
             }
         }
     }

--- a/src/assets/sass/protocol/includes/mixins/_details.scss
+++ b/src/assets/sass/protocol/includes/mixins/_details.scss
@@ -31,15 +31,15 @@
 
     &:before {
         background: $url-image-expand-black top left no-repeat;
-        @include background-size(16px, 16px);
+        @include background-size(20px, 20px);
         @include bidi(((right, 8px, left, auto),));
         @include transition(transform 100ms ease-in-out);
         content: '';
-        height: 16px;
+        height: 20px;
         margin-top: -8px;
         position: absolute;
         top: 50%;
-        width: 16px;
+        width: 20px;
     }
 }
 

--- a/src/assets/sass/protocol/includes/mixins/_images.scss
+++ b/src/assets/sass/protocol/includes/mixins/_images.scss
@@ -73,10 +73,10 @@
 // images
 
 // SVGs - xmlns attribute must be first
-// https://github.com/mozilla/protocol-assets/blob/master/icons/ui/expand-white.svg
-$svg-expand-white: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M7 7V1a1 1 0 1 1 2 0v6h6a1 1 0 1 1 0 2H9v6a1 1 0 1 1-2 0V9H1a1 1 0 1 1 0-2h6z" fill="#fff" fill-rule="evenodd"/></svg>';
-// https://github.com/mozilla/protocol-assets/blob/master/icons/ui/expand-black.svg
-$svg-expand-black: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M7 7V1a1 1 0 1 1 2 0v6h6a1 1 0 1 1 0 2H9v6a1 1 0 1 1-2 0V9H1a1 1 0 1 1 0-2h6z" fill="#000" fill-rule="evenodd"/></svg>';
+// https://github.com/mozilla/protocol-assets/blob/master/icons/expand-white.svg
+$svg-expand-white: '<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="#FFF" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"><path d="M12 3.515v16.97M3.515 12h16.97"/></g></svg>';
+// https://github.com/mozilla/protocol-assets/blob/master/icons/expand.svg
+$svg-expand-black: '<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"><path d="M12 3.515v16.97M3.515 12h16.97"/></g></svg>';
 $svg-arrow-down-link: '<svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"><polyline stroke="#0060df" stroke-width="2" points="5 9 12 16 19 9"></polyline></g></svg>';
 $svg-arrow-down-link-hover: '<svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"><polyline stroke="#0250bb" stroke-width="2" points="5 9 12 16 19 9"></polyline></g></svg>';
 $svg-download-link-hover: '<svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round"><g transform="translate(6.000000, 3.000000)" stroke="#0250bb" stroke-width="2"><path d="M0,18 L12,18"></path><polyline stroke-linejoin="round" points="0 8 6 14 12 8"></polyline><path d="M6,0 L6,14"></path></g></g></svg>';

--- a/src/pages/demos/navigation.hbs
+++ b/src/pages/demos/navigation.hbs
@@ -17,7 +17,7 @@ styles:
               <div class="mzp-c-menu-panel-content">
                 <ul>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/firefox.png" link="https://www.mozilla.org/firefox/"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/browser/logo-lg.png" link="https://www.mozilla.org/firefox/"}}
                       {{#content "title"}}Firefox Desktop Browser{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Get the browser that’s fast for good for Windows, Mac OS or Linux.</p>
@@ -177,7 +177,7 @@ styles:
               <div class="mzp-c-menu-panel-content">
                 <ul>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/developer.png" link="https://www.mozilla.org/firefox/developer/"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/browser/developer/logo-lg.png" link="https://www.mozilla.org/firefox/developer/"}}
                       {{#content "title"}}Developer Edition{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Firefox, built just for developers.</p>
@@ -186,7 +186,7 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/beta.png" link="https://www.mozilla.org/firefox/channel/desktop/#beta"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/browser/beta/logo-lg.png" link="https://www.mozilla.org/firefox/channel/desktop/#beta"}}
                       {{#content "title"}}Firefox Beta{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Test soon-to-be-released features in our most stable pre-release build.</p>
@@ -195,7 +195,7 @@ styles:
                     {{/embed}}
                   </li>
                   <li>
-                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/nightly.png" link="https://www.mozilla.org/firefox/channel/desktop/#nightly"}}
+                    {{#embed "patterns.molecules.menu.menu-item" icon="true" image="/assets/protocol/protocol/img/logos/firefox/browser/nightly/logo-lg.png" link="https://www.mozilla.org/firefox/channel/desktop/#nightly"}}
                       {{#content "title"}}Firefox Nightly{{/content}}
                       {{#content "desc"}}
                         <p class="mzp-c-menu-item-desc">Preview the latest build of Firefox and help us make it the best.</p>

--- a/src/patterns/organisms/call-out/call-out.hbs
+++ b/src/patterns/organisms/call-out/call-out.hbs
@@ -8,7 +8,6 @@ notes: |
       - `mzp-t-product-beta`.
       - `mzp-t-product-developer`.
       - `mzp-t-product-nightly`.
-      - `mzp-t-product-focus`.
     - Adding a theme class of `mzp-t-mozilla` will render the title font using Zilla Slab.
     - A dark theme is also available using the theme class `mzp-t-dark`.
 links:

--- a/src/patterns/organisms/hero/hero-branded.hbs
+++ b/src/patterns/organisms/hero/hero-branded.hbs
@@ -9,7 +9,6 @@ notes: |
     - `mzp-t-product-beta`.
     - `mzp-t-product-developer`.
     - `mzp-t-product-nightly`.
-    - `mzp-t-product-focus`.
   - Adding a theme class of `mzp-t-mozilla` will render the title font using Zilla Slab.
   - This example shows a mock download button. Actual download buttons on mozilla.org are much more complex with a lot of hidden markup so the CTA wrapper here is a `div` where other examples use a `p` element (a paragraph can only contain text and phrasing elements; a `p` wouldn’t be correct for a real download button).
   - [See the demo page](/demos/hero.html) for more examples in a full window context.


### PR DESCRIPTION
## Description

- Point all ui icons to the new locations
- Add background-size declarations to places icons are used (new icon files are larger)
- Remove `-black` from places referenceing black icon files
- Update logo urls
- Remove focus theme

---

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #479

### Testing

- All icons that were inside the ui folder have been moved
- Background-size declarations have been added to places icons are used (new icon files are larger)
- Black icons no longer have -black in the file name.
- mzp-t-product themes still work as expected

