### PR TITLE
Container update docs

### DIFF
--- a/src/patterns/organisms/call-out/call-out.hbs
+++ b/src/patterns/organisms/call-out/call-out.hbs
@@ -13,6 +13,8 @@ notes: |
       - `mzp-t-product-vpn`
       - `mzp-t-product-pocket`
     - A dark theme is also available using the theme class `mzp-t-dark`.
+nonos: |
+    - This component already has an inner container, so don't place it inside the `mzp-l-content` container. The nested spacing will get weird.
 links:
     Call Out Demo: /demos/call-out.html
 ---

--- a/src/patterns/organisms/hero/hero.hbs
+++ b/src/patterns/organisms/hero/hero.hbs
@@ -8,6 +8,8 @@ notes: |
   - The description can feature a larger tagline with the `mzp-c-hero-tagline` class.
   - Add the `mzp-t-dark` class to invert text colors for dark backgrounds.
   - [See the demo page](/demos/hero.html) for more examples in a full window context.
+nonos: |
+  - This component already has an inner container, so don't place it inside the `mzp-l-content` container. The nested spacing will get weird.
 links:
     More examples: /demos/hero.html
 ---

--- a/src/patterns/organisms/split/split.hbs
+++ b/src/patterns/organisms/split/split.hbs
@@ -15,6 +15,8 @@ notes: |
     - mobile display classes: `mzp-l-split-center-on-sm-md`, `mzp-l-split-hide-media-on-sm-md`
   - No default typography styles are applied to the body text; use atoms to achieve the desired content and appearance.
   - [See the demo page](/demos/split.html) for more examples in a full window context.
+nonos: |
+  - Split comes with a predefined column width, so don't place it inside containers with width-sizing classes, such as `mzp-l-content`.
 links:
     Demo: /demos/split.html
     Layout visualization: /demos/split-visual.html

--- a/src/patterns/organisms/split/split.hbs
+++ b/src/patterns/organisms/split/split.hbs
@@ -16,7 +16,7 @@ notes: |
   - No default typography styles are applied to the body text; use atoms to achieve the desired content and appearance.
   - [See the demo page](/demos/split.html) for more examples in a full window context.
 nonos: |
-  - Split comes with a predefined column width, so don't place it inside containers with width-sizing classes, such as `mzp-l-content`.
+  - This component already has an inner container, so don't place it inside the `mzp-l-content` container. The nested spacing will get weird.
 links:
     Demo: /demos/split.html
     Layout visualization: /demos/split-visual.html


### PR DESCRIPTION
## Description
Added **No-nos** section in Split, Hero, and Call Out document pages, and mentioned they shouldn't be placed in `mzp-l-content` containers

### Issue
#706 

### Testing

localhost:3000/patterns/organisms/split.html
localhost:3000/patterns/organisms/hero.html
localhost:3000/patterns/organisms/call-out.html

