### PR TITLE
Add horizontal grid tokens #345

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HEAD
 
+## Features
+
+* **css:** Add horizontal grid tokens (#345)
+
 ## Bug Fixes
 
 * **a11y:** Fix link button focus color. (#655)

--- a/src/assets/sass/protocol/base/elements/_sections.scss
+++ b/src/assets/sass/protocol/base/elements/_sections.scss
@@ -15,31 +15,19 @@
     position: relative;
 
     @media #{$mq-md} {
-        padding: $layout-xs $layout-lg;
+        padding: $layout-xs $h-grid-md;
     }
 
-    @media #{$mq-lg} {
-        padding: $layout-xs $layout-xl;
+    @media #{$mq-xl} {
+        padding: $layout-xs ($layout-lg * 2);
     }
 
     &.mzp-t-content-sm {
         max-width: $content-sm;
-
-        @media #{$mq-md} {
-            padding: $layout-xs;
-        }
-
-        @media #{$mq-lg} {
-            padding: $layout-xs;
-        }
     }
 
     &.mzp-t-content-md {
         max-width: $content-md;
-
-        @media #{$mq-md} {
-            padding: $layout-xs;
-        }
     }
 
     &.mzp-t-content-lg {

--- a/src/assets/sass/protocol/components/_feature-card.scss
+++ b/src/assets/sass/protocol/components/_feature-card.scss
@@ -67,7 +67,7 @@
 
     @media #{$mq-md} {
         margin-bottom: $layout-2xl;
-        max-width: 800px;
+        max-width: $content-md;
 
         .mzp-c-card-feature-list li {
             margin-bottom: $spacing-2xl;

--- a/src/assets/sass/protocol/components/_hero.scss
+++ b/src/assets/sass/protocol/components/_hero.scss
@@ -44,7 +44,7 @@
 
 .mzp-c-hero-body {
     margin: 0 auto;
-    max-width: 480px;
+    max-width: $content-sm;
 }
 
 .mzp-c-hero-title {

--- a/src/assets/sass/protocol/includes/_lib.scss
+++ b/src/assets/sass/protocol/includes/_lib.scss
@@ -46,5 +46,6 @@ $type-scale: 'standard' !default;
 // Import all the things!
 @import './node_modules/@mozilla-protocol/tokens/dist/index.scss';
 @import 'themes';
+@import 'variables';
 @import 'functions';
 @import 'mixins';

--- a/src/assets/sass/protocol/includes/_variables.scss
+++ b/src/assets/sass/protocol/includes/_variables.scss
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+$h-grid-xs: 40px;
+$h-grid-sm: 64px;
+$h-grid-md: 64px;
+$h-grid-lg: 64px;
+$h-grid-xl: 80px;


### PR DESCRIPTION
## Description

- Adds variables to use when defining the horizontal grid for components. 
- Decreased padding on content containers at 1024px breakpoint (this is in preparation for updating components to use this larger grid).
- Updates some hard-coded values to use existing variables

---

- ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

See #345

### Testing

Not much to see yet.

