### PR TITLE
CTA links now use text underlines instead of borders (#490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* **css:** CTA links now use text underlines instead of borders (#490)
+
 ## 9.0.1
 
 ## Bug Fixes

--- a/src/assets/sass/protocol/base/elements/_links.scss
+++ b/src/assets/sass/protocol/base/elements/_links.scss
@@ -32,29 +32,7 @@
 .mzp-c-cta-link {
     font-weight: bold;
 
-    &:link,
-    &:visited {
-        border-bottom: 2px solid;
-        color: $color-link;
-        text-decoration: none;
-    }
-
-    &:hover,
-    &:active,
-    &:focus {
-        @include transition(border-bottom-color 100ms ease-in-out);
-        border-bottom-color: transparent;
-    }
-
     .mzp-t-firefox & {
         @include font-firefox;
-    }
-
-    .mzp-t-dark & {
-        &:link,
-        &:visited {
-            color: $color-white;
-            text-decoration: none;
-        }
     }
 }

--- a/src/assets/sass/protocol/components/_menu-list.scss
+++ b/src/assets/sass/protocol/components/_menu-list.scss
@@ -10,10 +10,10 @@
 
 .mzp-c-menu-list-title {
     font-size: inherit;
-    font-weight: bold;
 
     .mzp-t-mozilla .mzp-t-cta & {
         @include font-firefox;
+        font-weight: bold;
     }
 }
 


### PR DESCRIPTION
## Description

CTA links now use text underlines instead of borders

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #490

### Testing
- cta-links http://localhost:3000/patterns/atoms/links.html
- cta theme for menu list http://localhost:3000/patterns/molecules/menu-list.html
- cta links in dark themes: http://localhost:3000/demos/feature-card.html
