### PR TITLE
Fix #638 - Revise the sticky promo to be hidden by default 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 12.1.0
+# HEAD
+
+## Features
+
+* **css:** Revise sticky promo component to be hidden by default  (#638)
+
+# 12.0.1
 
 ## Features
 

--- a/src/assets/js/protocol/protocol-sticky-promo.js
+++ b/src/assets/js/protocol/protocol-sticky-promo.js
@@ -41,6 +41,7 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
             e.preventDefault();
         }
 
+        e.currentTarget.parentNode.classList.remove('mzp-a-slide-in', 'mzp-js-show-on-load');
         e.currentTarget.parentNode.classList.add('mzp-a-fade-out');
     };
 
@@ -49,6 +50,7 @@ if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
             e.preventDefault();
         }
         stickyPromo.classList.add('mzp-a-slide-in');
+        stickyPromo.classList.remove('mzp-a-fade-out');
     };
 
     StickyPromo.init(stickyPromo);

--- a/src/assets/js/protocol/protocol-sticky-promo.js
+++ b/src/assets/js/protocol/protocol-sticky-promo.js
@@ -12,4 +12,11 @@
         e.currentTarget.parentNode.classList.add('mzp-a-fade-out');
     }, false);
 
+    var stickyPromo = document.querySelector('.mzp-c-sticky-promo');
+
+    if (stickyPromo.classList.contains('mzp-js-show-on-load')) {
+        document.addEventListener('DOMContentLoaded', function(){
+            stickyPromo.classList.add('mzp-a-slide-in');
+        });
+    }
 })();

--- a/src/assets/js/protocol/protocol-sticky-promo.js
+++ b/src/assets/js/protocol/protocol-sticky-promo.js
@@ -2,21 +2,57 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// create namespace
+if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
+    var Mzp = {};
+}
+
 (function() {
     'use strict';
 
-    var closeButton = document.querySelector('.mzp-c-sticky-promo-close');
+    var StickyPromo = {};
+    var stickyPromo;
+    var closeButton;
 
-    closeButton.addEventListener('click', function(e) {
-        e.preventDefault();
+    stickyPromo = document.querySelector('.mzp-c-sticky-promo');
+
+    /*
+    element: This component inits if it can find an instance of `.mzp-c-sticky-promo` in the DOM.
+    */
+    StickyPromo.init = function(element) {
+        if (!element) {
+            return false;
+        }
+
+        // Set close button/actions
+        closeButton = document.querySelector('.mzp-c-sticky-promo-close');
+        closeButton.addEventListener('click', StickyPromo.close, false);
+
+        // Backward compatibility to auto-show the promo if the class `mzp-js-show-on-load` is present.
+        if (element.classList.contains('mzp-js-show-on-load')) {
+            document.addEventListener('DOMContentLoaded', function(){
+                StickyPromo.open();
+            });
+        }
+    };
+
+    StickyPromo.close = function(e) {
+        if (e) {
+            e.preventDefault();
+        }
+
         e.currentTarget.parentNode.classList.add('mzp-a-fade-out');
-    }, false);
+    };
 
-    var stickyPromo = document.querySelector('.mzp-c-sticky-promo');
+    StickyPromo.open = function(e) {
+        if (e) {
+            e.preventDefault();
+        }
+        stickyPromo.classList.add('mzp-a-slide-in');
+    };
 
-    if (stickyPromo.classList.contains('mzp-js-show-on-load')) {
-        document.addEventListener('DOMContentLoaded', function(){
-            stickyPromo.classList.add('mzp-a-slide-in');
-        });
-    }
+    StickyPromo.init(stickyPromo);
+
+    window.Mzp.StickyPromo = StickyPromo;
+
 })();

--- a/src/assets/sass/protocol/components/_sticky-promo.scss
+++ b/src/assets/sass/protocol/components/_sticky-promo.scss
@@ -25,12 +25,7 @@ $logos: (
 }
 
 .mzp-c-sticky-promo {
-    @include bidi(((animation-name, mzp-a-slide-in-right, mzp-a-slide-in-left),));
-    @include bidi((
-        (right, $spacing-md, auto),
-        (left, auto, $spacing-md),
-    ));
-    animation: 600ms ease 1500ms both;
+
     background-color: $color-white;
     border-radius: $border-radius-sm;
     bottom: 0;
@@ -41,6 +36,15 @@ $logos: (
     position: fixed;
     width: $content-xs;
     z-index: 10;
+    animation: 600ms ease 1500ms both;
+
+    &.mzp-a-slide-in {
+        @include bidi(((animation-name, mzp-a-slide-in-right, mzp-a-slide-in-left),));
+        @include bidi((
+            (right, $spacing-md, auto),
+            (left, auto, $spacing-md),
+        ));
+    }
 
     &.mzp-a-fade-out {
         @include animation(mzp-a-fade-out 100ms ease 5ms both);
@@ -106,4 +110,3 @@ $logos: (
         background: transparent url("#{$image-path}/icons/close-white.svg") center center no-repeat;
     }
 }
-

--- a/src/assets/sass/protocol/components/_sticky-promo.scss
+++ b/src/assets/sass/protocol/components/_sticky-promo.scss
@@ -39,8 +39,12 @@ $logos: (
     position: fixed;
     width: $content-xs;
     z-index: 10;
-    animation: 600ms ease 1500ms both;
+    animation: 600ms ease 300ms both;
     opacity: 0;
+
+    &.mzp-js-show-on-load {
+        animation-delay: 1000ms;
+    }
 
     &.mzp-a-slide-in {
         @include bidi(((animation-name, mzp-a-slide-in-right, mzp-a-slide-in-left),));

--- a/src/assets/sass/protocol/components/_sticky-promo.scss
+++ b/src/assets/sass/protocol/components/_sticky-promo.scss
@@ -25,7 +25,10 @@ $logos: (
 }
 
 .mzp-c-sticky-promo {
-
+    @include bidi((
+        (right, $spacing-md, auto),
+        (left, auto, $spacing-md),
+    ));
     background-color: $color-white;
     border-radius: $border-radius-sm;
     bottom: 0;
@@ -37,13 +40,10 @@ $logos: (
     width: $content-xs;
     z-index: 10;
     animation: 600ms ease 1500ms both;
+    opacity: 0;
 
     &.mzp-a-slide-in {
         @include bidi(((animation-name, mzp-a-slide-in-right, mzp-a-slide-in-left),));
-        @include bidi((
-            (right, $spacing-md, auto),
-            (left, auto, $spacing-md),
-        ));
     }
 
     &.mzp-a-fade-out {

--- a/src/patterns/molecules/sticky-promo/sticky-promo.hbs
+++ b/src/patterns/molecules/sticky-promo/sticky-promo.hbs
@@ -16,12 +16,17 @@ notes: |
 
 ---
 
-<aside class="mzp-c-sticky-promo mzp-t-product-firefox mzp-t-dark mzp-js-show-on-load">
+<aside class="mzp-c-sticky-promo mzp-t-product-firefox mzp-t-dark">
   <button class="mzp-c-sticky-promo-close" type="button">Close</button>
   <h3 class="mzp-c-sticky-promo-title">Get the latest Firefox Browser.</h3>
   <a class="mzp-c-button mzp-t-product mzp-t-small" href="#">Download Now</a>
 </aside>
 
-<script
- src="../../../assets/protocol/protocol/js/protocol-sticky-promo.js">
+<script src="{{@root.baseurl}}/assets/protocol/protocol/js/protocol-sticky-promo.js"></script>
+
+<script>
+(function() {
+    'use strict';
+    Mzp.StickyPromo.open();
+})();
 </script>

--- a/src/patterns/molecules/sticky-promo/sticky-promo.hbs
+++ b/src/patterns/molecules/sticky-promo/sticky-promo.hbs
@@ -2,6 +2,8 @@
 name: Sticky Promo Card
 description: The primary purpose of the Sticky Card component is to ensure that the content it’s promoting remains a constant on the page -- always visible within the viewport no matter a user’s scroll position. Sticky Promo Cards can be used to promote a product and provide a CTA. While the card itself is both content and context agnostic, it should only be used strategically on pages where it will be most effective.
 notes: |
+  - The element is hidden by default. To show it, add `mzp-a-slide-in` to the class list.
+  - As a helper, you can set the sticky promo to automatically animate in once the page is loaded by adding `mzp-js-show-on-load` to the class list.
   - Use only one primary cta per card.
   - Use only one sticky promo card per page.
   - The copy on the card should be short and succinct, ideally no longer than 2 lines at display size in English.
@@ -14,7 +16,7 @@ notes: |
 
 ---
 
-<aside class="mzp-c-sticky-promo mzp-t-product-firefox mzp-t-dark">
+<aside class="mzp-c-sticky-promo mzp-t-product-firefox mzp-t-dark mzp-js-show-on-load">
   <button class="mzp-c-sticky-promo-close" type="button">Close</button>
   <h3 class="mzp-c-sticky-promo-title">Get the latest Firefox Browser.</h3>
   <a class="mzp-c-button mzp-t-product mzp-t-small" href="#">Download Now</a>

--- a/src/patterns/molecules/sticky-promo/sticky-promo.hbs
+++ b/src/patterns/molecules/sticky-promo/sticky-promo.hbs
@@ -2,7 +2,7 @@
 name: Sticky Promo Card
 description: The primary purpose of the Sticky Card component is to ensure that the content it’s promoting remains a constant on the page -- always visible within the viewport no matter a user’s scroll position. Sticky Promo Cards can be used to promote a product and provide a CTA. While the card itself is both content and context agnostic, it should only be used strategically on pages where it will be most effective.
 notes: |
-  - The element is hidden by default. To show it, add `mzp-a-slide-in` to the class list.
+  - The element is hidden by default and made visible by the `Mzp.StickyPromo.open()` function.
   - As a helper, you can set the sticky promo to automatically animate in once the page is loaded by adding `mzp-js-show-on-load` to the class list.
   - Use only one primary cta per card.
   - Use only one sticky promo card per page.
@@ -21,12 +21,14 @@ notes: |
   <h3 class="mzp-c-sticky-promo-title">Get the latest Firefox Browser.</h3>
   <a class="mzp-c-button mzp-t-product mzp-t-small" href="#">Download Now</a>
 </aside>
+<button id="showSticky" class="mzp-c-button mzp-t-md" type="button">Show Sticky Promo</button>
 
 <script src="{{@root.baseurl}}/assets/protocol/protocol/js/protocol-sticky-promo.js"></script>
 
 <script>
 (function() {
     'use strict';
-    Mzp.StickyPromo.open();
+    var showStickyBtn = document.getElementById("showSticky");
+    showStickyBtn.addEventListener('click', Mzp.StickyPromo.open, false);
 })();
 </script>


### PR DESCRIPTION
## Description

The sticky promo now requires an appended class to show. 
I also added a helper class to show the sticky promo on page load, providing backwards compatibility for previous behavior.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

https://github.com/mozilla/bedrock/issues/9406

### Testing

Enter helpful notes for whoever code reviews this change.
