### PR TITLE
Navigation is max-content width on large screens (#615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+* **css:** Navigation is max-content width on large screens (#615)
 * **css:** Set text-align on image replacement mixin (#618)
 * **css:** Reduce content container min-width to avoid crawlbars (#611)
 

--- a/src/assets/sass/protocol/components/_navigation.scss
+++ b/src/assets/sass/protocol/components/_navigation.scss
@@ -26,17 +26,9 @@
     }
 
     .mzp-c-navigation-container {
+        @include clearfix;
         margin: 0 auto;
-        max-width: $content-max - ($layout-xs * 2);
-
-        @media #{$mq-md} {
-            @include clearfix;
-            max-width: $content-max - ($layout-lg * 2);
-        }
-
-        @media #{$mq-lg} {
-            max-width: $content-max - ($layout-xl * 2);
-        }
+        max-width: $content-max;
     }
 }
 


### PR DESCRIPTION
## Description

Navigation is max-content width on large screens (#615)

- [ ] I have documented this change in the design system.
- [X] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #615

### Testing

http://localhost:3000/demos/navigation.html on a screen over 1440px wide.
