### PR TITLE
Add link color styles to notification bar (Fixes #541)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+* **css:** Add link color styles to notification bar (#541)
 * **css:** Fix notification bar line height breaking container. (#525)
 
 # 11.0.0

--- a/src/assets/sass/protocol/components/_notification-bar.scss
+++ b/src/assets/sass/protocol/components/_notification-bar.scss
@@ -11,6 +11,7 @@
     border-radius: $border-radius-sm;
     border: 1px;
     box-shadow: $box-shadow-md;
+    color: $color-ink-80;
     font-weight: normal;
     margin: $layout-xs auto 0;
     text-align: center;
@@ -27,13 +28,17 @@
         margin: 0 auto;
     }
 
-    a {
+    a:link,
+    a:visited {
         color: inherit;
         display: inline-block;
         font-size: inherit;
         font-weight: 700;
 
-        &:hover {
+        &:hover,
+        &:active,
+        &:focus {
+            color: inherit;
             text-decoration: none;
         }
     }

--- a/src/patterns/molecules/notification-bar/notification-bar.hbs
+++ b/src/patterns/molecules/notification-bar/notification-bar.hbs
@@ -56,7 +56,7 @@ notes: |
   <li>
     <aside class="mzp-c-notification-bar mzp-t-click">
       <button class="mzp-c-notification-bar-button" type="button"></button>
-      <p>Click this thing.</p>
+      <p><a href="#" class="mzp-c-notification-bar-cta">Click this thing</a></p>
     </aside>
   </li>
 


### PR DESCRIPTION
## Description

Describe what this change does.

- [ ] ~I have documented this change in the design system~.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#541

### Testing

- [ ] Link color states on a notification page should always inherit from the notification text color.