### PR TITLE
Fix button focus color [fix #655]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+## Bug Fixes
+
+* **a11y:** Fix link button focus color. (#655)
+
 # 13.0.1
 
 ## Features

--- a/src/assets/sass/docs/site.scss
+++ b/src/assets/sass/docs/site.scss
@@ -403,7 +403,9 @@
 // buttons
 #protosite-primary-dark-preview,
 #protosite-secondary-dark-preview,
-#protosite-download-dark-preview {
+#protosite-product-dark-preview,
+#protosite-product-secondary-dark-preview,
+#protosite-neutral-dark-preview {
   background: $color-black;
   padding: $spacing-md;
 }

--- a/src/assets/sass/protocol/components/_button.scss
+++ b/src/assets/sass/protocol/components/_button.scss
@@ -88,8 +88,9 @@ a.mzp-c-button {
     text-decoration: none !important;  /* stylelint-disable-line declaration-no-important */
 
     &:focus {
-        box-shadow: $field-focus-ring;
         border-color: $button-border-color-focus;
+        box-shadow: $field-focus-ring;
+        color: $color-white;
         outline: none;
     }
 


### PR DESCRIPTION
## Description

Fixes button focus color by explicitly declaring it for `a.mzp-c-button:focus`, overriding the color from the common `:link:focus` pseudo-class. Also fixes a docs issue with some button examples lacking a dark background.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Button focus color: #655 
Button example backgrounds: #656 

### Testing

For the focus color you'll need to test an instance of a link styled as a button, such as in the first example on the hero demo page: http://localhost:3000/demos/hero.html

Button examples backgrounds:
http://localhost:3000/patterns/atoms/buttons.html#product-secondary-dark
http://localhost:3000/patterns/atoms/buttons.html#neutral-dark