### PR TITLE
[fix #611] Reduce content container min-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+## Bug Fixes
+
+* **css:** Reduce content container min-width to avoid crawlbars (#611)
+
 # 12.0.0
 
 ## Features

--- a/src/assets/sass/protocol/base/elements/_sections.scss
+++ b/src/assets/sass/protocol/base/elements/_sections.scss
@@ -10,7 +10,7 @@
     @include clearfix;
     margin: 0 auto;
     max-width: $content-max;
-    min-width: $content-xs;
+    min-width: $content-xs - ($layout-xs * 2);
     padding: $layout-xs;
     position: relative;
 


### PR DESCRIPTION
## Description

The border-box declaration was removed in #595 but it probably shouldn't have been. This puts it back.

- [ ] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#611 

### Testing
Test responsiveness in small viewports. There should be no crawlbars as far down as 320px (smaller than that still crawls but that's OK).

http://localhost:3000/demos/content-containers.html
http://localhost:3000/demos/content-container-vis.html
