### PR TITLE
Icons page: update intro, de-list from nav

### DIFF
--- a/src/pages/fundamentals/icons.hbs
+++ b/src/pages/fundamentals/icons.hbs
@@ -1,16 +1,13 @@
 ---
-title: Icon Assets
-name: Icon Assets
-order: 5
+name: Icons
 labels:
   - inprogress
 ---
-<p>You can find the source icons in our <a href="https://github.com/mozilla/protocol-assets/tree/master/icons">protocol-assets</a> Github repo</p>
-<p>Todo:</p>
-<ul class="mzp-u-list-unstyled">
-  <li>add a background color selector for icons (white grey ink black)</li>
-  <li>add a icon size preview selector?</li>
-</ul>
+
+<p>This page lists all the icons in the <a href="https://github.com/mozilla/protocol-assets/tree/master/icons">protocol-assets</a> repository. However, the current set of icons is undergoing some changes and also needs better documentation on their usage.</p>
+
+<p>Icons shown here should be treated as <strong>outdated</strong> and you probably shouldn't use them. Proceed with caution.</p>
+
 <section class="icon-list">
   {{renderIcons (data "icons")}}
 </section>


### PR DESCRIPTION
The new icons page is super-handy but when folks on the brand and UX teams saw it, it sparked a bigger conversation about updating our icon set and writing some usage guidelines. The consensus was that we shouldn't encourage people to use the icons right now because they're going to change soon.

So this change doesn't delete the page but removes it from the side nav until we have a chance to refine the icons and improve documentation (you can still reach it directly if you know the URL) and adds a stronger warning.
