### PR TITLE
Add title size utility class (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Features
 
+* **utility:** Add title size utility classes (#297)
+  ** rename `text-display-` to `text-title-`, keep `text-display-` as an alias
 * **component:** Updates to emphasis box, with additional documentation and usage guidelines.
+
+## Migration Tips
+  * Find and replace `text-display-` to `text-title-`
 
 # 11.0.1
 

--- a/src/assets/sass/demos/hero.scss
+++ b/src/assets/sass/demos/hero.scss
@@ -19,7 +19,7 @@
     }
 
     h2 {
-        @include text-display-md;
+        @include text-title-md;
     }
 
     .mzp-c-card-picto .mzp-c-card-picto-content::before{

--- a/src/assets/sass/demos/type-scale.scss
+++ b/src/assets/sass/demos/type-scale.scss
@@ -18,13 +18,13 @@ hr {
     max-width: $content-max - (160px);
 }
 
-.scale-sample-display-xxl { @include text-display-xxl; }
-.scale-sample-display-xl { @include text-display-xl; }
-.scale-sample-display-lg { @include text-display-lg; }
-.scale-sample-display-md { @include text-display-md; }
-.scale-sample-display-sm { @include text-display-sm; }
-.scale-sample-display-xs { @include text-display-xs; }
-.scale-sample-display-xxs { @include text-display-xxs; }
+.scale-sample-display-xxl { @include text-title-xxl; }
+.scale-sample-display-xl { @include text-title-xl; }
+.scale-sample-display-lg { @include text-title-lg; }
+.scale-sample-display-md { @include text-title-md; }
+.scale-sample-display-sm { @include text-title-sm; }
+.scale-sample-display-xs { @include text-title-xs; }
+.scale-sample-display-xxs { @include text-title-xxs; }
 .scale-sample-body-lg { @include text-body-lg; }
 .scale-sample-body-md { @include text-body-md; }
 .scale-sample-body-sm { @include text-body-sm; }

--- a/src/assets/sass/docs/site.scss
+++ b/src/assets/sass/docs/site.scss
@@ -74,7 +74,7 @@
 }
 
 .protosite-nav-menu-title {
-    @include text-display-xs;
+    @include text-title-xs;
 }
 
 .protosite-nav-main-item {
@@ -124,7 +124,7 @@
 
     .protosite-swatch-name {
         @include font-base;
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     @media #{$mq-md} {
@@ -172,7 +172,7 @@
 }
 
 .protosite-specimen-font {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 #specimen-zilla-slab {
@@ -245,11 +245,11 @@
 }
 
 .protosite-pattern-title {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 .protosite-pattern-extra h3 {
-    @include text-display-sm;
+    @include text-title-sm;
 }
 
 .protosite-pattern-extra ul {

--- a/src/assets/sass/protocol/base/elements/_forms.scss
+++ b/src/assets/sass/protocol/base/elements/_forms.scss
@@ -71,7 +71,7 @@ select:focus {
 }
 
 legend {
-    @include text-display-sm;
+    @include text-title-sm;
 
     .mzp-u-inline & {
         @include text-body-md;

--- a/src/assets/sass/protocol/base/elements/_quotes.scss
+++ b/src/assets/sass/protocol/base/elements/_quotes.scss
@@ -6,7 +6,7 @@
 
 blockquote {
     @include bidi(((border-width, 0 0 0 5px, 0 5px 0 0),));
-    @include text-display-sm;
+    @include text-title-sm;
     border-color: $color-marketing-gray-20;
     border-style: solid;
     margin: $spacing-lg auto;
@@ -14,7 +14,7 @@ blockquote {
     font-weight: bold;
 
     cite {
-        @include text-display-xs;
+        @include text-title-xs;
         color: $color-marketing-gray-70;
 
         &:before {

--- a/src/assets/sass/protocol/base/elements/_typography.scss
+++ b/src/assets/sass/protocol/base/elements/_typography.scss
@@ -29,25 +29,29 @@ h1, h2, h3, h4, h5, h6, legend {
 
 // Type scale defined in includes/mixins/_typography.scss
 h1 {
-    @include text-display-xxl;
+    @include text-title-xxl;
     margin-bottom: .25em;
 }
 
 h2 {
-    @include text-display-xl;
+    @include text-title-xl;
     margin-bottom: .45em;
 }
 
 h3 {
-    @include text-display-lg;
+    @include text-title-lg;
 }
 
 h4 {
-    @include text-display-md;
+    @include text-title-md;
 }
 
-h5, h6 {
-    @include text-display-sm;
+h5 {
+    @include text-title-sm;
+}
+
+h6 {
+    @include text-title-xs;
 }
 
 p,

--- a/src/assets/sass/protocol/base/utilities/_typography.scss
+++ b/src/assets/sass/protocol/base/utilities/_typography.scss
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../includes/lib';
+
+.mzp-u-title-xxl {
+    @include text-title-xxl;
+
+    .mzp-t-mozilla {
+        & {
+            @include font-mozilla;
+        }
+    }
+
+    .mzp-t-firefox {
+        & {
+            @include font-firefox;
+        }
+    }
+}
+
+.mzp-u-title-xl {
+    @include text-title-xl;
+
+    .mzp-t-mozilla {
+        & {
+            @include font-mozilla;
+        }
+    }
+
+    .mzp-t-firefox {
+        & {
+            @include font-firefox;
+        }
+    }
+}
+
+.mzp-u-title-lg {
+    @include text-title-lg;
+
+    .mzp-t-mozilla {
+        & {
+            @include font-mozilla;
+        }
+    }
+
+    .mzp-t-firefox {
+        & {
+            @include font-firefox;
+        }
+    }
+}
+
+.mzp-u-title-md {
+    @include text-title-md;
+
+    .mzp-t-mozilla {
+        & {
+            @include font-mozilla;
+        }
+    }
+
+    .mzp-t-firefox {
+        & {
+            @include font-firefox;
+        }
+    }
+}
+
+.mzp-u-title-sm {
+    @include text-title-sm;
+
+    .mzp-t-mozilla {
+        & {
+            @include font-mozilla;
+        }
+    }
+
+    .mzp-t-firefox {
+        & {
+            @include font-firefox;
+        }
+    }
+}
+
+.mzp-u-title-xs {
+    @include text-title-xs;
+
+    .mzp-t-mozilla {
+        & {
+            @include font-mozilla;
+        }
+    }
+
+    .mzp-t-firefox {
+        & {
+            @include font-firefox;
+        }
+    }
+}
+
+.mzp-u-title-xxs {
+    @include text-title-xxs;
+
+    .mzp-t-mozilla {
+        & {
+            @include font-mozilla;
+        }
+    }
+
+    .mzp-t-firefox {
+        & {
+            @include font-firefox;
+        }
+    }
+}
+

--- a/src/assets/sass/protocol/components/_article.scss
+++ b/src/assets/sass/protocol/components/_article.scss
@@ -10,15 +10,15 @@
 
     // Step down the heading levels
     h2 {
-        @include text-display-md;
+        @include text-title-md;
     }
 
     h3 {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     h4 {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     @media #{$mq-md} {
@@ -35,7 +35,7 @@
 }
 
 .mzp-c-article-title {
-    @include text-display-xl;
+    @include text-title-xl;
 }
 
 .mzp-c-article-intro {

--- a/src/assets/sass/protocol/components/_billboard.scss
+++ b/src/assets/sass/protocol/components/_billboard.scss
@@ -29,7 +29,7 @@ $billboard-content-width-lg: 374px + $spacing-md; // content width + spacing med
     }
 
     .mzp-c-billboard-title {
-        @include text-display-md;
+        @include text-title-md;
     }
 
     .mzp-c-billboard-image-container {

--- a/src/assets/sass/protocol/components/_call-out.scss
+++ b/src/assets/sass/protocol/components/_call-out.scss
@@ -21,7 +21,7 @@
     }
 
     .mzp-c-call-out-title {
-        @include text-display-md;
+        @include text-title-md;
     }
 
     .mzp-c-call-out-desc {
@@ -87,7 +87,7 @@
     }
 
     .mzp-c-call-out-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .mzp-c-call-out-desc {

--- a/src/assets/sass/protocol/components/_card.scss
+++ b/src/assets/sass/protocol/components/_card.scss
@@ -72,7 +72,7 @@
     }
 
     .mzp-c-card-title {
-        @include text-display-xs;
+        @include text-title-xs;
         display: inline;
     }
 
@@ -149,7 +149,7 @@
 .mzp-c-card.mzp-c-card-large {
 
     .mzp-c-card-title {
-        @include text-display-md;
+        @include text-title-md;
     }
 
     .mzp-c-card-desc {
@@ -172,7 +172,7 @@
     }
 
     .mzp-c-card-title {
-        @include text-display-xxs;
+        @include text-title-xxs;
     }
 
     .mzp-c-card-desc {

--- a/src/assets/sass/protocol/components/_feature-card.scss
+++ b/src/assets/sass/protocol/components/_feature-card.scss
@@ -39,7 +39,7 @@
     }
 
     .mzp-c-card-feature-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .mzp-c-card-feature-desc {

--- a/src/assets/sass/protocol/components/_hero.scss
+++ b/src/assets/sass/protocol/components/_hero.scss
@@ -50,7 +50,7 @@
 }
 
 .mzp-c-hero-title {
-    @include text-display-lg;
+    @include text-title-lg;
     margin-bottom: $spacing-md;
 
     // Product logos
@@ -77,7 +77,7 @@
 }
 
 .mzp-c-hero-tagline {
-    @include text-display-sm;
+    @include text-title-sm;
 }
 
 .mzp-c-hero-image {

--- a/src/assets/sass/protocol/components/_menu-item.scss
+++ b/src/assets/sass/protocol/components/_menu-item.scss
@@ -60,7 +60,7 @@ $icon-size: 24px;
     }
 
     .mzp-c-menu-item-title {
-        @include text-display-xxs;
+        @include text-title-xxs;
         display: inline;
     }
 

--- a/src/assets/sass/protocol/components/_modal.scss
+++ b/src/assets/sass/protocol/components/_modal.scss
@@ -60,7 +60,7 @@ html.mzp-is-noscroll {
         @include bidi(((padding-right, $spacing-xl * 2, padding-left, 0),));
 
         h2 {
-            @include text-display-xs;
+            @include text-title-xs;
             @include font-base;
             color: #fff;
         }

--- a/src/assets/sass/protocol/components/_newsletter-form.scss
+++ b/src/assets/sass/protocol/components/_newsletter-form.scss
@@ -28,7 +28,7 @@
 }
 
 .mzp-c-newsletter-title {
-    @include text-display-md;
+    @include text-title-md;
     margin-bottom: .25em;
 }
 

--- a/src/assets/sass/protocol/components/_picto-card.scss
+++ b/src/assets/sass/protocol/components/_picto-card.scss
@@ -29,7 +29,7 @@
     }
 
     .mzp-c-card-picto-title {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .mzp-c-card-picto-desc {
@@ -62,7 +62,7 @@
     @include bidi(((text-align, left, right),));
 
     .mzp-c-card-picto-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .mzp-c-card-picto-content {

--- a/src/assets/sass/protocol/includes/mixins/_typography.scss
+++ b/src/assets/sass/protocol/includes/mixins/_typography.scss
@@ -41,72 +41,83 @@
 // there's some redundancy at smaller sizes because we don't want things
 // getting too tiny.
 // Example usage:
-//  .title { @include text-display-xl; }
-//  .subtitle { @include text-display-lg; }
+//  .title { @include text-title-xl; }
+//  .subtitle { @include text-title-lg; }
 //  .intro { @include text-body-lg; }
 
 $text-body-line-height: $font-base-line-height;
-$text-display-line-height: 1.1;
+$text-title-line-height: 1.1;
 
 // display copy: headings, blockquotes, other fancy stuff
-@mixin text-display-xxl { // Use this one sparingly.
+@mixin text-title-xxl { // Use this one sparingly.
     @include font-size(48px);
-    line-height: $text-display-line-height;
+    line-height: $text-title-line-height;
 
     @media #{$mq-md} {
         @include font-size(64px);
     }
 }
 
-@mixin text-display-xl {
+@mixin text-title-xl {
     @include font-size(40px);
-    line-height: $text-display-line-height;
+    line-height: $text-title-line-height;
 
     @media #{$mq-md} {
         @include font-size(56px);
     }
 }
 
-@mixin text-display-lg {
+@mixin text-title-lg {
     @include font-size(32px);
-    line-height: $text-display-line-height;
+    line-height: $text-title-line-height;
 
     @media #{$mq-md} {
         @include font-size(48px);
     }
 }
 
-@mixin text-display-md {
+@mixin text-title-md {
     @include font-size(24px);
-    line-height: $text-display-line-height;
+    line-height: $text-title-line-height;
 
     @media #{$mq-md} {
         @include font-size(40px);
     }
 }
 
-@mixin text-display-sm {
+@mixin text-title-sm {
     @include font-size(21px);
-    line-height: $text-display-line-height;
+    line-height: $text-title-line-height;
 
     @media #{$mq-md} {
         @include font-size(32px);
     }
 }
 
-@mixin text-display-xs {
+@mixin text-title-xs {
     @include font-size(18px);
-    line-height: $text-display-line-height;
+    line-height: $text-title-line-height;
 
     @media #{$mq-md} {
         @include font-size(24px);
     }
 }
 
-@mixin text-display-xxs {
+@mixin text-title-xxs {
     @include font-size(16px);
-    line-height: $text-display-line-height;
+    line-height: $text-title-line-height;
 }
+
+// backwards compatibility
+
+$text-display-line-height: $text-title-line-height;
+@mixin text-display-xxl { @include text-title-xxl; }
+@mixin text-display-xl { @include text-title-xl; }
+@mixin text-display-lg { @include text-title-lg; }
+@mixin text-display-md { @include text-title-md; }
+@mixin text-display-sm { @include text-title-sm; }
+@mixin text-display-xs { @include text-title-xs; }
+@mixin text-display-xxs { @include text-title-xxs; }
 
 // body copy
 @mixin text-body-lg {

--- a/src/assets/sass/protocol/protocol.scss
+++ b/src/assets/sass/protocol/protocol.scss
@@ -22,6 +22,9 @@ $image-path: '../img' !default;
 // Base includes - animations
 @import 'base/includes';
 
+// Utility includes
+@import 'base/utilities/typography';
+
 // Global components
 @import 'components/card';
 @import 'components/footer';

--- a/src/pages/fundamentals/typography.hbs
+++ b/src/pages/fundamentals/typography.hbs
@@ -108,13 +108,13 @@ styles:
 <p>We use Sass mixins to declare these font sizes:</p>
 
 <div class="protosite-pattern-embed">
-<pre class="protosite-pattern-code language-scss"><code>@include text-display-xxl;
-@include text-display-xl;
-@include text-display-lg;
-@include text-display-md;
-@include text-display-sm;
-@include text-display-xs;
-@include text-display-xxs;
+<pre class="protosite-pattern-code language-scss"><code>@include text-title-xxl;
+@include text-title-xl;
+@include text-title-lg;
+@include text-title-md;
+@include text-title-sm;
+@include text-title-xs;
+@include text-title-xxs;
 @include text-body-lg;
 @include text-body-md;
 @include text-body-sm;
@@ -128,9 +128,9 @@ styles:
 
 <div class="protosite-pattern-embed">
 <pre class="protosite-pattern-code language-scss"><code>
-  @mixin text-display-xl {
+  @mixin text-title-xl {
       @include font-size(40px);
-      line-height: $text-display-line-height;
+      line-height: $text-title-line-height;
 
       @media #{$mq-md} {
           @include font-size(56px);

--- a/src/patterns/atoms/typographic/headings.hbs
+++ b/src/patterns/atoms/typographic/headings.hbs
@@ -5,7 +5,9 @@ description: |
 nonos: |
     - Avoid breaking rank just for font sizing. The next heading after an `h1` should be an `h2` even if that `h2` is much smaller. Use HTML for meaning and CSS for styling. You can make that `h2` whatever size you need.
     - Avoid "stacking" headings without any body content in between, eg. an `h2` immediately following an `h1`. If you need a subheading or tagline immediately after a title, chances are it should be a paragraph rather than a second heading.
+    - If you only need to adjust the text size you can use the title size utility classes. Example: `mzp-u-title-sm`
 links:
+    Heading Utility Classes: /patterns/templates/card-layout.html
     MDN: https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements
 order: 1
 ---
@@ -17,4 +19,8 @@ order: 1
   <h4>{{heading}}</h4>
   <h5>{{heading}}</h5>
   <h6>{{heading}}</h6>
+{{/with}}
+
+{{#with (data "specimens")}}
+  <h6 class="mzp-u-title-md">H6 with the utility class to make it a medium title.</h6>
 {{/with}}


### PR DESCRIPTION
## Description

Add atomic heading utility classes.
- also change all instances of text-display to text-title

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

See #297 






