### PR TITLE
Switch to negative text indent for image replacement (#519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Bug Fixes
 
+* **css:** Switch to negative text indent for image replacement (#519)
 * **css:** Embiggen the modal close button (#557)
 * **css:** Center the notification bar in larger viewports
 * **css:** Button line-height bug fix

--- a/src/assets/sass/protocol/includes/_mixins.scss
+++ b/src/assets/sass/protocol/includes/_mixins.scss
@@ -159,8 +159,9 @@
 
 // not the most up to date method, but works in IE7
 @mixin image-replaced {
+    direction: ltr;
     overflow: hidden;
-    text-indent: 120%; // extra 20% to account for fancy fonts that may overhang
+    text-indent: -9999px;
     white-space: nowrap;
 }
 

--- a/src/patterns/molecules/notification-bar/notification-bar.hbs
+++ b/src/patterns/molecules/notification-bar/notification-bar.hbs
@@ -62,7 +62,7 @@ notes: |
 
   <li>
     <aside class="mzp-c-notification-bar">
-      <button class="mzp-c-notification-bar-button" type="button"Close notification></button>
+      <button class="mzp-c-notification-bar-button" type="button">Close notification</button>
       <p>Default.</p>
     </aside>
   </li>

--- a/src/patterns/molecules/notification-bar/notification-bar.hbs
+++ b/src/patterns/molecules/notification-bar/notification-bar.hbs
@@ -33,21 +33,21 @@ notes: |
 <ul class="notification-demo-list">
   <li>
     <aside class="mzp-c-notification-bar mzp-t-success">
-      <button class="mzp-c-notification-bar-button" type="button"></button>
+      <button class="mzp-c-notification-bar-button" type="button">Close notification</button>
       <p>Great! You clicked the thing!</p>
     </aside>
   </li>
 
   <li>
     <aside class="mzp-c-notification-bar mzp-t-warning">
-      <button class="mzp-c-notification-bar-button" type="button"></button>
+      <button class="mzp-c-notification-bar-button" type="button">Close notification</button>
       <p>Warning, you're about to do something bad!</p>
     </aside>
   </li>
 
   <li>
     <aside class="mzp-c-notification-bar mzp-t-error">
-      <button class="mzp-c-notification-bar-button" type="button"></button>
+      <button class="mzp-c-notification-bar-button" type="button">Close notification</button>
       <p>Whoops. You deleted something.</p>
       <a href="#" class="mzp-c-notification-bar-cta">Undo this action?</a>
     </aside>
@@ -55,14 +55,14 @@ notes: |
 
   <li>
     <aside class="mzp-c-notification-bar mzp-t-click">
-      <button class="mzp-c-notification-bar-button" type="button"></button>
+      <button class="mzp-c-notification-bar-button" type="button">Close notification</button>
       <p><a href="#" class="mzp-c-notification-bar-cta">Click this thing</a></p>
     </aside>
   </li>
 
   <li>
     <aside class="mzp-c-notification-bar">
-      <button class="mzp-c-notification-bar-button" type="button"></button>
+      <button class="mzp-c-notification-bar-button" type="button"Close notification></button>
       <p>Default.</p>
     </aside>
   </li>


### PR DESCRIPTION
## Description

Switch to negative text indent for image replacement

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #519
See also https://github.com/mozilla/bedrock/issues/8084

### Testing

Components with image replacements:

- footer
- menu
- modal
- navigation
- notification bar
