### PR TITLE
Updates '.mzp-c-button-download-container' class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD
 
 * **css:** CTA links now use text underlines instead of borders (#490)
+* **css:** Changes '.mzp-c-button-download-container' display property to 'inline-block' from 'block' (#486)
 
 ## 9.0.1
 

--- a/src/assets/sass/protocol/components/_button.scss
+++ b/src/assets/sass/protocol/components/_button.scss
@@ -147,6 +147,7 @@ a.mzp-c-button.mzp-t-product.mzp-t-secondary {
 .mzp-c-button-download-container {
     text-align: center;
     margin-bottom: 24px;
+    display: inline-block;
 }
 
 .mzp-c-button-download-privacy-link {


### PR DESCRIPTION
## Description

Download button containers were block level, meaning they take up 100% of their parent's container width in example previews. Changed it to 'inline-block'.

Changes `.mzp-c-button-download-container` display property to '**inline-block**' from 'block'

- [ ] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

https://github.com/mozilla/protocol/issues/486
