### PR TITLE
New picto component [fix #382] and multi-column layout [fix #233]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+* **component:** New picto component, deprecating the previous picto card (#382)
+* **template:** New multi-column layout container with up to four even columns (#233)
 * **css:** Add a theme class for alt background colors
 * **css:** Add logo and wordmark components (#665)
 * **css:** Add support for mozilla, pocket, and vpn logos to hero and callout components (#663)

--- a/src/assets/sass/demos/columns.scss
+++ b/src/assets/sass/demos/columns.scss
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//* -------------------------------------------------------------------------- */
+// Multi-column layout demo
+
+@import '../protocol/includes/lib';
+@import '../docs/protocol';
+@import '../docs/protocol-components';
+
+h1 {
+    @include text-title-md;
+}
+
+h2 {
+    @include text-title-sm;
+}
+
+h3 {
+    @include text-title-xs;
+}
+
+.label {
+    background: rgba(0, 255, 100, .5);
+    padding: $spacing-xs 0;
+    text-align: center;
+}
+
+.display .mzp-l-columns {
+    margin-bottom: $spacing-lg;
+
+    & > * {
+        background: rgba(0, 255, 100, .25);
+        margin-bottom: $spacing-lg;
+    }
+}

--- a/src/assets/sass/demos/picto.scss
+++ b/src/assets/sass/demos/picto.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//* -------------------------------------------------------------------------- */
+// Picto layout demo
+
+$brand-theme: 'firefox';
+
+@import '../protocol/includes/lib';
+@import '../docs/protocol';
+@import '../docs/protocol-components';

--- a/src/assets/sass/protocol/components/_picto.scss
+++ b/src/assets/sass/protocol/components/_picto.scss
@@ -15,7 +15,6 @@
 
 .mzp-c-picto-heading {
     @include text-title-xs;
-    color: get-theme('title-text-color');
 }
 
 .mzp-c-picto-image {
@@ -36,25 +35,27 @@
 
 
 // Image on the side
-.mzp-t-picto-side {
-    .mzp-c-picto {
-        @include bidi((
-            (padding-left, $layout-xl, 0),
-            (padding-right, 0, $layout-xl),
-        ));
-        position: relative;
-    }
+@media #{$mq-sm} {
+    .mzp-t-picto-side {
+        .mzp-c-picto {
+            @include bidi((
+                (padding-left, $layout-xl, 0),
+                (padding-right, 0, $layout-xl),
+            ));
+            position: relative;
+        }
 
-    .mzp-c-picto-image {
-        @include bidi((
-            (left, 0, auto),
-            (right, auto, 0),
-        ));
-        display: block;
-        margin: 0 auto;
-        position: absolute;
-        text-align: center;
-        width: $layout-lg;
+        .mzp-c-picto-image {
+            @include bidi((
+                (left, 0, auto),
+                (right, auto, 0),
+            ));
+            display: block;
+            margin: 0 auto;
+            position: absolute;
+            text-align: center;
+            width: $layout-lg;
+        }
     }
 }
 

--- a/src/assets/sass/protocol/components/_picto.scss
+++ b/src/assets/sass/protocol/components/_picto.scss
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../includes/lib';
+
+//* -------------------------------------------------------------------------- */
+// A small content block with a small image, usually an icon or spot illustration.
+
+.mzp-c-picto {
+    @include border-box;
+    margin: 0 auto $layout-md;
+    max-width: $content-md;
+}
+
+.mzp-c-picto-heading {
+    @include text-title-xs;
+    color: get-theme('title-text-color');
+}
+
+.mzp-c-picto-image {
+    margin-bottom: $layout-xs;
+}
+
+
+// Center aligned
+.mzp-t-picto-center {
+    .mzp-c-picto {
+        text-align: center;
+    }
+
+    .mzp-c-picto-image {
+        margin: 0 auto $layout-xs;
+    }
+}
+
+
+// Image on the side
+.mzp-t-picto-side {
+    .mzp-c-picto {
+        @include bidi((
+            (padding-left, $layout-xl, 0),
+            (padding-right, 0, $layout-xl),
+        ));
+        position: relative;
+    }
+
+    .mzp-c-picto-image {
+        @include bidi((
+            (left, 0, auto),
+            (right, auto, 0),
+        ));
+        display: block;
+        margin: 0 auto;
+        position: absolute;
+        text-align: center;
+        width: $layout-lg;
+    }
+}
+
+
+// Change side picto to top when in four columns and a narrow container
+.mzp-t-content-lg .mzp-l-columns.mzp-t-columns-four.mzp-t-picto-side,
+.mzp-t-content-lg .mzp-l-columns.mzp-t-columns-four .mzp-t-picto-side,
+.mzp-t-content-lg.mzp-l-columns.mzp-t-columns-four.mzp-t-picto-side,
+.mzp-t-content-lg.mzp-l-columns.mzp-t-columns-four .mzp-t-picto-side {
+    .mzp-c-picto {
+        padding: 0;
+    }
+
+    .mzp-c-picto-image {
+        margin-bottom: $layout-xs;
+        position: static;
+        text-align: inherit;
+        width: auto;
+    }
+}
+
+
+// Change side picto to top when in four columns and a narrow viewport
+@media #{$mq-lg} {
+    .mzp-t-columns-four.mzp-t-picto-side,
+    .mzp-t-columns-four .mzp-t-picto-side {
+        .mzp-c-picto {
+            padding: 0;
+        }
+
+        .mzp-c-picto-image {
+            margin-bottom: $layout-xs;
+            position: static;
+            text-align: inherit;
+            width: auto;
+        }
+    }
+}

--- a/src/assets/sass/protocol/protocol-components.scss
+++ b/src/assets/sass/protocol/protocol-components.scss
@@ -34,6 +34,7 @@ $image-path: '../img' !default;
 @import 'components/modal';
 @import 'components/newsletter-form';
 @import 'components/notification-bar';
+@import 'components/picto';
 @import 'components/picto-card';
 @import 'components/section-heading';
 @import 'components/sidebar-menu';
@@ -42,6 +43,7 @@ $image-path: '../img' !default;
 @import 'templates/card-layout';
 @import 'templates/main-with-sidebar';
 
+@import 'templates/multi-column';
 
 // logos
 @import 'components/logos/logo-product-firefox';

--- a/src/assets/sass/protocol/templates/_multi-column.scss
+++ b/src/assets/sass/protocol/templates/_multi-column.scss
@@ -37,34 +37,34 @@
 
 // Only one column in small containers
 .mzp-t-content-sm .mzp-l-columns,
-.mzp-l-columns.mzp-t-content-sm {
+.mzp-t-content-sm.mzp-l-columns {
     display: block;
 }
 
 // Change three columns to one in medium containers
 .mzp-t-content-md .mzp-l-columns.mzp-t-columns-three,
-.mzp-l-columns.mzp-t-columns-three.mzp-t-content-md {
+.mzp-t-content-md.mzp-l-columns.mzp-t-columns-three {
     display: block;
 }
 
 // Smaller gutters in medium containers
 .mzp-t-content-md .mzp-l-columns,
-.mzp-l-columns.mzp-t-content-md {
+.mzp-t-content-md.mzp-l-columns{
     grid-column-gap: get-theme('h-grid-md');
     column-gap: get-theme('h-grid-md');
 }
 
 // Change four columns to two in medium containers, plus smaller gutters
 .mzp-t-content-md .mzp-l-columns.mzp-t-columns-four,
-.mzp-l-columns.mzp-t-columns-four.mzp-t-content-md {
+.mzp-t-content-md.mzp-l-columns.mzp-t-columns-four {
     grid-template-columns: repeat(2, 1fr);
 }
 
 // Smaller gutters on three and four columns in large containers
 .mzp-t-content-lg .mzp-l-columns.mzp-t-columns-three,
-.mzp-l-columns.mzp-t-columns-three.mzp-t-content-lg,
+.mzp-t-content-lg.mzp-l-columns.mzp-t-columns-three,
 .mzp-t-content-lg .mzp-l-columns.mzp-t-columns-four,
-.mzp-l-columns.mzp-t-columns-four.mzp-t-content-lg {
+.mzp-t-content-lg.mzp-l-columns.mzp-t-columns-four {
     grid-column-gap: get-theme('h-grid-md');
     column-gap:get-theme('h-grid-md');
 }

--- a/src/assets/sass/protocol/templates/_multi-column.scss
+++ b/src/assets/sass/protocol/templates/_multi-column.scss
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../includes/lib';
+
+
+// TODO: Replace column gaps with grid spacing theme variables. (PR #669)
+
+@media #{$mq-md} {
+    .mzp-l-columns {
+        display: grid;
+        grid-column-gap: get-theme('h-grid-md');
+        column-gap: get-theme('h-grid-md');
+
+        &.mzp-t-columns-two,
+        &.mzp-t-columns-four {
+            grid-template-columns: repeat(2, 1fr);
+        }
+    }
+}
+
+@media #{$mq-lg} {
+    .mzp-l-columns {
+        grid-column-gap: get-theme('h-grid-xl');
+        column-gap: get-theme('h-grid-xl');
+
+        &.mzp-t-columns-three {
+            grid-template-columns: repeat(3, 1fr);
+        }
+
+        &.mzp-t-columns-four {
+            grid-template-columns: repeat(4, 1fr);
+        }
+    }
+}
+
+// Only one column in small containers
+.mzp-t-content-sm .mzp-l-columns,
+.mzp-l-columns.mzp-t-content-sm {
+    display: block;
+}
+
+// Change three columns to one in medium containers
+.mzp-t-content-md .mzp-l-columns.mzp-t-columns-three,
+.mzp-l-columns.mzp-t-columns-three.mzp-t-content-md {
+    display: block;
+}
+
+// Smaller gutters in medium containers
+.mzp-t-content-md .mzp-l-columns,
+.mzp-l-columns.mzp-t-content-md {
+    grid-column-gap: get-theme('h-grid-md');
+    column-gap: get-theme('h-grid-md');
+}
+
+// Change four columns to two in medium containers, plus smaller gutters
+.mzp-t-content-md .mzp-l-columns.mzp-t-columns-four,
+.mzp-l-columns.mzp-t-columns-four.mzp-t-content-md {
+    grid-template-columns: repeat(2, 1fr);
+}
+
+// Smaller gutters on three and four columns in large containers
+.mzp-t-content-lg .mzp-l-columns.mzp-t-columns-three,
+.mzp-l-columns.mzp-t-columns-three.mzp-t-content-lg,
+.mzp-t-content-lg .mzp-l-columns.mzp-t-columns-four,
+.mzp-l-columns.mzp-t-columns-four.mzp-t-content-lg {
+    grid-column-gap: get-theme('h-grid-md');
+    column-gap:get-theme('h-grid-md');
+}

--- a/src/pages/demos/columns.hbs
+++ b/src/pages/demos/columns.hbs
@@ -1,0 +1,264 @@
+---
+title: Multi-column layout examples
+layout: blank
+styles:
+  - columns
+---
+<h1 class="mzp-l-content">Multi-column layout examples</h1>
+
+{{#with (data "specimens")}}
+<section class="mzp-l-content mzp-l-columns mzp-t-columns-two">
+  <div>
+    <h2>Column One</h2>
+    <p>{{paragraph}}</p>
+  </div>
+
+  <div>
+    <h2>Column Two</h2>
+    <p>{{sentence}}</p>
+    <p>{{sentence}}</p>
+  </div>
+</section>
+
+<hr>
+
+<section class="mzp-l-content mzp-l-columns mzp-t-columns-three">
+  <div>
+    <h2>Column One</h2>
+    <p>{{sentence}}</p>
+  </div>
+
+  <div>
+    <h2>Column Two</h2>
+    <p>{{sentence}}</p>
+  </div>
+
+  <div>
+    <h2>Column Three</h2>
+    <p>{{sentence}}</p>
+  </div>
+</section>
+
+<hr>
+
+<section class="mzp-l-content mzp-l-columns mzp-t-columns-four">
+  <div>
+    <h2>Column One</h2>
+    <p>{{sentence}}</p>
+  </div>
+
+  <div>
+    <h2>Column Two</h2>
+    <p>{{sentence}}</p>
+  </div>
+
+  <div>
+    <h2>Column Three</h2>
+    <p>{{sentence}}</p>
+  </div>
+
+  <div>
+    <h2>Column Four</h2>
+    <p>{{sentence}}</p>
+  </div>
+</section>
+
+<hr>
+
+<section class="mzp-l-content mzp-l-columns mzp-t-columns-two">
+  {{#embed "patterns.molecules.card.medium-card"}}{{/embed}}
+
+  <div>
+    <h2>{{heading}}</h2>
+    <p>{{sentence}}</p>
+    <p>{{paragraph}}</p>
+    <p>{{sentence}}</p>
+    <p>{{paragraph}}</p>
+  </div>
+</section>
+
+<hr>
+
+<div id="container-sizes" class="mzp-l-content mzp-l-content-md">
+  <p>Multi-column layouts can changed depending on the size of their container, as well as the size of the viewport.</p>
+</div>
+
+<section class="mzp-l-content mzp-t-content-md display">
+  <h2 class="label">Medium container</h2>
+
+  <p class="label"><code>mzp-t-columns-two</code></p>
+  <div class="mzp-l-columns mzp-t-columns-two">
+    <div>
+      <h3>Column One</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Two</h3>
+      <p>{{sentence}}</p>
+    </div>
+  </div>
+
+  <p class="label"><code>mzp-t-columns-three</code></p>
+  <div class="mzp-l-columns mzp-t-columns-three">
+    <div>
+      <h3>Column One</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Two</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Three</h3>
+      <p>{{sentence}}</p>
+    </div>
+  </div>
+
+  <p class="label"><code>mzp-t-columns-four</code></p>
+  <div class="mzp-l-columns mzp-t-columns-four">
+    <div>
+      <h3>Column One</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Two</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Three</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Four</h3>
+      <p>{{sentence}}</p>
+    </div>
+  </div>
+</section>
+
+<hr>
+
+<section class="mzp-l-content mzp-t-content-lg display">
+  <h2 class="label">Large container</h2>
+
+  <p class="label"><code>mzp-t-columns-two</code></p>
+  <div class="mzp-l-columns mzp-t-columns-two">
+    <div>
+      <h3>Column One</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Two</h3>
+      <p>{{sentence}}</p>
+    </div>
+  </div>
+
+  <p class="label"><code>mzp-t-columns-three</code></p>
+  <div class="mzp-l-columns mzp-t-columns-three">
+    <div>
+      <h3>Column One</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Two</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Three</h3>
+      <p>{{sentence}}</p>
+    </div>
+  </div>
+
+  <p class="label"><code>mzp-t-columns-four</code></p>
+  <div class="mzp-l-columns mzp-t-columns-four">
+    <div>
+      <h3>Column One</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Two</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Three</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Four</h3>
+      <p>{{sentence}}</p>
+    </div>
+  </div>
+</section>
+
+<hr>
+
+<section class="mzp-l-content mzp-t-content-xl display">
+  <h2 class="label">Extra-large container</h2>
+
+  <p class="label"><code>mzp-t-columns-two</code></p>
+  <div class="mzp-l-columns mzp-t-columns-two">
+    <div>
+      <h3>Column One</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Two</h3>
+      <p>{{sentence}}</p>
+    </div>
+  </div>
+
+  <p class="label"><code>mzp-t-columns-three</code></p>
+  <div class="mzp-l-columns mzp-t-columns-three">
+    <div>
+      <h3>Column One</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Two</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Three</h3>
+      <p>{{sentence}}</p>
+    </div>
+  </div>
+
+  <p class="label"><code>mzp-t-columns-four</code></p>
+  <div class="mzp-l-columns mzp-t-columns-four">
+    <div>
+      <h3>Column One</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Two</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Three</h3>
+      <p>{{sentence}}</p>
+    </div>
+
+    <div>
+      <h3>Column Four</h3>
+      <p>{{sentence}}</p>
+    </div>
+  </div>
+</section>
+
+{{/with}}

--- a/src/pages/demos/picto.hbs
+++ b/src/pages/demos/picto.hbs
@@ -1,0 +1,172 @@
+---
+title: Picto Demo
+layout: blank
+styles:
+  - picto
+---
+
+  <div class="mzp-l-content">
+    {{#embed "patterns.molecules.picto.picto"}}{{/embed}}
+    {{#embed "patterns.molecules.picto.picto"}}{{/embed}}
+  </div>
+
+  <hr>
+
+  <div class="mzp-l-content mzp-t-picto-side">
+    {{#embed "patterns.molecules.picto.picto"}}{{/embed}}
+    {{#embed "patterns.molecules.picto.picto"}}{{/embed}}
+  </div>
+
+  <hr>
+
+  <div class="mzp-l-content mzp-t-picto-center">
+    {{#embed "patterns.molecules.picto.picto"}}{{/embed}}
+    {{#embed "patterns.molecules.picto.picto"}}{{/embed}}
+  </div>
+
+  <hr>
+
+  <div class="mzp-l-content mzp-l-columns mzp-t-columns-two">
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/orange/microchip.svg"}}{{/embed}}
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/orange/devices.svg"}}{{/embed}}
+  </div>
+
+  <hr>
+
+  <div class="mzp-l-content mzp-l-columns mzp-t-columns-two mzp-t-picto-side">
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/orange/microchip.svg"}}{{/embed}}
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/orange/devices.svg"}}{{/embed}}
+  </div>
+
+  <hr>
+
+  <div class="mzp-l-content mzp-t-content-md mzp-l-columns mzp-t-columns-two">
+    {{#embed "patterns.molecules.picto.picto"}}
+      {{#content "content"}}
+        <div class="mzp-c-picto-image">
+          <img src="{{@root.baseurl}}/assets/protocol/protocol/img/icons/brand/pink/password.svg" width="64" alt="">
+        </div>
+        <h3 class="mzp-c-picto-heading">Password fatigue is real</h3>
+        <div class="mzp-c-picto-body">
+          <p>The average person has 130 online accounts. Firefox for mobile remembers and stores your passwords safely across synced devices, so you can log in with just one click.</p>
+        </div>
+      {{/content}}
+    {{/embed}}
+
+    {{#embed "patterns.molecules.picto.picto"}}
+      {{#content "content"}}
+        <div class="mzp-c-picto-image">
+          <img src="{{@root.baseurl}}/assets/protocol/protocol/img/icons/brand/blue/no-eye.svg" width="64" alt="">
+        </div>
+        <h3 class="mzp-c-picto-heading">Privacy you never have to ponder</h3>
+        <div class="mzp-c-picto-body">
+          <p>Firefox for mobile blocks most online ad trackers automatically so there’s no need to dig into your security settings.</p>
+        </div>
+      {{/content}}
+    {{/embed}}
+  </div>
+
+  <hr>
+
+  <div class="mzp-l-content mzp-t-content-lg mzp-l-columns mzp-t-columns-three">
+    {{#embed "patterns.molecules.picto.picto"}}
+      {{#content "content"}}
+        <div class="mzp-c-picto-image">
+          <img src="{{@root.baseurl}}/assets/protocol/protocol/img/icons/brand/violet/feature-private-browsing-mask.svg" width="64" alt="">
+        </div>
+        <h3 class="mzp-c-picto-heading">More powerful Private Browsing</h3>
+        <div class="mzp-c-picto-body">
+          <p>Private Browsing mode deletes cookie data and your browsing history every time you close it.</p>
+          <p><a href="#" class="mzp-c-cta-link">Learn more</a></p>
+        </div>
+      {{/content}}
+    {{/embed}}
+
+    {{#embed "patterns.molecules.picto.picto"}}
+      {{#content "content"}}
+        <div class="mzp-c-picto-image">
+          <img src="{{@root.baseurl}}/assets/protocol/protocol/img/icons/brand/violet/feature-tracking-protection-shield.svg" width="64" alt="">
+        </div>
+        <h3 class="mzp-c-picto-heading">Ad tracker blocking</h3>
+        <div class="mzp-c-picto-body">
+          <p>Firefox automatically blocks 2000+ ad trackers from following you around the internet.</p>
+          <p><a href="#" class="mzp-c-cta-link">Learn more</a></p>
+        </div>
+      {{/content}}
+    {{/embed}}
+
+    {{#embed "patterns.molecules.picto.picto"}}
+      {{#content "content"}}
+        <div class="mzp-c-picto-image">
+          <img src="{{@root.baseurl}}/assets/protocol/protocol/img/icons/brand/violet/password.svg" width="64" alt="">
+        </div>
+        <h3 class="mzp-c-picto-heading">Password manager</h3>
+        <div class="mzp-c-picto-body">
+          <p>Firefox Lockwise lets you access all the passwords you’ve saved in Firefox — and it’s free.</p>
+          <p><a href="#" class="mzp-c-cta-link">Learn more</a></p>
+        </div>
+      {{/content}}
+    {{/embed}}
+  </div>
+
+  <hr>
+
+  <div class="mzp-l-content mzp-t-content-lg mzp-l-columns mzp-t-columns-three mzp-t-picto-center">
+    {{#embed "patterns.molecules.picto.picto"}}
+      {{#content "content"}}
+        <div class="mzp-c-picto-image">
+          <img src="{{@root.baseurl}}/assets/protocol/protocol/img/icons/brand/blue/feature-private-browsing-mask.svg" width="64" alt="">
+        </div>
+        <h3 class="mzp-c-picto-heading">More powerful Private Browsing</h3>
+        <div class="mzp-c-picto-body">
+          <p>Private Browsing mode deletes cookie data and your browsing history every time you close it.</p>
+          <p><a href="#" class="mzp-c-cta-link">Learn more</a></p>
+        </div>
+      {{/content}}
+    {{/embed}}
+
+    {{#embed "patterns.molecules.picto.picto"}}
+      {{#content "content"}}
+        <div class="mzp-c-picto-image">
+          <img src="{{@root.baseurl}}/assets/protocol/protocol/img/icons/brand/blue/feature-tracking-protection-shield.svg" width="64" alt="">
+        </div>
+        <h3 class="mzp-c-picto-heading">Ad tracker blocking</h3>
+        <div class="mzp-c-picto-body">
+          <p>Firefox automatically blocks 2000+ ad trackers from following you around the internet.</p>
+          <p><a href="#" class="mzp-c-cta-link">Learn more</a></p>
+        </div>
+      {{/content}}
+    {{/embed}}
+
+    {{#embed "patterns.molecules.picto.picto"}}
+      {{#content "content"}}
+        <div class="mzp-c-picto-image">
+          <img src="{{@root.baseurl}}/assets/protocol/protocol/img/icons/brand/blue/password.svg" width="64" alt="">
+        </div>
+        <h3 class="mzp-c-picto-heading">Password manager</h3>
+        <div class="mzp-c-picto-body">
+          <p>Firefox Lockwise lets you access all the passwords you’ve saved in Firefox — and it’s free.</p>
+          <p><a href="#" class="mzp-c-cta-link">Learn more</a></p>
+        </div>
+      {{/content}}
+    {{/embed}}
+  </div>
+
+  <hr>
+
+  <div class="mzp-l-content mzp-t-content-xl mzp-l-columns mzp-t-columns-four">
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/orange/picture.svg"}}{{/embed}}
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/blue/picture.svg"}}{{/embed}}
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/pink/picture.svg"}}{{/embed}}
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/violet/picture.svg"}}{{/embed}}
+  </div>
+
+  <hr>
+
+  <div class="mzp-l-content mzp-l-columns mzp-t-columns-four mzp-t-picto-center">
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/violet/picture.svg"}}{{/embed}}
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/pink/picture.svg"}}{{/embed}}
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/orange/picture.svg"}}{{/embed}}
+    {{#embed "patterns.molecules.picto.picto" image="/assets/protocol/protocol/img/icons/brand/blue/picture.svg"}}{{/embed}}
+  </div>
+</div>

--- a/src/patterns/molecules/picto-card/picto-card-compact.hbs
+++ b/src/patterns/molecules/picto-card/picto-card-compact.hbs
@@ -3,10 +3,13 @@ name: Picto Card (compact)
 description: A more compact version of a Picto Card with a horizontally aligned icon.
 order: 6
 notes: |
+    - **This component is deprecated. Use the new [Picto component](/patterns/molecules/picto.html).**
     - Horizontally aligned icon allows for a larger title and slightly longer description (max 100 characters).
 links:
     Card Layout Class: /patterns/templates/card-layout.html
     Picto Card Layout Demo: /demos/card-picto-layout.html
+labels:
+  - deprecated
 ---
 
 {{#embed "patterns.molecules.picto-card.picto-card" class="mzp-c-card-picto-compact"}}

--- a/src/patterns/molecules/picto-card/picto-card.hbs
+++ b/src/patterns/molecules/picto-card/picto-card.hbs
@@ -3,6 +3,7 @@ name: Picto Card
 description: A card with a pictographic icon, headline, and description.
 order: 5
 notes: |
+    - **This component is deprecated. Use the new [Picto component](/patterns/molecules/picto.html).**
     - This card type should be arranged in groups of two or three using the `.mzp-l-card-half` and `.mzp-l-card-third` layout classes.
     - Icons are presentational so should be applied as CSS background images via a `.mzp-c-card-picto-content::before` pseudo class.
     - Headlines should be a maximum of 30 characters, and descriptions a maximum of 60 characters.
@@ -11,6 +12,8 @@ notes: |
 links:
     Card Layout Class: /patterns/templates/card-layout.html
     Picto Card Layout Demo: /demos/card-picto-layout.html
+labels:
+  - deprecated
 ---
 
 <section class="mzp-c-card-picto {{#if class}}{{class}}{{/if}}">

--- a/src/patterns/molecules/picto/picto-center.hbs
+++ b/src/patterns/molecules/picto/picto-center.hbs
@@ -1,0 +1,11 @@
+---
+name: Picto, centered
+description: A picto with the image and text centered.
+order: 3
+links:
+    Picto examples: /demos/picto.html
+---
+
+<div class="mzp-t-picto-center">
+{{#embed "patterns.molecules.picto.picto"}}{{/embed}}
+</div>

--- a/src/patterns/molecules/picto/picto-side.hbs
+++ b/src/patterns/molecules/picto/picto-side.hbs
@@ -1,0 +1,17 @@
+---
+name: Picto, image on the side
+description: A picto component with the image oriented to one side of the content, with a bit of space in between.
+order: 2
+notes: |
+    - In this orientation the image has a maximum width of 64px, so it's best suited for simple icons.
+    - The image will be on the left in left-to-right languages, and on the right in right-to-left.
+    - The image is vertically aligned to the top of the text.
+nonos: |
+    - This style works best in wider columns, allowing space for the image and text. Don't use it in a very narrow container, such as a four-column layout.
+links:
+    Picto examples: /demos/picto.html
+---
+
+<div class="mzp-t-picto-side">
+{{#embed "patterns.molecules.picto.picto"}}{{/embed}}
+</div>

--- a/src/patterns/molecules/picto/picto.hbs
+++ b/src/patterns/molecules/picto/picto.hbs
@@ -1,0 +1,38 @@
+---
+name: Picto
+description: A small block of content featuring a pictographic icon, headline, and body.
+order: 1
+notes: |
+    - Pictos are best suited for a [multi-column layout](/patterns/templates/columns.html) but will otherwise stack in a single column.
+    - Without any other constraints, a picto has a maximum width of 688px (equal to the "medium" content width).
+    - The image should usually be a small icon (hence "picto") but larger images or even videos can be accommodated in some layouts.
+    - Three variants are available:
+      - The image on top, aligned with the text (this is the default).
+      - The image on top with text and image centered.
+      - The image on one side, aligned to the top of the text.
+    - The picto variant is determined by a theme class on a container element so the same variant applies to the entire set:
+      - The default (image on top, aligned with text) doesn't require a theme class.
+      - `mzp-t-picto-center`
+      - `mzp-t-picto-side`
+    - All parts are optional. For example, you could omit the headline and only use body text, or omit the body and only have a headline. Technically you could omit the image but then you might prefer some other component (is a picto without a picto really a picto?).
+tips: |
+    - This component should typically appear in groups of at least two. A single picto should be an uncommon exception.
+    - All the images in a set of pictos should be the same size so they'll all align neatly.
+nonos: |
+    - Avoid mismatching the number of picto components to the number of columns, e.g. four pictos in a three-column layout. It won't break, but the fourth one will wrap to another line and leave awkward empty space.
+    - Don't combine style variants; centered text with the image on the side doesn't look quite right.
+links:
+    Picto examples: /demos/picto.html
+---
+
+<section class="mzp-c-picto">
+  {{#block "content"}}
+  <div class="mzp-c-picto-image">
+    <img src="{{@root.baseurl}}{{#if image}}{{image}}{{else}}/static/img/picto/image.svg{{/if}}" width="64" alt="">
+  </div>
+  <h3 class="mzp-c-picto-heading">A headline with 30 characters</h3>
+  <div class="mzp-c-picto-body">
+    <p>A short description, just a sentence or two. Don't use this component for long-form content; it's only for blurbs.</p>
+  </div>
+  {{/block}}
+</section>

--- a/src/patterns/templates/columns/columns.hbs
+++ b/src/patterns/templates/columns/columns.hbs
@@ -1,0 +1,38 @@
+---
+name: Multi-column layout
+description: |
+    This container class sets up a multi-column layout with two, three, or four columns. It's content-agnostic, but not all Protocol components will work within a multi-column layout.
+links:
+    Examples: /demos/columns.html
+notes: |
+    - A theme class sets the number of columns:
+      - `mzp-t-columns-two`
+      - `mzp-t-columns-three`
+      - `mzp-t-columns-four`
+    - Columns are evenly sized and evenly spaced. Every column in a group is the same width with the same gutters (space between columns).
+    - We don't currently have options for an uneven distribution of columns, such as two columns in one-third/two-thirds proportions. If you need that kind of layout you'll need to use an alternative method.
+    - This uses [CSS grid](https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout), which is [well supported in modern browsers](https://caniuse.com/css-grid) but not supported in any browsers release prior to 2018. Older browsers will ignore the column layout and content will be linearized by default. If you need a multi-column layout in older browsers you'll need to use an alternative method.
+    - The contents of each column should be in its own container element that must be a _direct child_ of the multi-column container, as shown in the example. The kind of element doesn't matter (`div`, `section`, `p`, `img`, etc), it just needs to be a direct child of the container.
+    - The `.mzp-l-columns` class doesn't apply a width; without any other constraints the column container will fill the width of its own container, which may be the browser window. Use this in conjunction with a `.mzp-l-content` container, either nested or applying both classes to the same container.
+    - A column's width isn't explicit; the width of a column depends on the number of columns and the width of the container (which also varies).
+    - Gutters between columns are 64px at most viewport sizes, but expand to 80px in extra large viewports.
+    - Column layouts change automatically at different breakpoints, or in different container widths. [See the demo](/demos/columns.html#container-sizes).
+        - Small viewports and containers are always a single column.
+        - In medium viewports or containers, three columns will be a single column.
+        - In medium viewports or containers, four columns will be two columns with the third and fourth wrapping under the first and second.
+nonos: |
+    - Avoid nesting `.mzp-l-columns` containers. It gets weird.
+---
+{{#with (data "specimens")}}
+<section class="mzp-l-content mzp-l-columns mzp-t-columns-two">
+  <div>
+    <h3>Column One</h3>
+    <p>{{sentence}}</p>
+  </div>
+
+  <div>
+    <h3>Column Two</h3>
+    <p>{{sentence}}</p>
+  </div>
+</section>
+{{/with}}

--- a/src/patterns/templates/content-container/content-container.hbs
+++ b/src/patterns/templates/content-container/content-container.hbs
@@ -6,8 +6,8 @@ links:
     Examples: /demos/content-containers.html
     Container visualization: /demos/content-container-vis.html
 notes: |
-    - The container's width isn't explicit; it's a fluid box with a minimum width of 304px and constrained to a maximum width that differs at different responsive breakpoints. If you want to know how wide this box is, the answer is: it depends. Refer [the `$content-*` tokens](/fundamentals/tokens.html) for the maximum width values.
-    - Side padding also adjusts at different breakpoints, with less padding on small windows and more padding in large windows. [Check out the demo](/demos/content-container-vis.html) and resize your browser to see how the width and padding responds to the viewport.
+    - The container's width isn't explicit; it's a fluid box with a minimum width of 304px and constrained to a maximum width that differs at different responsive breakpoints. If you want to know how wide this box is, the answer is: it depends. Refer to [the `$content-*` tokens](/fundamentals/tokens.html) for the maximum width values.
+    - Side padding also adjusts at different breakpoints, with less padding in small windows and more padding in large windows. [Check out the demo](/demos/content-container-vis.html) and resize your browser to see how the width and padding responds to the viewport.
     - You can apply theme classes to set a max-width narrower than the default, to constrain the maximum width even in larger viewports. [See the demo](/demos/content-container.html) for examples of these.
         - `.mzp-t-content-sm` : 432px
         - `.mzp-t-content-md` : 688px

--- a/src/static/img/picto/image.svg
+++ b/src/static/img/picto/image.svg
@@ -1,0 +1,9 @@
+<svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(2.000000, 2.000000)">
+            <rect stroke="#000000" stroke-width="2" x="0" y="0" width="20" height="20" rx="2"></rect>
+            <circle fill="#000000" cx="6" cy="6" r="2"></circle>
+            <path d="M1,19 L11.0857864,8.91421356 C11.866835,8.13316498 13.133165,8.13316498 13.9142136,8.91421356 L20,15" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
## Description

This adds a new component called simply "picto" to replace the original picto card. It's a small block of content featuring an image (typically a small icon, hence the name "picto"), a headline, and a short blurb.

Also adds a mutli-column layout template. It's content-agnostic and doesn't impose any other layout or styling, it's literally just a container to create a simple set of even columns (two, three, or four). The multi-column container should be used in combination with a content container.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#233 - multi-column layout
#382 - new picto

### Testing

https://demo1--mozilla-protocol.netlify.app/patterns/molecules/picto.html
https://demo1--mozilla-protocol.netlify.app/demos/picto.html

https://demo1--mozilla-protocol.netlify.app/patterns/templates/columns.html
https://demo1--mozilla-protocol.netlify.app/demos/columns.html
