### PR TITLE
Bump version to 14.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 14.0.1
+
+## Bug fixes
+
+* **css:** Fix import order for themes and functions (#653)
+
 # 14.0.0
 
 ## Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "private": true,
   "author": "Mozilla",
   "description": "A design system for Mozilla's websites.",

--- a/src/assets/package/README.md
+++ b/src/assets/package/README.md
@@ -20,7 +20,7 @@ Install package with NPM and add it to your dependencies:
 </tr>
 <tr>
 <td>Version</td>
-<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">14.0.0</a></td>
+<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">14.0.1</a></td>
 </tr>
 </table>
 

--- a/src/assets/package/package.json
+++ b/src/assets/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/core",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "description": "A design system for Mozilla's websites.",
   "repository": {
     "type": "git",

--- a/src/templates/drizzle/nav.hbs
+++ b/src/templates/drizzle/nav.hbs
@@ -8,7 +8,7 @@
 <nav class="protosite-nav-main" id="protosite-nav-main">
   <header class="protosite-nav-main-head">
     <a href="https://www.mozilla.org">
-      <img class="protosite-nav-main-mozlogo" src="{{@root.baseurl}}/assets/protocol/protocol/img/logos/mozilla/white.svg" width="100" alt="Mozilla">
+      <img class="protosite-nav-main-mozlogo" src="{{@root.baseurl}}/assets/protocol/protocol/img/logos/mozilla/logo-word-hor-white.svg" width="100" alt="Mozilla">
     </a>
 
     <a class="protosite-js-nav-toggle" href="#nav">Menu</a>


### PR DESCRIPTION
## Description

This includes a bug fix in the main _lib.scss and also fixes the logo in the doc site nav (which I missed because I still had old assets on my local 🤦). I'll be more careful when publishing this.

- [x] I have recorded this change in `CHANGELOG.md`.