### PR TITLE
Add theme class for alt background color [no bug]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **css:** Add a theme class for alt background colors
 * **css:** Add logo and wordmark components (#665)
 * **css:** Add support for mozilla, pocket, and vpn logos to hero and callout components (#663)
 * **assets:** (breaking) Update @mozilla-protocol/assets to 4.0.0

--- a/src/assets/sass/demos/card.scss
+++ b/src/assets/sass/demos/card.scss
@@ -8,7 +8,3 @@
 @import '../protocol/includes/lib';
 @import '../docs/protocol';
 @import '../docs/protocol-components';
-
-.mzp-t-dark {
-    background-color: $color-marketing-gray-80;
-}

--- a/src/assets/sass/demos/content-container.scss
+++ b/src/assets/sass/demos/content-container.scss
@@ -11,7 +11,7 @@
 
 .mzp-c-hero.mzp-t-dark,
 .demo-alt-tier {
-    background: $color-ink-80;
+    background: get-theme('background-color-inverse');
 }
 
 // Styles for the visualization page

--- a/src/assets/sass/demos/hero.scss
+++ b/src/assets/sass/demos/hero.scss
@@ -8,27 +8,3 @@
 @import '../protocol/includes/lib';
 @import '../docs/protocol';
 @import '../docs/protocol-components';
-
-
-.section-next {
-    background: $color-marketing-gray-20;
-
-    &.mzp-t-dark {
-        color: #fff;
-        background-color: $color-marketing-gray-80;
-    }
-
-    h2 {
-        @include text-title-md;
-    }
-
-    .mzp-c-card-picto .mzp-c-card-picto-content::before{
-        background-color: $color-marketing-gray-40;
-    }
-
-}
-
-
-hr {
-    margin: $layout-xl 0 0;
-}

--- a/src/assets/sass/demos/link-styles.scss
+++ b/src/assets/sass/demos/link-styles.scss
@@ -16,11 +16,11 @@ span[class^='visited'] {
 }
 
 .link {
-    color: $color-link;
+    color: get-theme('link-color');
     text-decoration: underline;
 
     &:hover {
-        color: $color-link-hover;
+        color: get-theme('link-color-hover');
     }
 
     &:active {
@@ -29,37 +29,37 @@ span[class^='visited'] {
 }
 
 .visited {
-    color: $color-link-visited;
+    color: get-theme('link-color-visited');
     text-decoration: underline;
 
     &:hover {
-        color: $color-link-visited-hover;
+        color: get-theme('link-color-visited-hover');
     }
 }
 
 .link-hover {
-    color: $color-link-hover;
+    color: get-theme('link-color-visited');
     text-decoration: underline;
 }
 
 .link-active {
-    color: $color-link;
+    color: get-theme('link-color');
     background-color: rgba(0, 0, 0, .05);
     text-decoration: underline;
 }
 
 .visited {
-    color: $color-link-visited;
+    color: get-theme('link-color-visited');
     text-decoration: underline;
 }
 
 .visited-hover {
-    color: $color-link-visited-hover;
+    color: get-theme('link-color-visited-hover');
     text-decoration: underline;
 }
 
 .visited-active {
     background-color: rgba(0, 0, 0, .05);
-    color: $color-link-visited;
+    color: get-theme('link-color-visited');
     text-decoration: underline;
 }

--- a/src/assets/sass/protocol/base/utilities/_backgrounds.scss
+++ b/src/assets/sass/protocol/base/utilities/_backgrounds.scss
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../includes/lib';
+
+
+// Theme classes for background colors
+
+.mzp-t-background-alt {
+    background-color: get-theme('background-color-alt');
+}
+
+.mzp-t-dark {
+    background-color: get-theme('background-color-inverse');
+    color: get-theme('body-text-color-inverse');
+}
+
+.mzp-t-dark.mzp-t-background-alt,
+.mzp-t-dark .mzp-t-background-alt {
+    background-color: get-theme('background-color-alt-inverse');
+}

--- a/src/assets/sass/protocol/components/_call-out.scss
+++ b/src/assets/sass/protocol/components/_call-out.scss
@@ -12,7 +12,7 @@
     text-align: center;
 
     &.mzp-t-dark {
-        background-color: get-theme('background-color-inverse');
+        background-color: get-theme('background-color-alt-inverse');
         color: get-theme('body-text-color-inverse');
 
         .mzp-c-call-out-desc {
@@ -97,14 +97,14 @@
 // Compact Call Out component
 
 .mzp-c-call-out-compact {
-    background-color: $color-marketing-gray-20;
+    background-color: get-theme('background-color-alt');
 
     &.mzp-t-dark {
-        background-color: $color-marketing-gray-80;
-        color: $color-white;
+        background-color: get-theme('background-color-alt-inverse');
+        color: get-theme('body-text-color-inverse');
 
         .mzp-c-call-out-desc {
-            color: $color-marketing-gray-30;
+            color: get-theme('body-text-color-inverse');
         }
     }
 

--- a/src/assets/sass/protocol/protocol.scss
+++ b/src/assets/sass/protocol/protocol.scss
@@ -32,6 +32,7 @@ $font-path: '../fonts' !default;
 @import 'base/elements';
 
 // Base utilities
+@import 'base/utilities/backgrounds';
 @import 'base/utilities/titles';
 
 // Base includes - animations

--- a/src/pages/demos/hero.hbs
+++ b/src/pages/demos/hero.hbs
@@ -74,7 +74,7 @@ styles:
   {{/content}}
 {{/embed}}
 
-<section class="section-next">
+<section class="mzp-t-background-alt">
   <div class="mzp-l-card-third mzp-l-content">
     {{#embed "patterns.molecules.picto-card.picto-card"}}{{/embed}}
     {{#embed "patterns.molecules.picto-card.picto-card"}}{{/embed}}
@@ -104,7 +104,7 @@ styles:
   {{/content}}
 {{/embed}}
 
-<section class="section-next">
+<section class="mzp-t-background-alt">
   <div class="mzp-l-card-third mzp-l-content">
     {{#embed "patterns.molecules.picto-card.picto-card"}}{{/embed}}
     {{#embed "patterns.molecules.picto-card.picto-card"}}{{/embed}}
@@ -164,7 +164,7 @@ styles:
   {{/content}}
 {{/embed}}
 
-<section class="section-next mzp-t-dark">
+<section class="mzp-t-dark mzp-t-background-alt">
   <div class="mzp-l-card-third mzp-l-content">
     {{#embed "patterns.molecules.picto-card.picto-card"}}{{/embed}}
     {{#embed "patterns.molecules.picto-card.picto-card"}}{{/embed}}

--- a/src/pages/fundamentals/themes.md
+++ b/src/pages/fundamentals/themes.md
@@ -43,3 +43,15 @@ You can activate the condensed type scale by setting a variable when you compile
 ```scss
 $type-scale: 'condensed';
 ```
+
+## Component themes
+
+In addition to the global themes for brand and type scale, we have a few standard component-level theming classes you can use.
+
+### Dark theme
+
+Many components have an inverse color variant that applies a dark background color with light foreground colors, invoked with the `mzp-t-dark` theme class.
+
+### Section backgrounds
+
+There's a basic `mzp-t-background-alt` class that applies a secondary background color to most elements or component, especially useful for alternating sections of a page.


### PR DESCRIPTION
## Description

This adds a common theme class for applying an alternative background color: `.mzp-t-background-alt`
Also standardizes `.mzp-t-dark` class to use the theme variable for inverse backgrounds.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

I haven't really documented it because I'm not sure where that documentation should go... we probably need to think about that. I'd suggest a new doc page for these kinds of utility and theme classes. There's [an older issue about properly documenting the "dark" theme](#628 ), that would go in the same place. I can work on better docs but I don't want to hold up getting this class added.

### Testing

http://localhost:3000/demos/hero.html uses the alt background class on a few examples