### PR TITLE
Migrate continuous integration to GitHub actions (fixes #652)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,12 +16,18 @@ jobs:
         node-version: [10.x, 12.x, 14.x, 15.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
+    env:
+      DISPLAY: ":99.0"
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
+    - name: setup xvfb
+      run: |
+        sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
+        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,27 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - "10"
-cache: node_modules
-dist: xenial
-services:
-  - xvfb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HEAD
 
+## Features
+
+* Migrate CI to GitHub actions
+
 ## Bug Fixes
 
 * **js:** Set global `Mzp` namespace to default to `window` as root (#687).


### PR DESCRIPTION
This is more urgent now that [travis ci is shutting down for real](https://blog.travis-ci.com/2021-05-07-orgshutdown)

## Description

Describe what this change does.

- [x] (N/A) I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

This fixes #652 

### Testing

N/A, check ci status
