### PR TITLE
Add warning when compiling deprecated components (Fixes #709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+* **css:** Add warning when compiling deprecated components (#709)
+
 * Migrate CI to GitHub actions
 
 ## Bug Fixes

--- a/src/assets/sass/protocol/components/_hero.scss
+++ b/src/assets/sass/protocol/components/_hero.scss
@@ -4,6 +4,8 @@
 
 @import '../includes/lib';
 
+@warn "Hero component is now deprecated. Please migrate to use Split: https://protocol.mozilla.org/patterns/organisms/split.html";
+
 // Page hero section - should usually appear at the top of a page
 
 // - The content is centered by default without a hero image.

--- a/src/assets/sass/protocol/components/_picto-card.scss
+++ b/src/assets/sass/protocol/components/_picto-card.scss
@@ -4,6 +4,8 @@
 
 @import '../includes/lib';
 
+@warn "Picto Card component is now deprecated. Please migrate to use Picto: https://protocol.mozilla.org/patterns/molecules/picto.html";
+
 //* -------------------------------------------------------------------------- */
 // A small card with an icon and no link.
 

--- a/src/patterns/organisms/hero/hero-branded.hbs
+++ b/src/patterns/organisms/hero/hero-branded.hbs
@@ -15,6 +15,8 @@ notes: |
     - `mzp-t-product-pocket`
   - This example shows a mock download button. Actual download buttons on mozilla.org are much more complex with a lot of hidden markup so the CTA wrapper here is a `div` where other examples use a `p` element (a paragraph can only contain text and phrasing elements; a `p` wouldn’t be correct for a real download button).
   - [See the demo page](/demos/hero.html) for more examples in a full window context.
+labels:
+  - deprecated
 ---
 
 {{#embed "patterns.organisms.hero.hero" image="true" class="mzp-t-product-firefox"}}

--- a/src/patterns/organisms/hero/hero-image.hbs
+++ b/src/patterns/organisms/hero/hero-image.hbs
@@ -14,6 +14,8 @@ notes: |
 tips: |
   - We recommend hero images at least 800px by 600px. A 16:9 aspect ratio works well though more of it can be hidden when the hero section is tall. Plan for this and choose your image wisely.
   - Choose your image wisely.
+labels:
+  - deprecated
 ---
 
 {{#embed "patterns.organisms.hero.hero" image="true"}}{{/embed}}

--- a/src/patterns/organisms/hero/hero.hbs
+++ b/src/patterns/organisms/hero/hero.hbs
@@ -12,6 +12,8 @@ nonos: |
   - This component already has an inner container, so don't place it inside the `mzp-l-content` container. The nested spacing will get weird.
 links:
     More examples: /demos/hero.html
+labels:
+  - deprecated
 ---
 
 <section class="mzp-c-hero {{#if image}}mzp-has-image{{/if}} {{#if class}}{{class}}{{/if}}">


### PR DESCRIPTION
## Description

Describe what this change does.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#709

### Testing

Running `npm install` should display warnings in console for each deprecated component
