### PR TITLE
Add button container and alignment options (#580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **css:** Add button container and alignment options (#580)
 * **css:** Update form spacing and add form layout components (#508)
 * **css:** Add form dark theme (#508)
 * **css:** Add styled checkboxes and radio buttons (#439)

--- a/src/assets/sass/protocol/components/_button.scss
+++ b/src/assets/sass/protocol/components/_button.scss
@@ -267,14 +267,14 @@ a.mzp-c-button {
 
 .mzp-c-button-download-container {
     text-align: center;
-    margin-bottom: 24px;
+    margin-bottom: $field-v-spacing;
     display: inline-block;
 }
 
 .mzp-c-button-download-privacy-link {
     @include text-body-xs;
     display: block;
-    margin-top: $spacing-md;
+    margin-top: $info-v-spacing;
 
     a:link,
     a:visited {

--- a/src/assets/sass/protocol/components/forms/_button-container.scss
+++ b/src/assets/sass/protocol/components/forms/_button-container.scss
@@ -33,7 +33,7 @@
         margin-top: $info-v-spacing;
     }
 
-    &.mzp-t-stretch .mzp-c-button {
+    &.mzp-l-stretch .mzp-c-button {
         max-width: none;
     }
 
@@ -57,7 +57,7 @@
             justify-content: flex-end;
         }
 
-        &.mzp-t-stretch {
+        &.mzp-l-stretch {
             align-items: stretch;
 
             .mzp-c-button {

--- a/src/assets/sass/protocol/components/forms/_button-container.scss
+++ b/src/assets/sass/protocol/components/forms/_button-container.scss
@@ -33,6 +33,10 @@
         margin-top: $info-v-spacing;
     }
 
+    &.mzp-t-stretch .mzp-c-button {
+        max-width: none;
+    }
+
     @media #{$mq-sm} {
         @include bidi(((text-align, left, right),));
         align-items: start;
@@ -51,6 +55,14 @@
         &.mzp-l-align-end {
             @include bidi(((text-align, right, left),));
             justify-content: flex-end;
+        }
+
+        &.mzp-t-stretch {
+            align-items: stretch;
+
+            .mzp-c-button {
+                flex-grow: 1;
+            }
         }
     }
 }

--- a/src/assets/sass/protocol/components/forms/_button-container.scss
+++ b/src/assets/sass/protocol/components/forms/_button-container.scss
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../includes/lib';
+@import '../../includes/forms/lib';
+
+.mzp-c-button-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: $field-v-spacing;
+    text-align: center;
+
+    .mzp-c-button {
+        max-width: $content-xs;
+        width: 100%;
+    }
+
+    // no bottom spacing if it's the last thing in the form
+    .mzp-c-form > .mzp-c-button-container:last-child {
+        margin-bottom: 0;
+    }
+
+    // align center
+    &.mzp-l-align-center {
+        justify-content: center;
+        text-align: center;
+    }
+
+    // put spacing between multiple buttons
+    .mzp-c-button + .mzp-c-button {
+        margin-top: $info-v-spacing;
+    }
+
+    @media #{$mq-sm} {
+        @include bidi(((text-align, left, right),));
+        align-items: start;
+        justify-content: start;
+
+        .mzp-c-button {
+            width: auto;
+        }
+
+        .mzp-c-button + .mzp-c-button {
+            @include bidi(((margin-left, $field-h-spacing, margin-right, 0),));
+            margin-top: 0;
+        }
+
+        // align end
+        &.mzp-l-align-end {
+            @include bidi(((text-align, right, left),));
+            justify-content: flex-end;
+        }
+    }
+}
+
+.mzp-c-button-info {
+    @include form-info;
+    @include text-body-xs;
+    padding-top: $info-v-spacing;
+    width: 100%;
+}

--- a/src/assets/sass/protocol/protocol-extra.scss
+++ b/src/assets/sass/protocol/protocol-extra.scss
@@ -13,6 +13,7 @@ $image-path: '../img' !default;
 @import 'components/call-out';
 @import 'components/emphasis-box';
 @import 'components/feature-card';
+@import 'components/forms/button-container';
 @import 'components/forms/choice';
 @import 'components/forms/field';
 @import 'components/forms/form';

--- a/src/pages/demos/forms/button-alignment.hbs
+++ b/src/pages/demos/forms/button-alignment.hbs
@@ -37,10 +37,10 @@ styles:
 
     <hr>
 
-    <h2 class="mzp-u-title-xs"><code>mzp-t-stretch</code>: Stretch buttons to full width</h2>
+    <h2 class="mzp-u-title-xs"><code>mzp-l-stretch</code>: Stretch buttons to full width</h2>
     <p><strong>Only use this in narrow forms!</strong> This example shows two buttons but most forms will have only one.</p>
     <br>
-    <div class="mzp-c-button-container mzp-t-stretch">
+    <div class="mzp-c-button-container mzp-l-stretch">
       {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
       {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
       <p class="mzp-c-button-info">More information.</p>

--- a/src/pages/demos/forms/button-alignment.hbs
+++ b/src/pages/demos/forms/button-alignment.hbs
@@ -1,0 +1,40 @@
+---
+title: Button alignment
+layout: blank
+styles:
+  - forms
+---
+
+<section class="mzp-l-content">
+  <div class="mzp-c-form">
+
+    <h2 class="mzp-u-title-xs">Default. Buttons are aligned with text (left in LTR languages, right in RTL languages)</h2>
+    <br>
+    <div class="mzp-c-button-container">
+      {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+      {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+      <p class="mzp-c-button-info">More information.</p>
+    </div>
+
+    <hr>
+
+    <h2 class="mzp-u-title-xs"><code>mzp-l-align-end</code> Align buttons opposite to text (right in LTR languages, left in RTL languages)</h2>
+    <br>
+    <div class="mzp-c-button-container mzp-l-align-end">
+      {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+      {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+      <p class="mzp-c-button-info">More information.</p>
+    </div>
+
+    <hr>
+
+    <h2 class="mzp-u-title-xs"><code>mzp-l-align-center</code> Align buttons in the center</h2>
+    <br>
+    <div class="mzp-c-button-container mzp-l-align-center">
+      {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+      {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+      <p class="mzp-c-button-info">More information.</p>
+    </div>
+
+  </div>
+</section>

--- a/src/pages/demos/forms/button-alignment.hbs
+++ b/src/pages/demos/forms/button-alignment.hbs
@@ -7,8 +7,7 @@ styles:
 
 <section class="mzp-l-content">
   <div class="mzp-c-form">
-
-    <h2 class="mzp-u-title-xs">Default. Buttons are aligned with text (left in LTR languages, right in RTL languages)</h2>
+    <h2 class="mzp-u-title-xs">Default: Buttons are aligned with text (left in LTR languages, right in RTL languages)</h2>
     <br>
     <div class="mzp-c-button-container">
       {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
@@ -18,7 +17,7 @@ styles:
 
     <hr>
 
-    <h2 class="mzp-u-title-xs"><code>mzp-l-align-end</code> Align buttons opposite to text (right in LTR languages, left in RTL languages)</h2>
+    <h2 class="mzp-u-title-xs"><code>mzp-l-align-end</code>: Align buttons opposite to text (right in LTR languages, left in RTL languages)</h2>
     <br>
     <div class="mzp-c-button-container mzp-l-align-end">
       {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
@@ -28,9 +27,20 @@ styles:
 
     <hr>
 
-    <h2 class="mzp-u-title-xs"><code>mzp-l-align-center</code> Align buttons in the center</h2>
+    <h2 class="mzp-u-title-xs"><code>mzp-l-align-center</code>: Align buttons in the center</h2>
     <br>
     <div class="mzp-c-button-container mzp-l-align-center">
+      {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+      {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+      <p class="mzp-c-button-info">More information.</p>
+    </div>
+
+    <hr>
+
+    <h2 class="mzp-u-title-xs"><code>mzp-t-stretch</code>: Stretch buttons to full width</h2>
+    <p><strong>Only use this in narrow forms!</strong> This example shows two buttons but most forms will have only one.</p>
+    <br>
+    <div class="mzp-c-button-container mzp-t-stretch">
       {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
       {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
       <p class="mzp-c-button-info">More information.</p>

--- a/src/patterns/molecules/forms/collection.yml
+++ b/src/patterns/molecules/forms/collection.yml
@@ -1,2 +1,0 @@
-name: Forms
-title: Forms

--- a/src/patterns/molecules/forms/container.hbs
+++ b/src/patterns/molecules/forms/container.hbs
@@ -11,7 +11,7 @@ notes: |
   - Modifier classes for more layout options ([See the demo](/demos/forms/button-alignment.html)):
     - `mzp-l-align-end` aligns buttons opposite to the text (right in LTR languages, left in RTL languages).
     - `mzp-l-align-center` aligns buttons in the center.
-    - `mzp-t-stretch` makes buttons fill the width of the container. Multiple buttons will be stacked and full-width in smaller viewports, and appear inline and stretched in larger viewports ([See the demo](/demos/forms/button-alignment.html)). This option is best suited to narrow forms.
+    - `mzp-l-stretch` makes buttons fill the width of the container. Multiple buttons will be stacked and full-width in smaller viewports, and appear inline and stretched in larger viewports ([See the demo](/demos/forms/button-alignment.html)). This option is best suited to narrow forms.
   - Although the examples here show two buttons, most forms will have only one.
   - The `mzp-c-button-info` element adds a brief note in small text, typically for some kind of disclaimer or contextual information about the form being submitted. It usually appears below/after the buttons but in some cases could appear above/before.
 ---

--- a/src/patterns/molecules/forms/container.hbs
+++ b/src/patterns/molecules/forms/container.hbs
@@ -11,6 +11,9 @@ notes: |
   - Modifier classes for more layout options ([See the demo](/demos/forms/button-alignment.html)):
     - `mzp-l-align-end` aligns buttons opposite to the text (right in LTR languages, left in RTL languages).
     - `mzp-l-align-center` aligns buttons in the center.
+    - `mzp-t-stretch` makes buttons fill the width of the container. Multiple buttons will be stacked and full-width in smaller viewports, and appear inline and stretched in larger viewports ([See the demo](/demos/forms/button-alignment.html)). This option is best suited to narrow forms.
+  - Although the examples here show two buttons, most forms will have only one.
+  - The `mzp-c-button-info` element adds a brief note in small text, typically for some kind of disclaimer or contextual information about the form being submitted. It usually appears below/after the buttons but in some cases could appear above/before.
 ---
 <form class="mzp-c-form">
   <div class="mzp-c-button-container">

--- a/src/patterns/molecules/forms/container.hbs
+++ b/src/patterns/molecules/forms/container.hbs
@@ -1,0 +1,21 @@
+---
+name: Button Container
+description: |
+  The `.mzp-c-button-container` class can be used around a group of buttons. It applies a flexbox context and the default form spacing. Modifier classes can then be added to change the layout.
+order: 6
+links:
+  Alignment options: /demos/forms/button-alignment.html
+notes: |
+  - Buttons are stacked, centered, and full-width on small screens (though with a max-width of 300px).
+  - On larger screens, buttons are inline and aligned with the text direction (left in LTR languages, right in RTL languages)
+  - Modifier classes for more layout options ([See the demo](/demos/forms/button-alignment.html)):
+    - `mzp-l-align-end` aligns buttons opposite to the text (right in LTR languages, left in RTL languages).
+    - `mzp-l-align-center` aligns buttons in the center.
+---
+<form class="mzp-c-form">
+  <div class="mzp-c-button-container">
+    {{#embed "patterns.atoms.buttons.primary" }}{{#content "content"}}Primary{{/content}}{{/embed}}
+    {{#embed "patterns.atoms.buttons.secondary" }}{{#content "content"}}Secondary{{/content}}{{/embed}}
+    <p class="mzp-c-button-info">More information.</p>
+  </div>
+</form>

--- a/src/patterns/molecules/forms/set.hbs
+++ b/src/patterns/molecules/forms/set.hbs
@@ -1,10 +1,10 @@
 ---
 name: Field sets
 description: |
-  Field sets group form fields that are realted themeatically. Field-sets will often correspond to the fieldset element but not always.
+  Field sets group form fields that are related thematically. Field sets will often correspond to the `fieldset` element but not always.
 order: 2
 tips: |
-  - if you are using `<legends>` add the `mzp-c-form-subheading` class to make then behave as expected.
+  - if you are using `legend` elements add the `mzp-c-form-subheading` class to make them behave as expected.
 ---
 
 <form class="mzp-c-form">


### PR DESCRIPTION
## Description

Adds a button container element for forms, with a few alignment options. Also adds styling for the small button info text.

This is built on @stephaniehobson's work, which was in turn built on the work @kkellydesign did on SUMO.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#580 

### Testing

https://demo1--mozilla-protocol.netlify.app/patterns/molecules/forms.html#button-container
https://demo1--mozilla-protocol.netlify.app/demos/forms/button-alignment.html
