### PR TITLE
Update docs to clarify brand variable use (fixes #697)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Bug Fixes
 
+* **docs** Update docs to clarify SCSS variable use (#697)
 * **css:** Override styling native summary element when it’s polyfilled in IE11 (#658)
 * **js:** Set global `Mzp` namespace to default to `window` as root (#687).
 

--- a/src/pages/fundamentals/themes.md
+++ b/src/pages/fundamentals/themes.md
@@ -23,6 +23,8 @@ If you want to produce a Firefox-branded website you'll need to compile the Prot
 $brand-theme: 'firefox';
 ```
 
+(Note: SCSS variables do not cascade like CSS variables because they are compiled away in the build step. If you want to use a SCSS variable in multiple files, you need to re-declare it or import it to those files.)
+
 - [An example of the Mozilla theme](/demos/theme-mozilla.html)
 - [An example of the Firefox theme](/demos/theme-firefox.html)
 


### PR DESCRIPTION
## Description

Adds small note to https://protocol.mozilla.org/fundamentals/themes.html documentation to explain how SCSS variables should work across multiple files.

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

https://github.com/mozilla/protocol/issues/697

### Testing

Check note is on correct page. Confirm clarity of note content.
