### PR TITLE
Support an optional CTA link in a JS-created NotificationBar (#460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD
 
 * **css:** Changes '.mzp-c-button-download-container' display property to 'inline-block' from 'block' (#486)
+* **js:** Support a CTA link in NotificationBar (#460)
 
 ## 10.0.1
 

--- a/src/assets/js/protocol/protocol-notification-bar.js
+++ b/src/assets/js/protocol/protocol-notification-bar.js
@@ -17,6 +17,10 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
     origin: element that triggered the notification.
     options: object of params:
         title: title to display inside the notification. [required]
+        cta: [Object] options for rendering an Anchor node after the title.
+            text: text content for an Anchor element
+            url: URL for the Anchor element
+            attrs: map of additional options for the Anchor element, eg 'target', 'rel' etc
         className: CSS class name to apply to the notification.
         closeText: 'string to use for close button a11y.
         hasDismiss: boolean - include or not include dismiss button.
@@ -40,6 +44,7 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
         var className = (options && options.className) ? options.className : '';
         var closeText = (options && options.closeText) ? options.closeText : '';
         var isSticky = (options && options.isSticky) ? 'mzp-is-sticky' : '';
+        var ctaOptions = options && options.cta ? options.cta : {};
 
         var notification = document.createElement('aside');
         notification.className = 'mzp-c-notification-bar ' + className + ' ' + isSticky;
@@ -53,6 +58,23 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
 
             // add title to notification
             notification.appendChild(notificationTitle);
+        }
+
+        // Notification CTA link
+        if (options && options.cta) {
+            var ctaAnchor = document.createElement('a'),
+                ctaAttrs = ctaOptions.attrs ? ctaOptions.attrs : {};
+
+            // build main <a> element, with the appropriate CSS class
+            ctaAnchor.appendChild(document.createTextNode(ctaOptions.text));
+            ctaAnchor.href = ctaOptions.url;
+            ctaAnchor.className = 'mzp-c-notification-bar-cta';
+
+            // If there are any extra attrs, add them to the element
+            Object.entries(ctaAttrs).forEach(function(attrPair) {
+                ctaAnchor.setAttribute(attrPair[0], attrPair[1]);
+            });
+            notification.appendChild(ctaAnchor);
         }
 
         // Notification Fragment

--- a/src/assets/js/protocol/protocol-notification-bar.js
+++ b/src/assets/js/protocol/protocol-notification-bar.js
@@ -71,9 +71,10 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
             ctaAnchor.className = 'mzp-c-notification-bar-cta';
 
             // If there are any extra attrs, add them to the element
-            Object.entries(ctaAttrs).forEach(function(attrPair) {
-                ctaAnchor.setAttribute(attrPair[0], attrPair[1]);
-            });
+            var key;
+            for (key in ctaAttrs){
+                ctaAnchor.setAttribute(key, ctaAttrs[key]);
+            }
             notification.appendChild(ctaAnchor);
         }
 

--- a/src/patterns/molecules/notification-bar/notification-bar.hbs
+++ b/src/patterns/molecules/notification-bar/notification-bar.hbs
@@ -8,6 +8,10 @@ notes: |
     - `origin` [DOM Element] element that triggered the notification
     - `options` [Object] object of params
         - `title` [String] message to display in the notification. (Required)
+        - `cta`: [Object] options for rendering an Anchor node after the title.
+            text: (Required) text content for an Anchor element
+            url: (Required) URL for the Anchor element
+            attrs: map of additional options for the Anchor element, eg: 'target', 'rel'
         - `className` [String] optional CSS class name to apply to the notification.
         - `onNotificationOpen` [Function] function to fire after notification has been opened.
         - `onNotificationClose` [Function] function to fire after notification has been closed.
@@ -83,7 +87,12 @@ notes: |
       e.preventDefault();
 
       Mzp.Notification.init(e.target, {
-        title: 'This is the title',
+        title: 'This is the title.',
+        cta: {
+          text: "And this is a CTA link.",
+          url: "https://www.mozilla.org",
+          attrs: {"target": "_blank", "rel": "noopener"}
+        },
         className: 'mzp-t-warning',
         closeText: 'Close notification',
         hasDismiss: true,

--- a/tests/unit/protocol-notification-bar.js
+++ b/tests/unit/protocol-notification-bar.js
@@ -68,4 +68,126 @@ describe('protocol-notification.js', function() {
         });
 
     });
+
+    describe('interactions-with-cta-no-attrs', function () {
+
+        var options = {
+            open: function () {}, // eslint-disable-line no-empty-function
+            close: function () {} // eslint-disable-line no-empty-function
+        };
+
+        beforeEach(function () {
+            spyOn(options, 'open');
+            spyOn(options, 'close');
+
+            var button = document.querySelector('.mzp-c-button');
+
+            button.addEventListener('click', function (e) {
+                e.preventDefault();
+
+                Mzp.Notification.init(button, {
+                    cta: {
+                        text: 'This is a call to action',
+                        url: 'https://example.com/test/url',
+                    },
+                    hasDismiss: true,
+                    onNotificationOpen: options.open,
+                    onNotificationClose: options.close
+                });
+            });
+
+            button.click();
+        });
+
+        afterEach(function(){
+            var node = document.querySelector('.mzp-c-notification-bar');
+            if (node) {
+                node.parentNode.removeChild(node);
+            }
+        });
+
+        it('opens as expected, with a CTA', function() {
+            expect(options.open).toHaveBeenCalled();
+
+            var notification = document.querySelector('.mzp-c-notification-bar');
+            expect(notification).toBeTruthy();
+
+            var cta = document.querySelector('.mzp-c-notification-bar-cta');
+            expect(cta).toBeTruthy();
+        });
+
+        it('closes as expected', function() {
+            var dismissButton = document.querySelector('.mzp-c-notification-bar-button');
+            dismissButton.click();
+            expect(options.close).toHaveBeenCalled();
+
+            var notification = document.querySelector('.mzp-c-notification-bar');
+            expect(notification).toEqual(null);
+        });
+    });
+
+    describe('interactions-with-cta-extra-attrs', function () {
+
+        var options = {
+            open: function () {}, // eslint-disable-line no-empty-function
+            close: function () {} // eslint-disable-line no-empty-function
+        };
+
+        beforeEach(function () {
+            spyOn(options, 'open');
+            spyOn(options, 'close');
+
+            var button = document.querySelector('.mzp-c-button');
+
+            button.addEventListener('click', function (e) {
+                e.preventDefault();
+
+                Mzp.Notification.init(button, {
+                    cta: {
+                        text: 'This is a call to action',
+                        url: 'https://example.com/test/url',
+                        attrs: {
+                            'target': '_blank',
+                            'rel': 'nofollow',
+                            'hreflang': 'en-US',
+                        }
+                    },
+                    hasDismiss: true,
+                    onNotificationOpen: options.open,
+                    onNotificationClose: options.close
+                });
+            });
+
+            button.click();
+        });
+
+        afterEach(function(){
+            var node = document.querySelector('.mzp-c-notification-bar');
+            if (node) {
+                node.parentNode.removeChild(node);
+            }
+        });
+
+        it('opens as expected, with a CTA featuring the extra attributes', function() {
+            expect(options.open).toHaveBeenCalled();
+
+            var notification = document.querySelector('.mzp-c-notification-bar');
+            expect(notification).toBeTruthy();
+
+            var cta = document.querySelector('.mzp-c-notification-bar-cta');
+            expect(cta).toBeTruthy();
+            expect(cta.getAttribute('target')).toBe('_blank');
+            expect(cta.getAttribute('rel')).toBe('nofollow');
+            expect(cta.getAttribute('hreflang')).toBe('en-US');
+        });
+
+        it('closes as expected', function() {
+            var dismissButton = document.querySelector('.mzp-c-notification-bar-button');
+            dismissButton.click();
+            expect(options.close).toHaveBeenCalled();
+
+            var notification = document.querySelector('.mzp-c-notification-bar');
+            expect(notification).toEqual(null);
+        });
+    });
 });


### PR DESCRIPTION
This changeset adds support for an optional hyperlink ("call to action"/CTA) to be added after the main text in a JS-triggered `NotificationBar` component. 

Prior to this changeset, it was not possible to use JS to create a notification with a working CTA link.

<img width="751" alt="Screenshot 2020-01-29 at 22 42 46" src="https://user-images.githubusercontent.com/101457/73404057-b41f0880-42e8-11ea-8ba7-fe0280ce958b.png">


An optional options object lets the developer specify the text for inside the link, the URL for its href and, optionally, another object of additional attributes which are all then applied to the link.

Includes tests.

## Description

Describe what this change does.

- [X] I have documented this change in the design system.
- [X] I have recorded this change in `CHANGELOG.md`.

### Issue

Resolves https://github.com/mozilla/protocol/issues/460

### Testing

* Check out the build
* `npm start` to get it running locally
* Go to http://localhost:3000/patterns/molecules/notification-bar.html
* Click the "Open Notification" button to see the default/example notification now includes a CTA.
