### PR TITLE
Change the import order to fix sass compiling bug

### DIFF
--- a/src/assets/sass/protocol/includes/_lib.scss
+++ b/src/assets/sass/protocol/includes/_lib.scss
@@ -45,6 +45,6 @@ $type-scale: 'standard' !default;
 
 // Import all the things!
 @import './node_modules/@mozilla-protocol/tokens/dist/index.scss';
-@import 'themes';
 @import 'functions';
+@import 'themes';
 @import 'mixins';


### PR DESCRIPTION
## Description

Compiling Protocol with the [sass](https://www.npmjs.com/package/sass) package gives the below error.

```
(body-font-family: (Inter, X-LocaleSpecific, sans-serif), button-font-family: (Metropolis, Inter, X-LocaleSpecific, sans-serif), title-font-family: (Metropolis, Inter, X-LocaleSpecific, sans-serif)) isn't a valid CSS value.
```

![CleanShot 2021-04-09 at 12 19 28@2x](https://user-images.githubusercontent.com/28797553/114230484-0a94c780-992e-11eb-9abd-1998674215e9.png)

The line that caused this bug is:
https://github.com/mozilla/protocol/blob/b8542c88bdeede8dfc5b6c2614bcc6f811f4a505/src/assets/sass/protocol/includes/_themes.scss#L223

After investigating, I found that the reason why sass was not able to understand this line was because at the time of compiling, the function `map-collect` was not available. I then looked at the order of import and found that `themes` was imported before `functions`. 

https://github.com/mozilla/protocol/blob/b8542c88bdeede8dfc5b6c2614bcc6f811f4a505/src/assets/sass/protocol/includes/_lib.scss#L47-L50

After switching the import order, functions imported before themes to make `map-collect()` available to `themes`, I was then able to compile Protocol with sass 🎉 

### Issue

Fixes #653 

cc/ @craigcook 
