### PR TITLE
Picto bottom margins in multi-column [fix #699]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Bug Fixes
 
+* **css:** Let Picto retain its bottom margin in multi-column layouts in small viewports (#699)
 * **css:** Override styling native summary element when it’s polyfilled in IE11 (#658)
 * **js:** Set global `Mzp` namespace to default to `window` as root (#687).
 

--- a/src/assets/sass/protocol/components/_picto.scss
+++ b/src/assets/sass/protocol/components/_picto.scss
@@ -60,10 +60,12 @@
 }
 
 
-// Full width and no bottom margin in multi-column layout
-.mzp-l-columns .mzp-c-picto {
-    margin-bottom: 0;
-    width: 100%;
+// No bottom margins and full width in a multi-column layout
+@media #{$mq-md} {
+    .mzp-l-columns .mzp-c-picto {
+        margin-bottom: 0;
+        width: 100%;
+    }
 }
 
 


### PR DESCRIPTION
## Description

Picto has a rule zeroing the bottom margin in multi-column layouts. However, the columns only kick in at larger viewports so multi-column pictos had no vertical spacing when they stacked on mobile. This wraps that zero margin rule in a media query so it only takes effect with the columns do.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
#699 

### Testing
http://localhost:3000/patterns/molecules/picto.html
http://localhost:3000/demos/picto.html