### PR TITLE
Tweak form error styles (#508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **css:** Tweak form error styles (#508)
 * **css:** (breaking) Add styled text inputs (#430)
 * **css:** Button style updates. (#429)
 * **css:** Add styled select drop downs (#435)

--- a/src/assets/sass/protocol/base/elements/_forms.scss
+++ b/src/assets/sass/protocol/base/elements/_forms.scss
@@ -405,28 +405,23 @@ label {
 // Errors
 
 .mzp-c-form-errors {
-    background: $color-yellow-50;
-    border: 2px solid $color-yellow-60;
-    color: $color-black;
-    margin: 0 0 1em;
-    padding: $spacing-sm $spacing-md;
+    @include light-links;
+    background-color: $form-red;
+    border-radius: $field-border-radius;
+    color: $color-white;
+    padding: $spacing-sm;
+    margin-bottom: $spacing-xl;
 
-    ul {
+    :last-child {
         margin-bottom: 0;
     }
 
     li {
-        margin-bottom: .5em;
+        margin-bottom: $label-v-spacing;
     }
-}
 
-.mzp-is-error {
-    color: $form-red;
-
-    select,
     input[type='checkbox'],
     input[type='radio'] {
         box-shadow: 0 0 0 2px $color-red-50;
     }
-
 }

--- a/src/patterns/atoms/forms/errors.hbs
+++ b/src/patterns/atoms/forms/errors.hbs
@@ -17,10 +17,10 @@ order: 10
 
 <fieldset>
   <div class="mzp-is-error">
-    <label for="email">
+    <label for="email-e">
       E-mail <em class="mzp-c-fieldnote">Required</em>
     </label>
-    <input type="email" name="email" id="email" placeholder="you@example.com">
+    <input type="email" name="email" id="email-e" placeholder="you@example.com">
   </div>
 
   <div class="mzp-is-error">

--- a/src/patterns/atoms/forms/errors.hbs
+++ b/src/patterns/atoms/forms/errors.hbs
@@ -1,13 +1,9 @@
 ---
 name: Errors
 description: Display a summary list of form errors at the top of the form. Indicate individual field errors with the `mzp-is-error` class on the field’s parent element.
-notes: |
-  - These colors are temporary; we'll update when we expand the palette in the very near future.
 tips: |
   - Error messages should be short and simple. They should indicate what the user needs to do to resolve the error, not simply state that an error occurred. Bad example: “Invalid e-mail.” Good example: “Provide a complete e-mail address, like ‘yourname@example.com’.”
 order: 10
-labels:
-  - inprogress
 ---
 
 <div class="mzp-c-form-errors">
@@ -28,8 +24,8 @@ labels:
   </div>
 
   <div class="mzp-is-error">
-    <label for="language">Language</label>
-    <select name="language" id="language" required aria-required="true">
+    <label for="language-e">Language</label>
+    <select name="language" id="language-e" required aria-required="true">
       <option value="">- select -</option>
     {{#each (data "items")}}
       <option value="{{lang-code}}">{{language}}</option>
@@ -38,24 +34,24 @@ labels:
   </div>
 
   <div class="mzp-is-error">
-    <label for="username">
+    <label for="username-e">
       Username
       <span class="mzp-c-fieldnote">Must be at least 6 characters.</span>
     </label>
-    <input type="text" id="username" name="username" value="bub">
+    <input type="text" id="username-e" name="username" value="bub">
   </div>
   <div class="mzp-is-error">
-    <label for="password">
+    <label for="password-e">
       Password
       <span class="mzp-c-fieldnote">Must be at least 8 characters and contain at least one numeral. Passwords are case sensitive. This is an example of a pretty lengthy note.</span>
     </label>
-    <input type="password" id="password" name="password">
+    <input type="password" id="password-e" name="password">
   </div>
 
-  <p class="mzp-is-error">
-    <label for="accept" class="mzp-u-inline">
-      <input type="checkbox" id="accept" name="accept" required aria-required="true">
+  <div class="mzp-is-error">
+    <label for="accept-e">
+      <input type="checkbox" id="accept-e" name="accept" required aria-required="true">
       I accept the terms and conditions.
     </label>
-  </p>
+  </div>
 </fieldset>


### PR DESCRIPTION
## Description

Small tweaks to form error styles:
- use new form variables
- add unique IDs to error demo

---

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Part of #508

### Testing

http://localhost:3000/patterns/atoms/forms.html#errors
http://localhost:3000/demos/newsletter.html
