### PR TITLE
Remove max-width from cards in card-layout (Fix #620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+* **css:** Remove max-width from cards in card-layout (#620)
 * **css:** Navigation is max-content width on large screens (#615)
 * **css:** Set text-align on image replacement mixin (#618)
 * **css:** Reduce content container min-width to avoid crawlbars (#611)

--- a/src/assets/sass/protocol/components/_card.scss
+++ b/src/assets/sass/protocol/components/_card.scss
@@ -126,7 +126,7 @@
     }
 
     @media #{$mq-sm} {
-        max-width: 450px;
+        max-width: $content-sm;
     }
 
     @media #{$mq-md} {
@@ -139,7 +139,7 @@
 
 .mzp-c-card.mzp-c-card-medium {
     @media #{$mq-sm} {
-        max-width: 610px;
+        max-width: $content-md;
     }
 }
 
@@ -157,7 +157,7 @@
     }
 
     @media #{$mq-sm} {
-        max-width: 930px;
+        max-width: $content-lg;
     }
 }
 
@@ -185,6 +185,6 @@
     }
 
     @media #{$mq-lg} {
-        max-width: 300px;
+        max-width: $content-xs;
     }
 }

--- a/src/assets/sass/protocol/templates/_card-layout.scss
+++ b/src/assets/sass/protocol/templates/_card-layout.scss
@@ -24,6 +24,13 @@
             ));
             width: calc(50% - (#{$spacing-xl} / 2));
 
+            &.mzp-c-card-extra-small,
+            &,
+            &.mzp-c-card-medium,
+            &.mzp-c-card-large {
+                max-width: 100%;
+            }
+
             &:nth-child(odd) {
                 margin-left: 0;
                 margin-right: 0;
@@ -79,6 +86,13 @@
             ));
             width: calc(50% - (#{$spacing-xl} / 2));
 
+            &.mzp-c-card-extra-small,
+            &,
+            &.mzp-c-card-medium,
+            &.mzp-c-card-large {
+                max-width: 100%;
+            }
+
             &:nth-child(even) {
                 margin-left: 0;
                 margin-right: 0;
@@ -128,6 +142,13 @@
                 (margin-left, 0, $spacing-xl),
                 (margin-right, $spacing-xl, 0),
             ));
+
+            &.mzp-c-card-extra-small,
+            &,
+            &.mzp-c-card-medium,
+            &.mzp-c-card-large {
+                max-width: 100%;
+            }
 
             &:nth-child(even) {
                 margin-left: 0;
@@ -189,6 +210,13 @@
                 (margin-left, 0, $spacing-xl),
                 (margin-right, $spacing-xl, 0),
             ));
+
+            &.mzp-c-card-extra-small,
+            &,
+            &.mzp-c-card-medium,
+            &.mzp-c-card-large {
+                max-width: 100%;
+            }
 
             &:nth-child(2n) {
                 margin-left: 0;


### PR DESCRIPTION
## Description

Remove max-width from cards in card-layout.

- [ ] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #620

### Testing

- This is a very brittle way of doing this, it depends on the card template CSS to be included after the card CSS. Should I increase the specificity to avoid this problem?
- I am wondering if we should divorce the card widths from the card sizes all together. Perhaps that is a bigger issue that should be considered separately. Do we ever use the cards without the layout options?
