### PR TITLE
Add white-links mixin [fix #648]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+## Features
+
+* **css:** Add a new mixin for explicitly white links, when regular inverse link colors are undesirable (#648)
+
 # 13.0.0
 
 ## Features

--- a/src/assets/sass/protocol/base/elements/_forms.scss
+++ b/src/assets/sass/protocol/base/elements/_forms.scss
@@ -409,7 +409,7 @@ label {
 // Errors
 
 .mzp-c-form-errors {
-    @include light-links;
+    @include white-links;
     background-color: $form-red;
     border-radius: $field-border-radius;
     color: $color-white;

--- a/src/assets/sass/protocol/components/_footer.scss
+++ b/src/assets/sass/protocol/components/_footer.scss
@@ -9,6 +9,7 @@
 
 .mzp-c-footer {
     @include font-base;
+    @include white-links;
     background: $color-black;
     clear: both;
     color: $color-white;
@@ -18,16 +19,14 @@
 
     a:link,
     a:visited {
-        color: $color-white;
         font-weight: normal;
         text-decoration: underline;
-    }
 
-    a:hover,
-    a:focus,
-    a:active {
-        color: $color-white;
-        text-decoration: none;
+        &:hover,
+        &:focus,
+        &:active {
+            text-decoration: underline;
+        }
     }
 }
 
@@ -86,12 +85,12 @@
     a:link,
     a:visited {
         text-decoration: none;
-    }
 
-    a:hover,
-    a:focus,
-    a:active {
-        text-decoration: underline;
+        &:hover,
+        &:focus,
+        &:active {
+            text-decoration: underline;
+        }
     }
 
     @media (min-width: #{$screen-sm}) and (max-width: #{$screen-lg - 1px}) {

--- a/src/assets/sass/protocol/components/_footer.scss
+++ b/src/assets/sass/protocol/components/_footer.scss
@@ -25,7 +25,7 @@
         &:hover,
         &:focus,
         &:active {
-            text-decoration: underline;
+            text-decoration: none;
         }
     }
 }

--- a/src/assets/sass/protocol/includes/_mixins.scss
+++ b/src/assets/sass/protocol/includes/_mixins.scss
@@ -259,6 +259,20 @@
     }
 }
 
+// White color links for dark backgrounds, when link colors are undesirable.
+@mixin white-links {
+    a:link,
+    a:visited {
+        color: $color-white;
+
+        &:hover,
+        &:focus,
+        &:active {
+            color: $color-white;
+        }
+    }
+}
+
 
 // Mixins for CSS grid legacy prefixed properties
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1398482

--- a/src/pages/docs/contributing.md
+++ b/src/pages/docs/contributing.md
@@ -435,6 +435,23 @@ e.g. `example.png` and `example-high-res.png`
 @include at2x('/img/example.png', 100px, 100px);
 ```
 
+#### light-links
+The light-links mixin inverts link colors in elements/components with dark backgrounds.
+
+```scss
+@include light-links;
+```
+
+#### white-links
+The white-links mixin explicitly sets link colors (in all pseudo-class states) to white.
+This is useful for some elements/components with dark backgrounds where the regular
+inverted link colors might be undesirable, typically for utilitarian components like a
+footer.
+
+```scss
+@include white-links;
+```
+
 ### Themes
 
 Protocol supports [multiple brand themes](/fundamentals/typography.html), namely the Mozilla


### PR DESCRIPTION
## Description
Adds a new mixin for explicitly white links (as opposed to the inverted theme colors).

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
#648 
