### PR TITLE
Check for sidemenu before initializing (#643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * **component:** Add error message component (#430)
 
+## Bug Fixes
+
+* **js:** Check for sidemenu before initializing (#643)
+
 # 12.1.1
 
 ## Features

--- a/src/assets/js/protocol/protocol-sidemenu.js
+++ b/src/assets/js/protocol/protocol-sidemenu.js
@@ -9,18 +9,21 @@
     var menuMain = document.querySelector('.mzp-c-sidemenu-main');
     var menuToggle = document.querySelector('.mzp-js-toggle');
 
-    // Make the menu more accessible
-    menuToggle.setAttribute('tabindex', '0');
-    menuToggle.setAttribute('role', 'button');
-    menuMain.setAttribute('aria-expanded', 'false');
+    if(menu && menuMain && menuToggle) {
 
-    // Toggle the sidebar menu
-    menuToggle.addEventListener('click', function(e) {
-        e.preventDefault();
-        menu.classList.toggle('mzp-is-active');
+        // Make the menu more accessible
+        menuToggle.setAttribute('tabindex', '0');
+        menuToggle.setAttribute('role', 'button');
+        menuMain.setAttribute('aria-expanded', 'false');
 
-        var menuExpanded = menuMain.getAttribute('aria-expanded') === 'true' ? 'false' : 'true';
-        menuMain.setAttribute('aria-expanded', menuExpanded);
-    }, false);
+        // Toggle the sidebar menu
+        menuToggle.addEventListener('click', function(e) {
+            e.preventDefault();
+            menu.classList.toggle('mzp-is-active');
+
+            var menuExpanded = menuMain.getAttribute('aria-expanded') === 'true' ? 'false' : 'true';
+            menuMain.setAttribute('aria-expanded', menuExpanded);
+        }, false);
+    }
 
 })();


### PR DESCRIPTION
## Description

Check for sidemenu before initializing 

- [x] ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #643

### Testing

You can replicate the error on http://localhost:3000/demos/article.html by removing the menu html from `sidebar-menu.hbs`
