### PR TITLE
fixed #489 Rename `mzp-c-box-emphasis` to `mzp-c-emphasis-box`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* **css:** Rename `mzp-c-box-emphasis` to `mzp-c-emphasis-box` (#489)
+
 ## 9.0.0
 
 * **assets:** (breaking) Update @mozilla-protocol/assets to 3.0.0 (#479)

--- a/src/assets/sass/protocol/components/_emphasis-box.scss
+++ b/src/assets/sass/protocol/components/_emphasis-box.scss
@@ -6,7 +6,7 @@
 
 /* -------------------------------------------------------------------------- */
 // Base emphasis Box class
-.mzp-c-box-emphasis {
+.mzp-c-emphasis-box {
     background: $color-white;
     border-radius: 6px;
     margin: $spacing-md;

--- a/src/patterns/molecules/emphasis-box/medium-emphasis-box.hbs
+++ b/src/patterns/molecules/emphasis-box/medium-emphasis-box.hbs
@@ -7,7 +7,7 @@ notes: |
 
 ---
 
-<section class="mzp-c-box-emphasis" >
+<section class="mzp-c-emphasis-box" >
   {{#block "content"}}
     <h3>This is a standard Emphasis Box</h3>
     <p>This is some filler content. Cats are the best, every cat.</p>


### PR DESCRIPTION
## Description

fixed #489 Rename `mzp-c-box-emphasis` to `mzp-c-emphasis-box`

- [x ] I have documented this change in the design system.
- [ x] I have recorded this change in `CHANGELOG.md`.

### Issue

#489 

### Testing

Enter helpful notes for whoever code reviews this change.
