### PR TITLE
Menu List Firefox theme CTA uses firefox-font (#503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD
 
-* **css:** Rename `mzp-c-box-emphasis` to `mzp-c-emphasis-box` (#489)
+* **css:** Menu List Firefox theme CTA uses firefox-font #503
+* **css:** (breaking) Rename `mzp-c-box-emphasis` to `mzp-c-emphasis-box` (#489)
 * **assets:** Update @mozilla-protocol/assets to 3.0.1 (#509)
 * **css:** CTA links now use text underlines instead of borders (#490)
 

--- a/src/assets/sass/protocol/components/_menu-list.scss
+++ b/src/assets/sass/protocol/components/_menu-list.scss
@@ -11,7 +11,7 @@
 .mzp-c-menu-list-title {
     font-size: inherit;
 
-    .mzp-t-mozilla .mzp-t-cta & {
+    .mzp-t-firefox .mzp-t-cta & {
         @include font-firefox;
         font-weight: bold;
     }


### PR DESCRIPTION
## Description

Describe what this change does.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #503 

### Testing

http://localhost:3000/patterns/molecules/menu-list.html
