### PR TITLE
Add button container and alignment options (#580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **css:** Add button container and alignment options (#580)
 * **css:** Update form spacing and add form layout components (#508)
 * **css:** Add form dark theme (#508)
 * **css:** Add styled checkboxes and radio buttons (#439)

--- a/src/assets/sass/protocol/components/_button.scss
+++ b/src/assets/sass/protocol/components/_button.scss
@@ -267,14 +267,14 @@ a.mzp-c-button {
 
 .mzp-c-button-download-container {
     text-align: center;
-    margin-bottom: 24px;
+    margin-bottom: $field-v-spacing;
     display: inline-block;
 }
 
 .mzp-c-button-download-privacy-link {
     @include text-body-xs;
     display: block;
-    margin-top: $spacing-md;
+    margin-top: $info-v-spacing;
 
     a:link,
     a:visited {

--- a/src/assets/sass/protocol/components/forms/_button-container.scss
+++ b/src/assets/sass/protocol/components/forms/_button-container.scss
@@ -1,0 +1,105 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../includes/lib';
+@import '../../includes/forms/lib';
+
+.mzp-c-button-container {
+    display: flex;
+    flex-wrap: wrap;
+    margin-bottom: $field-v-spacing;
+
+    // no bottom spacing if last thing in form
+
+    .mzp-c-form > .mzp-c-button-container:last-child {
+        margin-bottom: 0;
+    }
+
+    // align start
+    &.mzp-l-h-start {
+        justify-content: flex-start;
+        @include bidi(((text-align, left, right),));
+    }
+
+    // align end
+    &.mzp-l-h-end {
+        justify-content: flex-end;
+        @include bidi(((text-align, right, left),));
+    }
+
+    // align space between
+    &.mzp-l-h-between {
+        justify-content: space-between;
+        text-align: center;
+    }
+
+    // align center
+    &.mzp-l-h-center {
+        justify-content: center;
+        text-align: center;
+    }
+
+    // full width
+    &.mzp-l-strech {
+        align-items: stretch;
+
+        .mzp-c-button {
+            flex-grow: 1;
+        }
+    }
+
+    // full width
+    &.mzp-l-column {
+        text-align: center;
+
+        .mzp-c-button {
+            width: 100%;
+
+            & + .mzp-c-button {
+                @include bidi(((margin-left, 0, margin-right, 0),));
+                margin-top: $field-v-spacing;
+            }
+        }
+    }
+
+    // mobile only full width
+    @media (max-width: #{$screen-md - 1px}) {
+        &.mzp-l-column-on-xs-sm {
+            text-align: center;
+
+            .mzp-c-button {
+                width: 100%;
+
+                & + .mzp-c-button {
+                    @include bidi(((margin-left, 0, margin-right, 0),));
+                    margin-top: $field-v-spacing;
+                }
+            }
+        }
+    }
+
+    @media #{$mq-lg} {
+        // desktop only reverse order
+        &.mzp-l-reversed-on-lg-xl {
+            flex-direction: row-reverse;
+
+            .mzp-c-button + .mzp-c-button {
+                margin-right: $field-h-spacing;
+                @include bidi(((margin-left, 0, margin-right, 0),));
+            }
+        }
+    }
+
+    // put spacing between multiple buttons
+    .mzp-c-button + .mzp-c-button {
+        @include bidi(((margin-left, $field-h-spacing, margin-right, 0),));
+    }
+}
+
+.mzp-c-button-info {
+    @include form-info;
+    @include text-body-xs;
+    width: 100%;
+    padding-top: $info-v-spacing;
+}

--- a/src/assets/sass/protocol/protocol-extra.scss
+++ b/src/assets/sass/protocol/protocol-extra.scss
@@ -13,6 +13,7 @@ $image-path: '../img' !default;
 @import 'components/call-out';
 @import 'components/emphasis-box';
 @import 'components/feature-card';
+@import 'components/forms/button-container';
 @import 'components/forms/choice';
 @import 'components/forms/field';
 @import 'components/forms/form';

--- a/src/patterns/molecules/forms/collection.yml
+++ b/src/patterns/molecules/forms/collection.yml
@@ -1,2 +1,1 @@
-name: Forms
-title: Forms
+

--- a/src/patterns/molecules/forms/container.hbs
+++ b/src/patterns/molecules/forms/container.hbs
@@ -1,0 +1,70 @@
+---
+name: Button Container
+description: |
+  The `.mzp-c-button-container` class can be used around a group of buttons. It applies a flexbox context and the default   form spacing. Modifier classes can then be added to change the layout.
+order: 1
+---
+<div class="mzp-c-form">
+  <h2 class="mzp-u-title-xs">Default</h2>
+  <div class="mzp-c-button-container">
+    {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+    {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+    <p class="mzp-c-button-info">More information.</p>
+  </div>
+
+  <h2 class="mzp-u-title-xs"><code>mzp-l-h-end</code> Align buttons to the right</h2>
+  <div class="mzp-c-button-container mzp-l-h-end">
+    {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+    {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+    <p class="mzp-c-button-info">More information.</p>
+  </div>
+
+  <h2 class="mzp-u-title-xs"><code>mzp-l-h-center</code> Align buttons in the center</h2>
+  <div class="mzp-c-button-container mzp-l-h-center">
+    {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+    {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+    <p class="mzp-c-button-info">More information.</p>
+  </div>
+
+  <h2 class="mzp-u-title-xs"><code>mzp-l-h-between</code> Space buttons appart evenly, starting from the edges of the container</h2>
+  <div class="mzp-c-button-container mzp-l-h-between">
+    {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+    {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+    <p class="mzp-c-button-info">More information.</p>
+  </div>
+
+  <h2 class="mzp-u-title-xs"><code>mzp-l-column</code> Stack the buttons in one column</h2>
+  <div class="mzp-c-button-container mzp-l-column">
+    {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+    {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+    <p class="mzp-c-button-info">More information.</p>
+  </div>
+
+  <h2 class="mzp-u-title-xs"><code>mzp-l-column-xs-sm</code> Stack the buttons in one column on xs and sm screens</h2>
+  <div class="mzp-c-button-container mzp-l-column-xs-sm">
+    {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+    {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+    <p class="mzp-c-button-info">More information.</p>
+  </div>
+
+  <h2 class="mzp-u-title-xs"><code>mzp-l-strech</code> Strech the buttons to fill the container</h2>
+  <div class="mzp-c-button-container mzp-l-strech mzp-l-h-center">
+    {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+    {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+    <p class="mzp-c-button-info">You can combine <code>mzp-l-strech</code> with <code>mzp-l-column-on-xs-sm</code> to switch to a single column on mobile.</p>
+  </div>
+
+  <h2 class="mzp-u-title-xs"><code>mzp-l-reversed-on-lg-xl</code> Reverse the button order on lg and xl screens</h2>
+  <div class="mzp-c-button-container mzp-l-reversed-on-lg-xl mzp-l-h-end">
+    {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+    {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+    <p class="mzp-c-button-info">More information.</p>
+  </div>
+
+  <h2 class="mzp-u-title-xs">Reversed buttons with a different alignment option</h2>
+  <div class="mzp-c-button-container mzp-l-reversed-on-lg-xl mzp-l-h-between">
+    {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+    {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+    <p class="mzp-c-button-info">More information.</p>
+  </div>
+</div>


### PR DESCRIPTION
## Description

Adds a button container component with some alignment options. Integrating work done by the SUMO team as part of their updates. 👏 

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #580

### Testing

We should consider how we want to indicate a class only applies at certain break points. I am currently using: `mzp-l-column-on-xs-sm`  and `mzp-l-reversed-on-lg-xl` but maybe we want to get fancier with capitalization `mzp-l-column-ON-xs-sm` or more explicit `mzp-l-column-mq-xs-sm` 🤷‍♀️ 

We should also consider if the layout classes should just be utility classes `mzp-u-h-start` since the block component uses identical classes.

http://localhost:3000/patterns/molecules/forms.html
