### PR TITLE
Override styling native summary element when it’s polyfilled [fix #658]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## Bug Fixes
 
+* **css:** Override styling native summary element when it’s polyfilled in IE11 (#658)
 * **js:** Set global `Mzp` namespace to default to `window` as root (#687).
+
 
 # 14.0.3
 

--- a/src/assets/sass/protocol/base/elements/_details.scss
+++ b/src/assets/sass/protocol/base/elements/_details.scss
@@ -16,6 +16,15 @@ details .is-summary button,
     @include summary;
 }
 
+// Override styling the native element when the polyfill is applied (issue #658)
+summary.is-summary {
+    @include bidi(((padding-right, 0, padding-left, 0),));
+
+    &:before {
+        display: none;
+    }
+}
+
 details[open] summary:before,
 details .is-summary button[aria-expanded=true]:before,
 .mzp-c-details .is-summary button[aria-expanded=true]:before {

--- a/src/patterns/molecules/details/details-custom.hbs
+++ b/src/patterns/molecules/details/details-custom.hbs
@@ -3,14 +3,14 @@ name: Custom expand and collapse
 description: The functions driving the details and summary component can be called independently.
 order: 3
 notes: |
-    - Styling must be provided seperately
+    - Styling must be provided separately.
     - Details can be initialized using `Mzp.Details.init(selector, options)`, where `options` is an Object with the following properties:
       - `onDetailsOpen` [Function] callback when a details is opened (optional).
       - `onDetailsClosed` [Function] callback when a details is closed (optional).
 ---
 
 <style>
-  /* Styling must be provided seperately, don't use these ones they're intentionally bad */
+  /* Styling must be provided separately. Don't use these ones; they're intentionally bad. */
   .demo-section:before {
     color: #00A;
     content: 'Enlarge window to see Mzp.Details.destroy';


### PR DESCRIPTION
## Description

The native details element was getting double icons in IE11. It was doubling up because the native element is being styled, but it also gets classes and a button from the polyfill. This overrides native styling when the polyfill applies.

- [ ] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#658 

### Testing

http://localhost:3000/patterns/molecules/details.html

It's really just an issue in IE11 since I think that's the only browser that gets the polyfill. Older IEs get no fancy details support and modern browsers get native support.