### PR TITLE
Logos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## Features
 
+* **css:** Add logo and wordmark components (#665)
+* **css:** Add support for mozilla, pocket, and vpn logos to hero and callout components (#663)
+* **assets:** (breaking) Update @mozilla-protocol/assets to 4.0.0
 * **css:** Add Section Heading component (Fix #664)
 * **css:** Add horizontal spacing tokens (#345)
 * **css:** Add vertical spacing tokens (#536)
+
+## Migration Tips
+
+* See notes for [Protocol Assets 4.0.0](https://github.com/mozilla/protocol-assets/blob/main/CHANGELOG.md#migration-tips)
 
 ## Bug Fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -303,9 +303,9 @@
       }
     },
     "@mozilla-protocol/assets": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/assets/-/assets-3.0.2.tgz",
-      "integrity": "sha512-X/6SHdyji69BXB0PeIVqG8/7vxfknlijsW8J1T0PYLZy9OzMLMJmvGXovpxJFHpmYPwRTpScOQHsXiwCr9g3KQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/assets/-/assets-4.0.0.tgz",
+      "integrity": "sha512-bH2JGXhrDPYFM7Veezb8tiLgtDfeH8WTL1KlhTcL8jEp/5gxPSVih71fJIXp65vnKrKizMsWTSDFBLnwC323gQ=="
     },
     "@mozilla-protocol/eslint-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@cloudfour/hbs-helpers": "^0.9.0",
-    "@mozilla-protocol/assets": "^3.0.2",
+    "@mozilla-protocol/assets": "^4.0.0",
     "@mozilla-protocol/tokens": "^5.0.5",
     "del": "^3.0.0",
     "drizzle-builder": "0.0.10",

--- a/src/assets/sass/demos/logo.scss
+++ b/src/assets/sass/demos/logo.scss
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//* -------------------------------------------------------------------------- */
+// Logo demo
+
+@import '../protocol/includes/lib';
+@import '../docs/protocol';
+@import '../docs/protocol-components';
+
+.demo-logos td {
+    padding: $layout-sm;
+    vertical-align: middle;
+
+    &.mzp-t-dark {
+        background-color: get-theme('background-color-inverse');
+    }
+}

--- a/src/assets/sass/docs/site.scss
+++ b/src/assets/sass/docs/site.scss
@@ -110,6 +110,14 @@
     list-style-type: disc;
 }
 
+.protosite-pattern-desc ol {
+    list-style-type: decimal;
+}
+
+.protosite-pattern-desc li li {
+    margin-left: $layout-sm;
+}
+
 .protosite-nav-main-head {
     margin: 0 0 20px;
 }

--- a/src/assets/sass/protocol/components/_call-out.scss
+++ b/src/assets/sass/protocol/components/_call-out.scss
@@ -33,16 +33,17 @@
         margin: $spacing-lg 0 0;
     }
 
-    &.mzp-t-product-firefox,
-    &.mzp-t-product-beta,
-    &.mzp-t-product-developer,
-    &.mzp-t-product-nightly {
+    &[class*='mzp-t-product-'] {
         .mzp-c-call-out-title {
             @include background-size(64px 64px);
             background-position: top center;
             background-repeat: no-repeat;
             padding: (64px + $spacing-lg) 0 0 0;
         }
+    }
+
+    &.mzp-t-product-family .mzp-c-call-out-title {
+        @include at2x('#{$image-path}/logos/firefox/logo-lg.png', 64px, 64px);
     }
 
     &.mzp-t-product-firefox .mzp-c-call-out-title {
@@ -60,6 +61,27 @@
     &.mzp-t-product-nightly .mzp-c-call-out-title {
         @include at2x('#{$image-path}/logos/firefox/browser/nightly/logo-lg.png', 64px, 64px);
     }
+
+    &.mzp-t-product-focus .mzp-c-call-out-title {
+        @include at2x('#{$image-path}/logos/firefox/browser/focus/logo-lg.png', 64px, 64px);
+    }
+
+    &.mzp-t-product-mozilla .mzp-c-call-out-title {
+        @include at2x('#{$image-path}/logos/mozilla/logo-lg.png', 64px, 64px);
+    }
+
+    &.mzp-t-product-vpn .mzp-c-call-out-title {
+        @include at2x('#{$image-path}/logos/mozilla/vpn/logo-lg.png', 64px, 64px);
+    }
+
+    &.mzp-t-product-vpn.mzp-t-dark .mzp-c-call-out-content {
+        background-image: url('#{$image-path}/logos/mozilla/vpn/logo-flat-white.svg');
+    }
+
+    &.mzp-t-product-pocket .mzp-c-call-out-title {
+        @include at2x('#{$image-path}/logos/pocket/logo-lg.png', 64px, 64px);
+    }
+
 
     @media #{$mq-md} {
         .mzp-l-content {
@@ -103,10 +125,7 @@
         margin-bottom: 0;
     }
 
-    &.mzp-t-product-firefox ,
-    &.mzp-t-product-beta,
-    &.mzp-t-product-developer,
-    &.mzp-t-product-nightly {
+    &[class*='mzp-t-product-'] {
         .mzp-c-call-out-content {
             @include border-box;
             @include background-size(64px 64px);
@@ -114,6 +133,10 @@
             background-repeat: no-repeat;
             padding: (64px + $spacing-lg) 0 0 0;
         }
+    }
+
+    &.mzp-t-product-family .mzp-c-call-out-content {
+        @include at2x('#{$image-path}/logos/firefox/logo-lg.png', 64px, 64px);
     }
 
     &.mzp-t-product-firefox .mzp-c-call-out-content {
@@ -132,6 +155,26 @@
         @include at2x('#{$image-path}/logos/firefox/browser/nightly/logo-lg.png', 64px, 64px);
     }
 
+    &.mzp-t-product-focus .mzp-c-call-out-content {
+        @include at2x('#{$image-path}/logos/firefox/browser/focus/logo-lg.png', 64px, 64px);
+    }
+
+    &.mzp-t-product-mozilla .mzp-c-call-out-content {
+        @include at2x('#{$image-path}/logos/mozilla/logo-lg.png', 64px, 64px);
+    }
+
+    &.mzp-t-product-vpn .mzp-c-call-out-content {
+        @include at2x('#{$image-path}/logos/mozilla/vpn/logo-lg.png', 64px, 64px);
+    }
+
+    &.mzp-t-product-vpn.mzp-t-dark .mzp-c-call-out-content {
+        background-image: url('#{$image-path}/logos/mozilla/vpn/logo-flat-white.svg');
+    }
+
+    &.mzp-t-product-pocket .mzp-c-call-out-content {
+        @include at2x('#{$image-path}/logos/pocket/logo-lg.png', 64px, 64px);
+    }
+
     @media #{$mq-md} {
         @include clearfix;
 
@@ -142,10 +185,7 @@
             padding-top: $spacing-2xl;
         }
 
-        &.mzp-t-product-firefox,
-        &.mzp-t-product-beta,
-        &.mzp-t-product-developer,
-        &.mzp-t-product-nightly {
+        &[class*='mzp-t-product-'] {
             .mzp-c-call-out-content {
                 @include bidi((
                     (background-position, left center, right center),

--- a/src/assets/sass/protocol/components/_hero.scss
+++ b/src/assets/sass/protocol/components/_hero.scss
@@ -18,10 +18,7 @@
     text-align: center;
 
     // Product logos
-    &.mzp-t-product-firefox,
-    &.mzp-t-product-beta,
-    &.mzp-t-product-developer,
-    &.mzp-t-product-nightly {
+    &[class*='mzp-t-product-'] {
         .mzp-c-hero-title {
             @include background-size(80px 80px);
             background-position: top center;
@@ -67,6 +64,26 @@
     .mzp-t-product-nightly & {
         @include at2x('#{$image-path}/logos/firefox/browser/nightly/logo-lg.png', 80px, 80px);
     }
+
+    .mzp-t-product-focus & {
+        @include at2x('#{$image-path}/logos/firefox/browser/focus/logo-lg.png', 80px, 80px);
+    }
+
+    .mzp-t-product-mozilla & {
+        @include at2x('#{$image-path}/logos/mozilla/logo-lg.png', 80px, 80px);
+    }
+
+    .mzp-t-product-vpn & {
+        @include at2x('#{$image-path}/logos/mozilla/vpn/logo-lg.png', 80px, 80px);
+    }
+
+    .mzp-t-product-vpn.mzp-t-dark & {
+        background-image: url('#{$image-path}/logos/mozilla/vpn/logo-flat-white.svg');
+    }
+
+    .mzp-t-product-pocket & {
+        @include at2x('#{$image-path}/logos/pocket/logo-lg.png', 80px, 80px);
+    }
 }
 
 .mzp-c-hero-desc {
@@ -105,10 +122,7 @@
                 clear: both;
             }
 
-            &.mzp-t-product-firefox,
-            &.mzp-t-product-beta,
-            &.mzp-t-product-developer,
-            &.mzp-t-product-nightly {
+            &[class*='mzp-t-product-'] {
                 .mzp-c-hero-title {
                     @include bidi(((background-position, left top, right top),));
                     padding-top: (80px + $spacing-2xl);

--- a/src/assets/sass/protocol/components/logos/_logo-product-beta.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-beta.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'beta';
+$dir: 'firefox/browser/beta';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_logo-product-developer.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-developer.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'developer';
+$dir: 'firefox/browser/developer';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_logo-product-family.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-family.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'family';
+$dir: 'firefox';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_logo-product-firefox.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-firefox.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'firefox';
+$dir: 'firefox/browser';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_logo-product-focus.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-focus.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'focus';
+$dir: 'firefox/browser/focus';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_logo-product-lockwise.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-lockwise.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'lockwise';
+$dir: 'firefox/lockwise';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_logo-product-monitor.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-monitor.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'monitor';
+$dir: 'firefox/monitor';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_logo-product-mozilla.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-mozilla.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'mozilla';
+$dir: 'mozilla';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_logo-product-nightly.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-nightly.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'nightly';
+$dir: 'firefox/browser/nightly';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_logo-product-pocket.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-pocket.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'pocket';
+$dir: 'pocket';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_logo-product-vpn.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-vpn.scss
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'vpn';
+$dir: 'mozilla/vpn';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}
+
+.mzp-t-dark {
+    @each $layout-size, $logo-size in $logo-sizes {
+
+        .mzp-c-logo.mzp-t-product-#{$class}.mzp-t-#{$layout-size} {
+            background-image: url('#{$image-path}/logos/mozilla/vpn/logo-flat-white.svg');
+        }
+    }
+}
+

--- a/src/assets/sass/protocol/components/logos/_logo.scss
+++ b/src/assets/sass/protocol/components/logos/_logo.scss
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../includes/lib';
+
+
+$logo-sizes: (
+    xs: 'xs',
+    sm: 'xs',
+    md: 'xs',
+    lg: 'sm',
+    xl: 'md',
+    2xl: 'lg',
+);
+
+
+.mzp-c-logo {
+    @include bidi(((background-position, top left, top right),));
+    @include image-replaced;
+    background-size: contain;
+    background-repeat: no-repeat;
+    display: block;
+    margin-top: 0;
+
+    &.mzp-t-xs {
+        height: $layout-xs;
+        width: $layout-xs;
+    }
+
+    &.mzp-t-sm {
+        height: $layout-sm;
+        width: $layout-sm;
+    }
+
+    &.mzp-t-md {
+        height: $layout-md;
+        width: $layout-md;
+    }
+
+    &.mzp-t-lg {
+        height: $layout-lg;
+        width: $layout-lg;
+    }
+
+    &.mzp-t-xl {
+        height: $layout-xl;
+        width: $layout-xl;
+    }
+}
+@mixin logo($product, $dir, $layout-size, $logo-size) {
+    $path : '#{$image-path}/logos/#{$dir}/logo-#{$logo-size}.png';
+    $at2x_path: '#{$image-path}/logos/#{$dir}/logo-#{$logo-size}-high-res.png';
+
+    .mzp-c-logo.mzp-t-product-#{$product}.mzp-t-#{$layout-size} {
+        background-image: url('#{$path}');
+
+        // xs does not need high res version, it's shrunk for low-res
+        @if $layout-size != 'xs' {
+            @media #{$mq-high-res} {
+                background-image: url('#{$at2x_path}');
+            }
+        }
+    }
+}

--- a/src/assets/sass/protocol/components/logos/_logo.scss
+++ b/src/assets/sass/protocol/components/logos/_logo.scss
@@ -23,27 +23,27 @@ $logo-sizes: (
     display: block;
     margin-top: 0;
 
-    &.mzp-t-xs {
+    &.mzp-t-logo-xs {
         height: $layout-xs;
         width: $layout-xs;
     }
 
-    &.mzp-t-sm {
+    &.mzp-t-logo-sm {
         height: $layout-sm;
         width: $layout-sm;
     }
 
-    &.mzp-t-md {
+    &.mzp-t-logo-md {
         height: $layout-md;
         width: $layout-md;
     }
 
-    &.mzp-t-lg {
+    &.mzp-t-logo-lg {
         height: $layout-lg;
         width: $layout-lg;
     }
 
-    &.mzp-t-xl {
+    &.mzp-t-logo-xl {
         height: $layout-xl;
         width: $layout-xl;
     }
@@ -52,7 +52,7 @@ $logo-sizes: (
     $path : '#{$image-path}/logos/#{$dir}/logo-#{$logo-size}.png';
     $at2x_path: '#{$image-path}/logos/#{$dir}/logo-#{$logo-size}-high-res.png';
 
-    .mzp-c-logo.mzp-t-product-#{$product}.mzp-t-#{$layout-size} {
+    .mzp-c-logo.mzp-t-product-#{$product}.mzp-t-logo-#{$layout-size} {
         background-image: url('#{$path}');
 
         // xs does not need high res version, it's shrunk for low-res

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-beta.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-beta.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'beta';
+$dir: 'firefox/browser/beta';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-developer.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-developer.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'developer';
+$dir: 'firefox/browser/developer';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-family.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-family.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'family';
+$dir: 'firefox';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-firefox.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-firefox.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'firefox';
+$dir: 'firefox/browser';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-focus.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-focus.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'focus';
+$dir: 'firefox/browser/focus';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-lockwise.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-lockwise.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'lockwise';
+$dir: 'firefox/lockwise';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-monitor.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-monitor.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'monitor';
+$dir: 'firefox/monitor';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-mozilla.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-mozilla.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'mozilla';
+$dir: 'mozilla';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-nightly.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-nightly.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'nightly';
+$dir: 'firefox/browser/nightly';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-pocket.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-pocket.scss
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'pocket';
+$dir: 'pocket';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}
+

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-vpn.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-vpn.scss
@@ -12,7 +12,7 @@
     $path_white : '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-white-#{$logo-size}.png';
     $at2x_path_white: '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-white-#{$logo-size}-high-res.png';
 
-    .mzp-c-wordmark.mzp-t-product-vpn.mzp-t-#{$layout-size} {
+    .mzp-c-wordmark.mzp-t-product-vpn.mzp-t-wordmark-#{$layout-size} {
         background-image: url('#{$path}');
 
         // xs does not need high res version, it's shrunk for low-res

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-vpn.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-vpn.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'vpn';
+$dir: 'mozilla/vpn';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-vpn.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-vpn.scss
@@ -4,9 +4,35 @@
 
 @import 'logo';
 
-$class: 'vpn';
-$dir: 'mozilla/vpn';
 
+// can't re-use wordmark mixin because VPN uses the "stack" version by default
 @each $layout-size, $logo-size in $logo-sizes {
-    @include wordmark($class, $dir, $layout-size, $logo-size);
+    $path : '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-#{$logo-size}.png';
+    $at2x_path: '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-#{$logo-size}-high-res.png';
+    $path_white : '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-white-#{$logo-size}.png';
+    $at2x_path_white: '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-white-#{$logo-size}-high-res.png';
+
+    .mzp-c-wordmark.mzp-t-product-vpn.mzp-t-#{$layout-size} {
+        background-image: url('#{$path}');
+
+        // xs does not need high res version, it's shrunk for low-res
+        @if $layout-size != 'xs' {
+            @media #{$mq-high-res} {
+                background-image: url('#{$at2x_path}');
+            }
+        }
+
+        .mzp-t-dark & {
+            background-image: url('#{$path_white}');
+
+            // xs does not need high res version, it's shrunk for low-res
+            @if $layout-size != 'xs' {
+                @media #{$mq-high-res} {
+                    background-image: url('#{$at2x_path_white}');
+                }
+            }
+
+        }
+    }
+
 }

--- a/src/assets/sass/protocol/components/logos/_wordmark.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark.scss
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../includes/lib';
+
+
+$logo-sizes: (
+    xs: 'xs',
+    sm: 'xs',
+    md: 'xs',
+    lg: 'sm',
+    xl: 'md',
+    2xl: 'lg',
+);
+
+.mzp-c-wordmark {
+    @include bidi(((background-position, top left, top right),));
+    @include image-replaced;
+    background-size: contain;
+    background-repeat: no-repeat;
+    display: block;
+    margin-top: 0;
+    max-width: 100%;
+
+    &.mzp-t-xs {
+        height: $layout-xs;
+        width: 130px;
+    }
+
+    &.mzp-t-sm {
+        height: $layout-sm;
+        width: 174px;
+    }
+
+    &.mzp-t-md {
+        height: $layout-md;
+        width: 262px;
+    }
+
+    &.mzp-t-lg {
+        height: $layout-lg;
+        width: 347px;
+    }
+
+    &.mzp-t-xl {
+        height: $layout-xl;
+        width: 521px;
+    }
+}
+
+@mixin wordmark($product, $dir, $layout-size, $logo-size) {
+    $path : '#{$image-path}/logos/#{$dir}/logo-word-hor-#{$logo-size}.png';
+    $at2x_path: '#{$image-path}/logos/#{$dir}/logo-word-hor-#{$logo-size}-high-res.png';
+    $path_white : '#{$image-path}/logos/#{$dir}/logo-word-hor-white-#{$logo-size}.png';
+    $at2x_path_white: '#{$image-path}/logos/#{$dir}/logo-word-hor-white-#{$logo-size}-high-res.png';
+
+    .mzp-c-wordmark.mzp-t-product-#{$product}.mzp-t-#{$layout-size} {
+        background-image: url('#{$path}');
+
+        // xs does not need high res version, it's shrunk for low-res
+        @if $layout-size != 'xs' {
+            @media #{$mq-high-res} {
+                background-image: url('#{$at2x_path}');
+            }
+        }
+
+        .mzp-t-dark & {
+            background-image: url('#{$path_white}');
+
+            // xs does not need high res version, it's shrunk for low-res
+            @if $layout-size != 'xs' {
+                @media #{$mq-high-res} {
+                    background-image: url('#{$at2x_path_white}');
+                }
+            }
+
+        }
+    }
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark.scss
@@ -23,27 +23,27 @@ $logo-sizes: (
     margin-top: 0;
     max-width: 100%;
 
-    &.mzp-t-xs {
+    &.mzp-t-wordmark-xs {
         height: $layout-xs;
         width: 130px;
     }
 
-    &.mzp-t-sm {
+    &.mzp-t-wordmark-sm {
         height: $layout-sm;
         width: 174px;
     }
 
-    &.mzp-t-md {
+    &.mzp-t-wordmark-md {
         height: $layout-md;
         width: 262px;
     }
 
-    &.mzp-t-lg {
+    &.mzp-t-wordmark-lg {
         height: $layout-lg;
         width: 347px;
     }
 
-    &.mzp-t-xl {
+    &.mzp-t-wordmark-xl {
         height: $layout-xl;
         width: 521px;
     }
@@ -55,7 +55,7 @@ $logo-sizes: (
     $path_white : '#{$image-path}/logos/#{$dir}/logo-word-hor-white-#{$logo-size}.png';
     $at2x_path_white: '#{$image-path}/logos/#{$dir}/logo-word-hor-white-#{$logo-size}-high-res.png';
 
-    .mzp-c-wordmark.mzp-t-product-#{$product}.mzp-t-#{$layout-size} {
+    .mzp-c-wordmark.mzp-t-product-#{$product}.mzp-t-wordmark-#{$layout-size} {
         background-image: url('#{$path}');
 
         // xs does not need high res version, it's shrunk for low-res

--- a/src/assets/sass/protocol/protocol-components.scss
+++ b/src/assets/sass/protocol/protocol-components.scss
@@ -25,17 +25,51 @@ $image-path: '../img' !default;
 @import 'components/forms/form';
 @import 'components/forms/msg';
 @import 'components/forms/set';
-@import 'components/sticky-promo';
 @import 'components/forms/status';
 @import 'components/hero';
 @import 'components/inline-list';
-@import 'components/modal';
+@import 'components/logos/logo';
+@import 'components/logos/wordmark';
 @import 'components/menu-list';
+@import 'components/modal';
 @import 'components/newsletter-form';
 @import 'components/notification-bar';
 @import 'components/picto-card';
 @import 'components/section-heading';
 @import 'components/sidebar-menu';
+@import 'components/sticky-promo';
 @import 'components/zap';
 @import 'templates/card-layout';
 @import 'templates/main-with-sidebar';
+
+
+// logos
+@import 'components/logos/logo-product-firefox';
+@import 'components/logos/logo-product-beta';
+@import 'components/logos/logo-product-developer';
+@import 'components/logos/logo-product-nightly';
+@import 'components/logos/logo-product-focus';
+
+@import 'components/logos/logo-product-family';
+@import 'components/logos/logo-product-lockwise';
+@import 'components/logos/logo-product-monitor';
+
+@import 'components/logos/logo-product-mozilla';
+@import 'components/logos/logo-product-vpn';
+@import 'components/logos/logo-product-pocket';
+
+// wordmarks
+
+@import 'components/logos/wordmark-product-firefox';
+@import 'components/logos/wordmark-product-beta';
+@import 'components/logos/wordmark-product-developer';
+@import 'components/logos/wordmark-product-nightly';
+@import 'components/logos/wordmark-product-focus';
+
+@import 'components/logos/wordmark-product-family';
+@import 'components/logos/wordmark-product-lockwise';
+@import 'components/logos/wordmark-product-monitor';
+
+@import 'components/logos/wordmark-product-mozilla';
+@import 'components/logos/wordmark-product-vpn';
+@import 'components/logos/wordmark-product-pocket';

--- a/src/pages/demos/logo.hbs
+++ b/src/pages/demos/logo.hbs
@@ -1,0 +1,113 @@
+---
+title: Logos
+layout: blank
+styles:
+  - logo
+---
+
+<header class="mzp-l-content">
+  <h1>Logos &amp; Wordmarks</h1>
+</header>
+
+<div class="mzp-l-content">
+  <h2>Sizes</h2>
+  <table class="demo-logos">
+    <tr>
+      <td><code>xl</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="xl" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="xl" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>lg</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>md</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="md" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="md" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>sm</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="sm" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="sm" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>xs</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="xs" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="xs" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+    </tr>
+  </table>
+</div>
+<div class="mzp-l-content">
+  <h2>Products</h2>
+  <table class="demo-logos">
+    <tr>
+      <td><code>firefox</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>beta</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="beta" label="Firefox Browser Beta"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="beta" label="Firefox Browser Beta"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="beta" label="Firefox Browser Beta"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>developer</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="developer" label="Firefox Browser Developer"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="developer" label="Firefox Browser Developer"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="developer" label="Firefox Browser Developer"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>nightly</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="nightly" label="Firefox Browser Nightly"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="nightly" label="Firefox Browser Nightly"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="nightly" label="Firefox Browser Nightly"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>focus</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="focus" label="Firefox Browser Focus"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="focus" label="Firefox Browser Focus"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="focus" label="Firefox Browser Focus"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>family</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="family" label="Firefox"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="family" label="Firefox"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="family" label="Firefox"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>lockwise</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>monitor</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="monitor" label="Firefox Monitor"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="monitor" label="Firefox Monitor"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="monitor" label="Firefox Monitor"}}{{/embed}}</td>
+    </tr>
+
+    <tr>
+      <td><code>mozilla</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="mozilla" label="Mozilla"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="mozilla" label="Mozilla"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="mozilla" label="Mozilla"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>vpn</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="vpn" label="Mozilla VPN"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="vpn" label="Mozilla VPN"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="vpn" label="Mozilla VPN"}}{{/embed}}</td>
+    </tr>
+    <tr>
+      <td><code>pocket</code></td>
+      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="pocket" label="Pocket"}}{{/embed}}</td>
+      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="pocket" label="Pocket"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="pocket" label="Pocket"}}{{/embed}}</td>
+    </tr>
+  </table>
+</div>

--- a/src/pages/demos/logo.hbs
+++ b/src/pages/demos/logo.hbs
@@ -14,28 +14,28 @@ styles:
   <table class="demo-logos">
     <tr>
       <td><code>xl</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="xl" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="xl" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="xl" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="xl" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>lg</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>md</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="md" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="md" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="md" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="md" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>sm</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="sm" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="sm" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="sm" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="sm" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>xs</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="xs" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="xs" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="xs" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="xs" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
     </tr>
   </table>
 </div>
@@ -44,70 +44,70 @@ styles:
   <table class="demo-logos">
     <tr>
       <td><code>firefox</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
-      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="firefox" label="Firefox Browser"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>beta</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="beta" label="Firefox Browser Beta"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="beta" label="Firefox Browser Beta"}}{{/embed}}</td>
-      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="beta" label="Firefox Browser Beta"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="beta" label="Firefox Browser Beta"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="beta" label="Firefox Browser Beta"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="beta" label="Firefox Browser Beta"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>developer</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="developer" label="Firefox Browser Developer"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="developer" label="Firefox Browser Developer"}}{{/embed}}</td>
-      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="developer" label="Firefox Browser Developer"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="developer" label="Firefox Browser Developer"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="developer" label="Firefox Browser Developer"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="developer" label="Firefox Browser Developer"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>nightly</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="nightly" label="Firefox Browser Nightly"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="nightly" label="Firefox Browser Nightly"}}{{/embed}}</td>
-      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="nightly" label="Firefox Browser Nightly"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="nightly" label="Firefox Browser Nightly"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="nightly" label="Firefox Browser Nightly"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="nightly" label="Firefox Browser Nightly"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>focus</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="focus" label="Firefox Browser Focus"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="focus" label="Firefox Browser Focus"}}{{/embed}}</td>
-      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="focus" label="Firefox Browser Focus"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="focus" label="Firefox Browser Focus"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="focus" label="Firefox Browser Focus"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="focus" label="Firefox Browser Focus"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>family</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="family" label="Firefox"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="family" label="Firefox"}}{{/embed}}</td>
-      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="family" label="Firefox"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="family" label="Firefox"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="family" label="Firefox"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="family" label="Firefox"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>lockwise</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</td>
-      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>monitor</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="monitor" label="Firefox Monitor"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="monitor" label="Firefox Monitor"}}{{/embed}}</td>
-      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="monitor" label="Firefox Monitor"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="monitor" label="Firefox Monitor"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="monitor" label="Firefox Monitor"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="monitor" label="Firefox Monitor"}}{{/embed}}</td>
     </tr>
 
     <tr>
       <td><code>mozilla</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="mozilla" label="Mozilla"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="mozilla" label="Mozilla"}}{{/embed}}</td>
-      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="mozilla" label="Mozilla"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="mozilla" label="Mozilla"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="mozilla" label="Mozilla"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="mozilla" label="Mozilla"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>vpn</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="vpn" label="Mozilla VPN"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="vpn" label="Mozilla VPN"}}{{/embed}}</td>
-      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="vpn" label="Mozilla VPN"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="vpn" label="Mozilla VPN"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="vpn" label="Mozilla VPN"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="vpn" label="Mozilla VPN"}}{{/embed}}</td>
     </tr>
     <tr>
       <td><code>pocket</code></td>
-      <td>{{#embed "patterns.molecules.logo.logo" size="lg" product="pocket" label="Pocket"}}{{/embed}}</td>
-      <td>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="pocket" label="Pocket"}}{{/embed}}</td>
-      <td class="mzp-t-dark">{{#embed "patterns.molecules.logo.wordmark" size="lg" product="pocket" label="Pocket"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="pocket" label="Pocket"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="pocket" label="Pocket"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="pocket" label="Pocket"}}{{/embed}}</td>
     </tr>
   </table>
 </div>

--- a/src/patterns/atoms/logo/collection.yaml
+++ b/src/patterns/atoms/logo/collection.yaml
@@ -1,0 +1,2 @@
+name: Logos & Wordmarks
+title: Logos & Wordmarks

--- a/src/patterns/atoms/logo/logo.hbs
+++ b/src/patterns/atoms/logo/logo.hbs
@@ -2,13 +2,13 @@
 name: Logos
 description: |
   1. Add the CSS files to your bundle. You will need both the file for logo and for the product logo you want.
-  2. Add the component class `mzp-c-logo` the size class (eg: `mzp-t-md`) and the product class (eg: `mzp-t-product-firefox`) to your markup
+  2. Add the component class `mzp-c-logo` the size class (eg: `mzp-t-logo-md`) and the product class (eg: `mzp-t-product-firefox`) to your markup
      - For vertical spacing put the logo classes on or inside a heading or paragraph.
 order: 2
 notes: |
 tips: |
   - Logos need both a size and product theme to display.
-    - Size classes are: `mzp-t-xs`, `mzp-t-sm`, `mzp-t-md`, `mzp-t-lg`, `mzp-t-xl`.
+    - Size classes are: `mzp-t-logo-xs`, `mzp-t-logo-sm`, `mzp-t-logo-md`, `mzp-t-logo-lg`, `mzp-t-logo-xl`.
     - Product classes are: `mzp-t-product-family`, `mzp-t-product-firefox`, `mzp-t-product-beta`, `mzp-t-product-developer`, `mzp-t-product-nightly`, `mzp-t-product-focus`, `mzp-t-product-lockwise`, `mzp-t-product-monitor`, `mzp-t-product-mozilla`, `mzp-t-product-vpn`, `mzp-t-product-pocket`.
 ---
 

--- a/src/patterns/atoms/logo/logo.hbs
+++ b/src/patterns/atoms/logo/logo.hbs
@@ -1,0 +1,21 @@
+---
+name: Logos
+description: |
+  This component uses an image replacement technique for better SEO. You can, of course, still use a regular img element to insert a logo if it fits your use case better. Don't forget the alt text.
+
+  1. Add the CSS files to your bundle. You will need both the file for logo and for the product logo you want.
+  2. Add the component class `mzp-c-logo` the size class (eg: `mzp-t-md`) and the product class (eg: `mzp-t-product-firefox`) to your page
+     - For vertical spacing put the logo classes on or inside a heading or paragraph.
+order: 1
+notes: |
+tips: |
+  - Logos need both a size and product theme to display.
+    - Size classes are: `mzp-t-xs`, `mzp-t-sm`, `mzp-t-md`, `mzp-t-lg`, `mzp-t-xl`.
+    - Product classes are: `mzp-t-product-family`, `mzp-t-product-firefox`, `mzp-t-product-beta`, `mzp-t-product-developer`, `mzp-t-product-nightly`, `mzp-t-product-focus`, `mzp-t-product-lockwise`, `mzp-t-product-monitor`, `mzp-t-product-mozilla`, `mzp-t-product-vpn`, `mzp-t-product-pocket`.
+links:
+    See all sizes and products: /demos/logo.html
+---
+
+
+<h2>{{#embed "patterns.molecules.logo.logo" size="lg" product="family" label="Firefox"}}{{/embed}}</h2>
+<p>{{#embed "patterns.molecules.logo.logo" size="sm" product="firefox" label="Firefox Browser"}}{{/embed}}</p>

--- a/src/patterns/atoms/logo/logo.hbs
+++ b/src/patterns/atoms/logo/logo.hbs
@@ -12,7 +12,7 @@ tips: |
     - Product classes are: `mzp-t-product-family`, `mzp-t-product-firefox`, `mzp-t-product-beta`, `mzp-t-product-developer`, `mzp-t-product-nightly`, `mzp-t-product-focus`, `mzp-t-product-lockwise`, `mzp-t-product-monitor`, `mzp-t-product-mozilla`, `mzp-t-product-vpn`, `mzp-t-product-pocket`.
 ---
 
-<div class="mzp-c-logo mzp-t-{{#if size}}{{size}}{{else}}md{{/if}} mzp-t-product-{{#if product}}{{product}}{{else}}firefox{{/if}}">
+<div class="mzp-c-logo mzp-t-logo-{{#if size}}{{size}}{{else}}md{{/if}} mzp-t-product-{{#if product}}{{product}}{{else}}firefox{{/if}}">
   {{#if label}}{{label}}{{else}}Firefox Browser{{/if}}
 </div>
 

--- a/src/patterns/atoms/logo/logo.hbs
+++ b/src/patterns/atoms/logo/logo.hbs
@@ -1,21 +1,18 @@
 ---
 name: Logos
 description: |
-  This component uses an image replacement technique for better SEO. You can, of course, still use a regular img element to insert a logo if it fits your use case better. Don't forget the alt text.
-
   1. Add the CSS files to your bundle. You will need both the file for logo and for the product logo you want.
-  2. Add the component class `mzp-c-logo` the size class (eg: `mzp-t-md`) and the product class (eg: `mzp-t-product-firefox`) to your page
+  2. Add the component class `mzp-c-logo` the size class (eg: `mzp-t-md`) and the product class (eg: `mzp-t-product-firefox`) to your markup
      - For vertical spacing put the logo classes on or inside a heading or paragraph.
-order: 1
+order: 2
 notes: |
 tips: |
   - Logos need both a size and product theme to display.
     - Size classes are: `mzp-t-xs`, `mzp-t-sm`, `mzp-t-md`, `mzp-t-lg`, `mzp-t-xl`.
     - Product classes are: `mzp-t-product-family`, `mzp-t-product-firefox`, `mzp-t-product-beta`, `mzp-t-product-developer`, `mzp-t-product-nightly`, `mzp-t-product-focus`, `mzp-t-product-lockwise`, `mzp-t-product-monitor`, `mzp-t-product-mozilla`, `mzp-t-product-vpn`, `mzp-t-product-pocket`.
-links:
-    See all sizes and products: /demos/logo.html
 ---
 
+<div class="mzp-c-logo mzp-t-{{#if size}}{{size}}{{else}}md{{/if}} mzp-t-product-{{#if product}}{{product}}{{else}}firefox{{/if}}">
+  {{#if label}}{{label}}{{else}}Firefox Browser{{/if}}
+</div>
 
-<h2>{{#embed "patterns.molecules.logo.logo" size="lg" product="family" label="Firefox"}}{{/embed}}</h2>
-<p>{{#embed "patterns.molecules.logo.logo" size="sm" product="firefox" label="Firefox Browser"}}{{/embed}}</p>

--- a/src/patterns/atoms/logo/overview.hbs
+++ b/src/patterns/atoms/logo/overview.hbs
@@ -1,0 +1,9 @@
+---
+name: Overview
+description: |
+  These component uses an image replacement technique for better SEO. You can, of course, still use a regular img element to insert a logo if it fits your use case better. Don't forget the alt text.
+order: 1
+hideembed: true
+links:
+    See all sizes and products: /demos/logo.html
+---

--- a/src/patterns/atoms/logo/wordmark.hbs
+++ b/src/patterns/atoms/logo/wordmark.hbs
@@ -4,13 +4,13 @@ description: |
   Wordmarks work a lot like the logos except they change when nested under a `.mzp-t-dark` class.
 
   1. Add the CSS files to your bundle. You will need both the file for wordmark and for the product wordmark you want.
-  2. Add the component class `mzp-c-wordmark` the size class (eg: `mzp-t-md`) and the product class (eg: `mzp-t-product-firefox`) to your markup
+  2. Add the component class `mzp-c-wordmark` the size class (eg: `mzp-t-wordmark-md`) and the product class (eg: `mzp-t-product-firefox`) to your markup
      - For vertical spacing put the wordmark classes on or inside a heading or paragraph.
 order: 3
 notes: |
 tips: |
   - Wordmarks need both a size and product theme to display.
-    - Size classes are: `mzp-t-xs`, `mzp-t-sm`, `mzp-t-md`, `mzp-t-lg`, `mzp-t-xl`.
+    - Size classes are: `mzp-t-wordmark-xs`, `mzp-t-wordmark-sm`, `mzp-t-wordmark-md`, `mzp-t-wordmark-lg`, `mzp-t-wordmark-xl`.
     - Product classes are: `mzp-t-product-family`, `mzp-t-product-firefox`, `mzp-t-product-beta`, `mzp-t-product-developer`, `mzp-t-product-nightly`, `mzp-t-product-focus`, `mzp-t-product-lockwise`, `mzp-t-product-monitor`, `mzp-t-product-mozilla`, `mzp-t-product-vpn`, `mzp-t-product-pocket`.
 ---
 

--- a/src/patterns/atoms/logo/wordmark.hbs
+++ b/src/patterns/atoms/logo/wordmark.hbs
@@ -4,21 +4,17 @@ description: |
   Wordmarks work a lot like the logos except they change when nested under a `.mzp-t-dark` class.
 
   1. Add the CSS files to your bundle. You will need both the file for wordmark and for the product wordmark you want.
-  2. Add the component class `mzp-c-wordmark` the size class (eg: `mzp-t-md`) and the product class (eg: `mzp-t-product-firefox`) to your page
+  2. Add the component class `mzp-c-wordmark` the size class (eg: `mzp-t-md`) and the product class (eg: `mzp-t-product-firefox`) to your markup
      - For vertical spacing put the wordmark classes on or inside a heading or paragraph.
-order: 1
+order: 3
 notes: |
 tips: |
   - Wordmarks need both a size and product theme to display.
     - Size classes are: `mzp-t-xs`, `mzp-t-sm`, `mzp-t-md`, `mzp-t-lg`, `mzp-t-xl`.
     - Product classes are: `mzp-t-product-family`, `mzp-t-product-firefox`, `mzp-t-product-beta`, `mzp-t-product-developer`, `mzp-t-product-nightly`, `mzp-t-product-focus`, `mzp-t-product-lockwise`, `mzp-t-product-monitor`, `mzp-t-product-mozilla`, `mzp-t-product-vpn`, `mzp-t-product-pocket`.
-links:
-    See all sizes and products: /demos/logo.html
 ---
 
-<h2>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="family" label="Firefox"}}{{/embed}}</h2>
-<p>{{#embed "patterns.molecules.logo.wordmark" size="md" product="firefox" label="Firefox Browser"}}{{/embed}}</p>
-<p>{{#embed "patterns.molecules.logo.wordmark" size="md" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</p>
-<h2>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="mozilla" label="Mozilla"}}{{/embed}}</h2
-<p>{{#embed "patterns.molecules.logo.wordmark" size="md" product="vpn" label="Mozilla VPN"}}{{/embed}}</p>
+<div class="mzp-c-wordmark mzp-t-{{#if size}}{{size}}{{else}}md{{/if}} mzp-t-product-{{#if product}}{{product}}{{else}}firefox{{/if}}">
+  {{#if label}}{{label}}{{else}}Firefox Browser{{/if}}
+</div>
 

--- a/src/patterns/atoms/logo/wordmark.hbs
+++ b/src/patterns/atoms/logo/wordmark.hbs
@@ -14,7 +14,7 @@ tips: |
     - Product classes are: `mzp-t-product-family`, `mzp-t-product-firefox`, `mzp-t-product-beta`, `mzp-t-product-developer`, `mzp-t-product-nightly`, `mzp-t-product-focus`, `mzp-t-product-lockwise`, `mzp-t-product-monitor`, `mzp-t-product-mozilla`, `mzp-t-product-vpn`, `mzp-t-product-pocket`.
 ---
 
-<div class="mzp-c-wordmark mzp-t-{{#if size}}{{size}}{{else}}md{{/if}} mzp-t-product-{{#if product}}{{product}}{{else}}firefox{{/if}}">
+<div class="mzp-c-wordmark mzp-t-wordmark-{{#if size}}{{size}}{{else}}md{{/if}} mzp-t-product-{{#if product}}{{product}}{{else}}firefox{{/if}}">
   {{#if label}}{{label}}{{else}}Firefox Browser{{/if}}
 </div>
 

--- a/src/patterns/atoms/logo/wordmark.hbs
+++ b/src/patterns/atoms/logo/wordmark.hbs
@@ -1,0 +1,24 @@
+---
+name: Wordmarks
+description: |
+  Wordmarks work a lot like the logos except they change when nested under a `.mzp-t-dark` class.
+
+  1. Add the CSS files to your bundle. You will need both the file for wordmark and for the product wordmark you want.
+  2. Add the component class `mzp-c-wordmark` the size class (eg: `mzp-t-md`) and the product class (eg: `mzp-t-product-firefox`) to your page
+     - For vertical spacing put the wordmark classes on or inside a heading or paragraph.
+order: 1
+notes: |
+tips: |
+  - Wordmarks need both a size and product theme to display.
+    - Size classes are: `mzp-t-xs`, `mzp-t-sm`, `mzp-t-md`, `mzp-t-lg`, `mzp-t-xl`.
+    - Product classes are: `mzp-t-product-family`, `mzp-t-product-firefox`, `mzp-t-product-beta`, `mzp-t-product-developer`, `mzp-t-product-nightly`, `mzp-t-product-focus`, `mzp-t-product-lockwise`, `mzp-t-product-monitor`, `mzp-t-product-mozilla`, `mzp-t-product-vpn`, `mzp-t-product-pocket`.
+links:
+    See all sizes and products: /demos/logo.html
+---
+
+<h2>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="family" label="Firefox"}}{{/embed}}</h2>
+<p>{{#embed "patterns.molecules.logo.wordmark" size="md" product="firefox" label="Firefox Browser"}}{{/embed}}</p>
+<p>{{#embed "patterns.molecules.logo.wordmark" size="md" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</p>
+<h2>{{#embed "patterns.molecules.logo.wordmark" size="lg" product="mozilla" label="Mozilla"}}{{/embed}}</h2
+<p>{{#embed "patterns.molecules.logo.wordmark" size="md" product="vpn" label="Mozilla VPN"}}{{/embed}}</p>
+

--- a/src/patterns/molecules/logo/logo.hbs
+++ b/src/patterns/molecules/logo/logo.hbs
@@ -1,4 +1,0 @@
-<div class="mzp-c-logo mzp-t-{{ size }} mzp-t-product-{{ product }}">
-  {{ label }}
-</div>
-

--- a/src/patterns/molecules/logo/logo.hbs
+++ b/src/patterns/molecules/logo/logo.hbs
@@ -1,0 +1,4 @@
+<div class="mzp-c-logo mzp-t-{{ size }} mzp-t-product-{{ product }}">
+  {{ label }}
+</div>
+

--- a/src/patterns/molecules/logo/wordmark.hbs
+++ b/src/patterns/molecules/logo/wordmark.hbs
@@ -1,4 +1,0 @@
-<div class="mzp-c-wordmark mzp-t-{{ size }} mzp-t-product-{{ product }}">
-  {{ label }}
-</div>
-

--- a/src/patterns/molecules/logo/wordmark.hbs
+++ b/src/patterns/molecules/logo/wordmark.hbs
@@ -1,0 +1,4 @@
+<div class="mzp-c-wordmark mzp-t-{{ size }} mzp-t-product-{{ product }}">
+  {{ label }}
+</div>
+

--- a/src/patterns/organisms/call-out/call-out-compact.hbs
+++ b/src/patterns/organisms/call-out/call-out-compact.hbs
@@ -9,6 +9,10 @@ notes: |
       - `mzp-t-product-beta`
       - `mzp-t-product-developer`
       - `mzp-t-product-nightly`
+      - `mzp-t-product-focus`
+      - `mzp-t-product-mozilla`
+      - `mzp-t-product-vpn`
+      - `mzp-t-product-pocket`
 links:
     Compact Call Out Demo: /demos/call-out-compact.html
 ---

--- a/src/patterns/organisms/call-out/call-out.hbs
+++ b/src/patterns/organisms/call-out/call-out.hbs
@@ -8,6 +8,10 @@ notes: |
       - `mzp-t-product-beta`
       - `mzp-t-product-developer`
       - `mzp-t-product-nightly`
+      - `mzp-t-product-focus`
+      - `mzp-t-product-mozilla`
+      - `mzp-t-product-vpn`
+      - `mzp-t-product-pocket`
     - A dark theme is also available using the theme class `mzp-t-dark`.
 links:
     Call Out Demo: /demos/call-out.html

--- a/src/patterns/organisms/hero/hero-branded.hbs
+++ b/src/patterns/organisms/hero/hero-branded.hbs
@@ -9,6 +9,10 @@ notes: |
     - `mzp-t-product-beta`
     - `mzp-t-product-developer`
     - `mzp-t-product-nightly`
+    - `mzp-t-product-focus`
+    - `mzp-t-product-mozilla`
+    - `mzp-t-product-vpn`
+    - `mzp-t-product-pocket`
   - This example shows a mock download button. Actual download buttons on mozilla.org are much more complex with a lot of hidden markup so the CTA wrapper here is a `div` where other examples use a `p` element (a paragraph can only contain text and phrasing elements; a `p` wouldn’t be correct for a real download button).
   - [See the demo page](/demos/hero.html) for more examples in a full window context.
 ---


### PR DESCRIPTION
## Description

- Update to protocol-assets v4
    - Adds VPN and Focus logos
    - Updates Mozilla and Pocket logos
- Update hero and callout classes to support new products
- Add logo and wordmark components

---

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #663
Fix #665

### Testing

New components:
http://localhost:3000/patterns/atoms/logo.html
http://localhost:3000/demos/logo.html

Try new product classes on:
http://localhost:3000/patterns/organisms/hero.html
http://localhost:3000/patterns/organisms/call-out.html
