### PR TITLE
Reduce base heading sizes [no bug]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **css:** Reduce base heading sizes
 * **component:** Add Split component (#326)
 * **component:** New picto component, deprecating the previous picto card (#382)
 * **template:** New multi-column layout container with up to four even columns (#233)
@@ -9,13 +10,9 @@
 * **css:** Add logo and wordmark components (#665)
 * **css:** Add support for mozilla, pocket, and vpn logos to hero and callout components (#663)
 * **assets:** (breaking) Update @mozilla-protocol/assets to 4.0.0
-* **css:** Add Section Heading component (Fix #664)
-* **css:** Add horizontal spacing tokens (#345)
-* **css:** Add vertical spacing tokens (#536)
-
-## Migration Tips
-
-* See notes for [Protocol Assets 4.0.0](https://github.com/mozilla/protocol-assets/blob/main/CHANGELOG.md#migration-tips)
+* **css:** Add Section Heading component (#664)
+* **css:** Add horizontal spacing variables (#345)
+* **css:** Add vertical spacing variables (#536)
 
 ## Bug Fixes
 
@@ -23,8 +20,9 @@
 
 ## Migration Tips
 
-* The new spacing tokens increase vertical spacing at some breakpoints for `.mzp-l-content`. If you have custom components which match the padding around Protocol components you may wish to update those components to use the new spacing tokens.
-
+* Default sizes for heading elements (h1–h6) are smaller. Most components declare sizes explicitly but if you're relying on generic sizes for HTML headings you may need to adjust.
+* The new spacing variables increase top and bottom padding for `.mzp-l-content` at some breakpoints. If you have custom components which match the padding around Protocol components you may wish to update those components to use the new variables.
+* See notes for [Protocol Assets 4.0.0](https://github.com/mozilla/protocol-assets/blob/main/CHANGELOG.md#migration-tips)
 
 # 13.0.1
 

--- a/src/assets/sass/docs/site.scss
+++ b/src/assets/sass/docs/site.scss
@@ -40,22 +40,6 @@
             padding-top: 0;
         }
     }
-
-    > h1 {
-        @include text-title-lg;
-    }
-
-    > h2 {
-        @include text-title-md;
-    }
-
-    > h3 {
-        @include text-title-sm;
-    }
-
-    > h4 {
-        @include text-title-xs;
-    }
 }
 
 // Nav sidebar

--- a/src/assets/sass/protocol/base/elements/_titles.scss
+++ b/src/assets/sass/protocol/base/elements/_titles.scss
@@ -21,27 +21,25 @@ h1, h2, h3, h4, h5, h6 {
 // Type scale mixins can be found in includes/mixins/_typography.scss
 // Sizes are defined in includes/_themes.scss
 h1 {
-    @include text-title-2xl;
-    margin-bottom: .25em;
-}
-
-h2 {
-    @include text-title-xl;
-    margin-bottom: .45em;
-}
-
-h3 {
     @include text-title-lg;
 }
 
-h4 {
+h2 {
     @include text-title-md;
 }
 
-h5 {
+h3 {
     @include text-title-sm;
 }
 
-h6 {
+h4 {
     @include text-title-xs;
+}
+
+h5 {
+    @include text-title-2xs;
+}
+
+h6 {
+    @include text-title-3xs;
 }

--- a/src/assets/sass/protocol/components/_article.scss
+++ b/src/assets/sass/protocol/components/_article.scss
@@ -8,19 +8,6 @@
     width: $content-md;
     max-width: 100%;
 
-    // Step down the heading levels
-    h2 {
-        @include text-title-md;
-    }
-
-    h3 {
-        @include text-title-sm;
-    }
-
-    h4 {
-        @include text-title-xs;
-    }
-
     @media #{$mq-md} {
         // Float left when sidebar is on the left
         .mzp-l-sidebar-left .mzp-l-main & {
@@ -35,7 +22,7 @@
 }
 
 .mzp-c-article-title {
-    @include text-title-xl;
+    @include text-title-lg;
 }
 
 .mzp-c-article-intro {

--- a/src/pages/demos/theme-firefox.hbs
+++ b/src/pages/demos/theme-firefox.hbs
@@ -49,13 +49,14 @@ styles:
 
   <hr>
   <p>Type scale</p>
-  <h1>Title 2XL {{heading}}</h1>
-  <h2>Title XL {{heading}}</h2>
-  <h3>Title LG {{heading}}</h3>
-  <h4>Title MD {{heading}}</h4>
-  <h5>Title SM {{heading}}</h5>
-  <h6>Title XS {{heading}}</h6>
+  <h1 class="mzp-u-title-2xl">Title 2XL {{heading}}</h1>
+  <h2 class="mzp-u-title-xl">Title XL {{heading}}</h2>
+  <h3 class="mzp-u-title-lg">Title LG {{heading}}</h3>
+  <h4 class="mzp-u-title-md">Title MD {{heading}}</h4>
+  <h5 class="mzp-u-title-sm">Title SM {{heading}}</h5>
+  <h6 class="mzp-u-title-xs">Title XS {{heading}}</h6>
   <h6 class="mzp-u-title-2xs">Title 2XS {{heading}}</h6>
+  <h6 class="mzp-u-title-3xs">Title 3XS {{heading}}</h6>
 
   <p class="body-xl"><b>Body XL</b> {{sentence}}</p>
   <p class="body-lg"><b>Body LG</b> {{sentence}}</p>

--- a/src/pages/demos/theme-mozilla.hbs
+++ b/src/pages/demos/theme-mozilla.hbs
@@ -49,13 +49,15 @@ styles:
 
   <hr>
   <p>Type scale</p>
-  <h1>Title 2XL {{heading}}</h1>
-  <h2>Title XL {{heading}}</h2>
-  <h3>Title LG {{heading}}</h3>
-  <h4>Title MD {{heading}}</h4>
-  <h5>Title SM {{heading}}</h5>
-  <h6>Title XS {{heading}}</h6>
+  <h1 class="mzp-u-title-2xl">Title 2XL {{heading}}</h1>
+  <h2 class="mzp-u-title-xl">Title XL {{heading}}</h2>
+  <h3 class="mzp-u-title-lg">Title LG {{heading}}</h3>
+  <h4 class="mzp-u-title-md">Title MD {{heading}}</h4>
+  <h5 class="mzp-u-title-sm">Title SM {{heading}}</h5>
+  <h6 class="mzp-u-title-xs">Title XS {{heading}}</h6>
   <h6 class="mzp-u-title-2xs">Title 2XS {{heading}}</h6>
+  <h6 class="mzp-u-title-3xs">Title 3XS {{heading}}</h6>
+
 
   <p class="body-xl"><b>Body XL</b> {{sentence}}</p>
   <p class="body-lg"><b>Body LG</b> {{sentence}}</p>


### PR DESCRIPTION
## Description

Generic heading elements are downsized, starting at `lg` for `h1` and stepping down to `3xs` for `h6`. I did a trial run on bedrock and found no ill effects. Most components have sizes declared explicitly already and any custom pages that need smaller headings are also declaring them explicitly to override the defaults.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Testing

http://localhost:3000/patterns/atoms/typographic.html#heading-elements