### PR TITLE
center the notification bar in larger viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Bug Fixes
 
 * **css:** Embiggen the modal close button (#557)
+* **css:** Center the notification bar in larger viewports
 
 ## Migration Tips
 

--- a/src/assets/sass/protocol/components/_notification-bar.scss
+++ b/src/assets/sass/protocol/components/_notification-bar.scss
@@ -20,6 +20,7 @@
     text-align: center;
 
     @media #{$mq-sm} {
+        margin: $layout-xs auto 0;
         max-width: $content-md;
     }
 


### PR DESCRIPTION
## Description

When updating the notification bar in https://github.com/mozilla/protocol/pull/553/ I left out a rule to center it in the viewport when it's non-sticky. D'oh!

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

