### PR TITLE
Implement sticky navigation (Fixes #560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Features
 
-* **utility:** Add title size utility classes (#297)
-  ** rename `text-display-` to `text-title-`, keep `text-display-` as an alias
+* **js:** Implement sticky scrolling behaviour for navigation component as an opt-in feature (#560).
+* **utility:** Add title size utility classes. Rename `text-display-` to `text-title-`, keep `text-display-` as an alias (#297).
 * **component:** Updates to emphasis box, with additional documentation and usage guidelines.
-* **css:** Notification bar updates; use border-box (#549), fix image replacement bug, add focus styles, tweak spacing.
+* **css:** Notification bar updates; use border-box, fix image replacement bug, add focus styles, tweak spacing (#549).
 
 ## Migration Tips
-  * Find and replace `text-display-` to `text-title-`
+
+* Add a class of `mzp-is-sticky` to `mzp-c-navigation` to opt-in to sticky navigation.
+* Find and replace `text-display-` to `text-title-`.
 
 # 11.0.1
 

--- a/src/assets/js/protocol/protocol-navigation.js
+++ b/src/assets/js/protocol/protocol-navigation.js
@@ -7,14 +7,138 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
     var Mzp = {};
 }
 
-(function() {
+(function(Mzp) {
     'use strict';
 
     var Navigation = {};
-    var navItemsLists;
+    var _navElem;
+    var _navItemsLists;
     var _options = {
         onNavOpen: null,
         onNavClose: null
+    };
+    var _ticking = false;
+    var _lastKnownScrollPosition = 0;
+    var _animationFrameID = null;
+    var _stickyScrollOffset = 300;
+    var _wideBreakpoint = '768px';
+    var _tallBreakpoint = '600px';
+    var _mqLargeNav;
+    var _viewport = document.getElementsByTagName('html')[0];
+
+    /**
+     * Does the viewport meet the minimum width and height
+     * requirements for sticky behaviour?
+     * @returns {Boolean}
+     */
+    Navigation.isLargeViewport = function() {
+        return _mqLargeNav.matches;
+    };
+
+    /**
+     * Feature detect for sticky navigation
+     * @returns {Boolean}
+     */
+    Navigation.supportsSticky = function() {
+        if (typeof Mzp.Supports !== 'undefined') {
+            return Mzp.Supports.matchMedia &&
+                   Mzp.Supports.classList &&
+                   Mzp.Supports.requestAnimationFrame &&
+                   Mzp.Supports.cssFeatureQueries &&
+                   CSS.supports('position', 'sticky');
+        } else {
+            return false;
+        }
+    };
+
+    /**
+     * Scroll event listener. No computationally expensive
+     * operations such as DOM modifications should happen
+     * here. Instead we throttle using `requestAnimationFrame`.
+     */
+    Navigation.onScroll = function() {
+        if (!_ticking) {
+            _animationFrameID = window.requestAnimationFrame(Navigation.checkScrollPosition);
+            _ticking = true;
+        }
+    };
+
+    /**
+     * Create sticky state for the navigation.
+     */
+    Navigation.createSticky = function() {
+        _viewport.classList.add('mzp-has-sticky-navigation');
+        _animationFrameID = window.requestAnimationFrame(Navigation.checkScrollPosition);
+        window.addEventListener('scroll', Navigation.onScroll, false);
+    };
+
+    /**
+     * Destroy sticky state for the navigation.
+     */
+    Navigation.destroySticky = function() {
+        _viewport.classList.remove('mzp-has-sticky-navigation');
+        _navElem.classList.remove('mzp-is-scrolling');
+        _navElem.classList.remove('mzp-is-hidden');
+        _lastKnownScrollPosition = 0;
+
+        if (_animationFrameID) {
+            window.cancelAnimationFrame(_animationFrameID);
+        }
+        window.removeEventListener('scroll', Navigation.onScroll, false);
+    };
+
+    /**
+     * Initialize sticky state for the navigation.
+     * Uses `matchMedia` to determine if conditions
+     * for sticky navigation are satisfied.
+     */
+    Navigation.initSticky = function() {
+        _mqLargeNav = matchMedia('(min-width: ' + _wideBreakpoint + ') and (min-height: ' + _tallBreakpoint + ')');
+
+        _mqLargeNav.addListener(function(mq) {
+            if (mq.matches) {
+                Navigation.createSticky();
+            } else {
+                Navigation.destroySticky();
+            }
+        });
+
+        if (Navigation.isLargeViewport()) {
+            Navigation.createSticky();
+        }
+    };
+
+    /**
+     * Implements sticky navigation behaviour as
+     * user scrolls up and down the viewport.
+     */
+    Navigation.checkScrollPosition = function() {
+        // add tyling for when scrolling the viewport
+        if (window.scrollY > 0) {
+            _navElem.classList.add('mzp-is-scrolling');
+        } else {
+            _navElem.classList.remove('mzp-is-scrolling');
+        }
+
+        // scrolling down
+        if (window.scrollY > _lastKnownScrollPosition) {
+            // hide the sticky nav shortly after scrolling down the viewport.
+            if (window.scrollY > _stickyScrollOffset) {
+                // if there's a menu currently open, close it.
+                if (typeof Mzp.Menu !== 'undefined') {
+                    Mzp.Menu.close();
+                }
+
+                _navElem.classList.add('mzp-is-hidden');
+            }
+        }
+        // scrolling up
+        else {
+            _navElem.classList.remove('mzp-is-hidden');
+        }
+
+        _lastKnownScrollPosition = window.scrollY;
+        _ticking = false;
     };
 
     /**
@@ -50,8 +174,8 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
      * Set initial ARIA navigation states.
      */
     Navigation.setAria = function() {
-        for (var i = 0; i < navItemsLists.length; i++) {
-            navItemsLists[i].setAttribute('aria-expanded', false);
+        for (var i = 0; i < _navItemsLists.length; i++) {
+            _navItemsLists[i].setAttribute('aria-expanded', false);
         }
     };
 
@@ -59,8 +183,8 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
      * Bind navigation event handlers.
      */
     Navigation.bindEvents = function() {
-        navItemsLists = document.querySelectorAll('.mzp-c-navigation-items');
-        if (navItemsLists.length > 0) {
+        _navItemsLists = document.querySelectorAll('.mzp-c-navigation-items');
+        if (_navItemsLists.length > 0) {
             var navButtons = document.querySelectorAll('.mzp-c-navigation-menu-button');
             for (var i = 0; i < navButtons.length; i++) {
                 navButtons[i].addEventListener('click', Navigation.onClick, false);
@@ -83,8 +207,22 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
         }
 
         Navigation.bindEvents();
+
+        /**
+         * Init (optional) sticky navigation.
+         * If there are multiple navigation organisms on a single page,
+         * assume only the first (and hence top-most) instance can and
+         * will be sticky.
+         */
+        _navElem = document.querySelector('.mzp-c-navigation');
+
+        if (_navElem && _navElem.classList.contains('mzp-is-sticky')) {
+            if (Navigation.supportsSticky()) {
+                Navigation.initSticky();
+            }
+        }
     };
 
     window.Mzp.Navigation = Navigation;
 
-})();
+})(window.Mzp);

--- a/src/assets/js/protocol/protocol-supports.js
+++ b/src/assets/js/protocol/protocol-supports.js
@@ -22,6 +22,22 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
     }());
 
     /**
+    * requestAnimationFrame
+    * @return {Boolean} boolean value for if the browser supports requestAnimationFrame
+    */
+    Supports.requestAnimationFrame = (function() {
+        return 'requestAnimationFrame' in window;
+    }());
+
+    /**
+    * cssFeatureQueries
+    * @return {Boolean} boolean value for if the browser supports cssFeatureQueries
+    */
+    Supports.cssFeatureQueries = (function() {
+        return typeof CSS !== 'undefined' && typeof CSS.supports !== 'undefined';
+    }());
+
+    /**
     * classList
     * @return {Boolean} boolean value for if the browser supports classList
     */

--- a/src/assets/sass/protocol/components/_navigation.scss
+++ b/src/assets/sass/protocol/components/_navigation.scss
@@ -51,6 +51,34 @@
 }
 
 /* -------------------------------------------------------------------------- */
+// Sticky navigation styles
+
+@supports (position: sticky) {
+    html.mzp-has-sticky-navigation {
+        .mzp-c-navigation.mzp-is-sticky {
+            @include transition(transform 300ms ease-in-out);
+            left: 0;
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+
+            &.mzp-is-scrolling {
+                box-shadow: 0 0 5px 1px rgba(9, 32, 77, .12);
+            }
+
+            &.mzp-is-hidden {
+                @include transform(translate(0, -100%));
+            }
+        }
+
+        // add scroll-offset for anchor links.
+        .mzp-is-anchor-link {
+            scroll-margin-top: 120px; /* stylelint-disable-line property-no-unknown */
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------- */
 // Mozilla Logo
 
 .mzp-c-navigation-logo {

--- a/src/assets/sass/protocol/components/_navigation.scss
+++ b/src/assets/sass/protocol/components/_navigation.scss
@@ -63,11 +63,12 @@
             z-index: 1000;
 
             &.mzp-is-scrolling {
-                box-shadow: 0 0 5px 1px rgba(9, 32, 77, .12);
+                // Shadow colors are equivalent to $color-ink-90, $color-blue-90, $color-ink-90
+                box-shadow: 0 0 6px 1px rgba(29, 17, 51, .04), 0 0 8px 2px rgba(9, 32, 77, .12), 0 0 5px -3px rgba(29, 17, 51, .12);
             }
 
             &.mzp-is-hidden {
-                @include transform(translate(0, -100%));
+                @include transform(translate(0, -110%));
             }
         }
 

--- a/src/pages/demos/navigation.hbs
+++ b/src/pages/demos/navigation.hbs
@@ -5,7 +5,7 @@ styles:
   - navigation
 ---
 
-{{#embed "patterns.organisms.navigation.navigation" logo=true download=true id="navigation-demo"}}
+{{#embed "patterns.organisms.navigation.navigation" logo=true download=true sticky=true id="navigation-demo"}}
   {{#content "menu"}}
     {{#embed "patterns.molecules.menu.menu"}}
       {{#content "content"}}
@@ -497,8 +497,10 @@ styles:
 
     <div class="mzp-l-content">
       <article class="mzp-c-article">
+        <h2 id="section-heading" class="mzp-is-anchor-link">Veniam saperet</h2>
+
         <ol class="mzp-u-list-styled">
-          <li id="one">
+          <li>
             <p><strong>Veniam saperet</strong> corrumpit in has. Vim movet doming concludaturque an,
             elitr libris sit ei. Ut vel probo viris, qui persius scripserit
             repudiandae ut.</p>
@@ -508,7 +510,7 @@ styles:
               tantas nostrud, ea docendi blandit nec, vis id aeterno intellegat
               accommodare.</p>
           </li>
-          <li id="two">
+          <li>
             <p><strong>Eum doming</strong> forensibus at. Has an justo aperiam evertitur. Sea dolor
             nullam scripta ea, possit appareat pericula ea pro.</p>
             <p>Suavitate comprehensam ea nam, tacimates vituperata vim te. Usu in
@@ -517,7 +519,7 @@ styles:
               tantas nostrud, ea docendi blandit nec, vis id aeterno intellegat
               accommodare.</p>
           </li>
-          <li id="three">
+          <li>
             <p><strong>Mei sint</strong> consequuntur ei, est ut quando omittam, possim efficiendi sed id.</p>
             <p>Suavitate comprehensam ea nam, tacimates vituperata vim te. Usu in
               laboramus maiestatis definitionem, noster complectitur at vim. Qui ut
@@ -532,6 +534,69 @@ styles:
           doctus sententiae percipitur, vivendum mediocritatem ea eum. Eu cum
           tantas nostrud, ea docendi blandit nec, vis id aeterno intellegat
           accommodare.</p>
+
+        <p>Et pri porro ceteros tacimates, est at option dignissim intellegat.
+          Tollit fuisset urbanitas nec no, feugiat sensibus an mea, nominavi
+          <a href="#">interpretaris te eam</a>. No virtute imperdiet pro, ut pro
+          sint viderer philosophia. Torquatos necessitatibus sit in, ad sit summo
+          molestie adolescens, liber oratio veniam in per.</p>
+
+        <p>No qui option timeam impetus, dolor salutatus pertinacia ea eam, at
+          inani summo democritum vis. Est id quis admodum tractatos, ei ius
+          eligendi platonem, maiorum eleifend et eam. Ei odio cetero voluptatibus
+          ius, prima blandit epicurei te cum. Illud verterem principes vix te,
+          te pro tale dicit. Debitis senserit no quo, vix et altera mollis
+          scaevola. Sit no soleat aperiri vituperata. Qui <a href="#">id placerat
+          euripidis</a>.</p>
+
+        <h2>Tale augue splendide in quo</h2>
+
+        <ul class="mzp-u-list-styled">
+          <li>Diam repudiare vel cu.</li>
+          <li>Meis augue regione mei at, <a href="#">ornatus epicurei</a> ius eu.</li>
+          <li>Nam nemore consulatu et, alia hinc ex pro. Sumo rebum ea his, cu
+            possit nostro interesset has. Vide mollis eleifend cum cu, nec an
+            aeque simul concludaturque.</li>
+          <li>Eius omnium appellantur eam ne, pri an unum appellantur. Cu ius tota
+            posse dicant, autem quodsi evertitur eum no.</li>
+        </ul>
+
+        <h3>Affert graeco eum id</h3>
+
+        <p>An quo epicurei placerat repudiare. Ut cetero molestiae mei, per id
+          efficiantur consectetuer, in paulo repudiare vim. Inermis delectus
+          adipiscing eos ad, sed ei graeci eleifend intellegam. Eu abhorreant
+          neglegentur duo, eu mei nisl mundi.</p>
+
+        <ol class="mzp-u-list-styled">
+          <li>
+            <p><strong>Veniam saperet</strong> corrumpit in has. Vim movet doming concludaturque an,
+            elitr libris sit ei. Ut vel probo viris, qui persius scripserit
+            repudiandae ut.</p>
+            <p>Suavitate comprehensam ea nam, tacimates vituperata vim te. Usu in
+              laboramus maiestatis definitionem, noster complectitur at vim. Qui ut
+              doctus sententiae percipitur, vivendum mediocritatem ea eum. Eu cum
+              tantas nostrud, ea docendi blandit nec, vis id aeterno intellegat
+              accommodare.</p>
+          </li>
+          <li>
+            <p><strong>Eum doming</strong> forensibus at. Has an justo aperiam evertitur. Sea dolor
+            nullam scripta ea, possit appareat pericula ea pro.</p>
+            <p>Suavitate comprehensam ea nam, tacimates vituperata vim te. Usu in
+              laboramus maiestatis definitionem, noster complectitur at vim. Qui ut
+              doctus sententiae percipitur, vivendum mediocritatem ea eum. Eu cum
+              tantas nostrud, ea docendi blandit nec, vis id aeterno intellegat
+              accommodare.</p>
+          </li>
+          <li>
+            <p><strong>Mei sint</strong> consequuntur ei, est ut quando omittam, possim efficiendi sed id.</p>
+            <p>Suavitate comprehensam ea nam, tacimates vituperata vim te. Usu in
+              laboramus maiestatis definitionem, noster complectitur at vim. Qui ut
+              doctus sententiae percipitur, vivendum mediocritatem ea eum. Eu cum
+              tantas nostrud, ea docendi blandit nec, vis id aeterno intellegat
+              accommodare.</p>
+          </li>
+        </ol>
       </article>
     </div>
   </main>

--- a/src/patterns/organisms/navigation/navigation.hbs
+++ b/src/patterns/organisms/navigation/navigation.hbs
@@ -12,11 +12,13 @@ notes: |
   - Navigation can be initialized using `Mzp.Navigation.init(options)`, where `options` is an Object with the following properties.
       - `onNavOpen` [Function] A callback when the small screen navigation icon is clicked to open (optional).
       - `onNavClose` [Function] A callback when the small screen navigation icon is clicked to close (optional).
+  - Navigation can opt-in to sticky scroll behaviour by adding the class `mzp-is-sticky`.
+      - Sticky behaviour will only be applied to viewports that are wider than `$mq-md` and taller than `$mq-tall`.
 links:
     Navigation Demo: /demos/navigation.html
 ---
 
-<div class="mzp-c-navigation">
+<div class="mzp-c-navigation {{#if sticky}}mzp-is-sticky{{/if}}">
   <div class="mzp-c-navigation-l-content">
     <div class="mzp-c-navigation-container">
       <button class="mzp-c-navigation-menu-button{{#if button-label}} has-label{{/if}}" type="button" aria-controls="{{ id }}">{{#if button-label}}{{ button-label }}{{ else }}Menu{{/if}}</button>

--- a/tests/unit/protocol-navigation.js
+++ b/tests/unit/protocol-navigation.js
@@ -17,6 +17,8 @@ describe('protocol-navigation.js', function() {
                     '</div>' +
                   '</div>';
         document.documentElement.insertAdjacentHTML('beforeend', nav);
+
+        spyOn(Mzp.Navigation, 'supportsSticky').and.returnValue(true);
     });
 
     afterEach(function(){
@@ -54,6 +56,40 @@ describe('protocol-navigation.js', function() {
             expect(menu.classList.contains('mzp-is-open')).toBeFalsy();
             expect(button.classList.contains('mzp-is-active')).toBeFalsy();
             expect(options.close).toHaveBeenCalled();
+        });
+    });
+
+    describe('sticky behaviour', function() {
+
+        it('should not initialize sticky behaviour by default', function() {
+            spyOn(Mzp.Navigation, 'initSticky');
+
+            Mzp.Navigation.init();
+            expect(Mzp.Navigation.initSticky).not.toHaveBeenCalled();
+        });
+
+        it('should initialize sticky behaviour when specified', function() {
+            document.querySelector('.mzp-c-navigation').classList.add('mzp-is-sticky');
+            spyOn(Mzp.Navigation, 'initSticky');
+
+            Mzp.Navigation.init();
+            expect(Mzp.Navigation.initSticky).toHaveBeenCalled();
+        });
+
+        it('should create sticky behaviour for large viewports', function() {
+            document.querySelector('.mzp-c-navigation').classList.add('mzp-is-sticky');
+            spyOn(Mzp.Navigation, 'isLargeViewport').and.returnValue(true);
+            spyOn(Mzp.Navigation, 'createSticky');
+            Mzp.Navigation.init();
+            expect(Mzp.Navigation.createSticky).toHaveBeenCalled();
+        });
+
+        it('should not create sticky behaviour for small viewports', function() {
+            document.querySelector('.mzp-c-navigation').classList.add('mzp-is-sticky');
+            spyOn(Mzp.Navigation, 'isLargeViewport').and.returnValue(false);
+            spyOn(Mzp.Navigation, 'createSticky');
+            Mzp.Navigation.init();
+            expect(Mzp.Navigation.createSticky).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
## Description

Implement sticky scrolling behaviour for navigation component as an opt-in feature

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#560

### Testing
Demo: https://demo2--mozilla-protocol.netlify.com/demos/navigation.html

- [x] Navigation should be sticky only when opt-in is specifically given.
- [x] Navigation should only be sticky when large viewport requirements are met.
- [x] Link clicks should still function as expected when nav is sticky.
- [x] Scrolling part way down from the top of the viewport should hide the sticky nav.
- [x] Scrolling back up the viewport should immediately show the sticky nav again.
- [x] Resizing the viewport between large/small screen sizes should not introduce bugs or break expected behaviour.
- [x] Sticky nav should still be accessible via keyboard when hidden (focus should bring it back into view).