### PR TITLE
Set global Mzp namespace to default to window as root (Fixes #687)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+## Bug Fixes
+
+* **js:** Set global `Mzp` namespace to default to `window` as root (#687).
+
 # 14.0.3
 
 ## Bug Fixes

--- a/src/assets/js/protocol/protocol-details.js
+++ b/src/assets/js/protocol/protocol-details.js
@@ -4,8 +4,8 @@
 
 
 // create namespace
-if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
-    var Mzp = {};
+if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
+    window.Mzp = {};
 }
 
 (function(doc, Mzp) {

--- a/src/assets/js/protocol/protocol-lang-switcher.js
+++ b/src/assets/js/protocol/protocol-lang-switcher.js
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // create namespace
-if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
-    var Mzp = {};
+if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
+    window.Mzp = {};
 }
 
 (function() {

--- a/src/assets/js/protocol/protocol-menu.js
+++ b/src/assets/js/protocol/protocol-menu.js
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // create namespace
-if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
-    var Mzp = {};
+if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
+    window.Mzp = {};
 }
 
 (function(Mzp) {

--- a/src/assets/js/protocol/protocol-modal.js
+++ b/src/assets/js/protocol/protocol-modal.js
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // create namespace
-if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
-    var Mzp = {};
+if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
+    window.Mzp = {};
 }
 
 (function() {

--- a/src/assets/js/protocol/protocol-navigation.js
+++ b/src/assets/js/protocol/protocol-navigation.js
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // create namespace
-if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
-    var Mzp = {};
+if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
+    window.Mzp = {};
 }
 
 (function(Mzp) {

--- a/src/assets/js/protocol/protocol-notification-bar.js
+++ b/src/assets/js/protocol/protocol-notification-bar.js
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // create namespace
-if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
-    var Mzp = {};
+if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
+    window.Mzp = {};
 }
 
 (function() {

--- a/src/assets/js/protocol/protocol-sticky-promo.js
+++ b/src/assets/js/protocol/protocol-sticky-promo.js
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // create namespace
-if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
-    var Mzp = {};
+if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
+    window.Mzp = {};
 }
 
 (function() {

--- a/src/assets/js/protocol/protocol-supports.js
+++ b/src/assets/js/protocol/protocol-supports.js
@@ -4,8 +4,8 @@
 
 
 // create namespace
-if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
-    var Mzp = {};
+if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
+    window.Mzp = {};
 }
 
 (function(doc) {

--- a/src/assets/js/protocol/protocol-utils.js
+++ b/src/assets/js/protocol/protocol-utils.js
@@ -4,8 +4,8 @@
 
 
 // create namespace
-if (typeof Mzp === 'undefined') { // eslint-disable-line block-scoped-var
-    var Mzp = {};
+if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
+    window.Mzp = {};
 }
 
 (function() {


### PR DESCRIPTION
## Description

Ensures JS components are always accessible via `window.Mzp` namespace.

~- [ ] I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#687

### Testing

- [ ] Components should still be accessible via `window.Mzp` as before by default.
- [ ] Check I didn't miss anywhere else?
