### PR TITLE
Button line-height bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * **css:** Embiggen the modal close button (#557)
 * **css:** Center the notification bar in larger viewports
+* **css:** Button line-height bug fix
 
 ## Migration Tips
 

--- a/src/assets/sass/protocol/components/_button.scss
+++ b/src/assets/sass/protocol/components/_button.scss
@@ -82,6 +82,7 @@ a.mzp-c-button {
     cursor: pointer;
     display: inline-block;
     font-weight: bold;
+    line-height: $text-body-line-height;
     padding: 6px $spacing-lg;
     text-decoration: none !important;  /* stylelint-disable-line declaration-no-important */
 


### PR DESCRIPTION
## Description

Makes `button` and `a` elements of class `mzp-c-button` the same height

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

N/a

### Testing

http://localhost:3000/patterns/atoms/buttons.html
