### PR TITLE
Split updates, logo margins, 3xs title class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Features
 
+* **css:** Add content width classes to Split component.
+* **css:** Add default bottom margins to Logo and Wordmark components (#712)
+* **css:** Add `.mzp-u-title-3xs` utility class.
 * **css:** Add warning when compiling deprecated components (#709)
 
 * Migrate CI to GitHub actions

--- a/src/assets/sass/protocol/base/utilities/_titles.scss
+++ b/src/assets/sass/protocol/base/utilities/_titles.scss
@@ -42,3 +42,8 @@
     @include text-title-2xs;
     font-family: get-theme('title-font-family');
 }
+
+.mzp-u-title-3xs {
+    @include text-title-3xs;
+    font-family: get-theme('title-font-family');
+}

--- a/src/assets/sass/protocol/components/_split.scss
+++ b/src/assets/sass/protocol/components/_split.scss
@@ -17,15 +17,15 @@
 
     @media #{$mq-md} {
         padding: get-theme('v-grid-md') 0;
+
+        &.mzp-t-split-nospace {
+            padding-top: 0;
+            padding-bottom: 0;
+        }
     }
 
     @media #{$mq-xl} {
         padding: get-theme('v-grid-xl') 0;
-    }
-
-    &.mzp-t-split-nospace {
-        padding-top: 0;
-        padding-bottom: 0;
     }
 }
 
@@ -44,6 +44,18 @@
 
     @media #{$mq-xl} {
         padding: 0 get-theme('h-grid-xl');
+    }
+
+    .mzp-t-content-md & {
+        max-width: $content-md;
+    }
+
+    .mzp-t-content-lg & {
+        max-width: $content-lg;
+    }
+
+    .mzp-t-content-xl & {
+        max-width: $content-xl;
     }
 }
 

--- a/src/assets/sass/protocol/components/logos/_logo.scss
+++ b/src/assets/sass/protocol/components/logos/_logo.scss
@@ -14,17 +14,18 @@ $logo-sizes: (
     2xl: 'lg',
 );
 
-
 .mzp-c-logo {
     @include bidi(((background-position, top left, top right),));
     @include image-replaced;
-    background-size: contain;
     background-repeat: no-repeat;
+    background-size: contain;
     display: block;
+    margin-bottom: $layout-sm;
     margin-top: 0;
 
     &.mzp-t-logo-xs {
         height: $layout-xs;
+        margin-bottom: $layout-xs;
         width: $layout-xs;
     }
 
@@ -40,14 +41,17 @@ $logo-sizes: (
 
     &.mzp-t-logo-lg {
         height: $layout-lg;
+        margin-bottom: $layout-md;
         width: $layout-lg;
     }
 
     &.mzp-t-logo-xl {
         height: $layout-xl;
+        margin-bottom: $layout-lg;
         width: $layout-xl;
     }
 }
+
 @mixin logo($product, $dir, $layout-size, $logo-size) {
     $path : '#{$image-path}/logos/#{$dir}/logo-#{$logo-size}.png';
     $at2x_path: '#{$image-path}/logos/#{$dir}/logo-#{$logo-size}-high-res.png';

--- a/src/assets/sass/protocol/components/logos/_wordmark.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark.scss
@@ -20,11 +20,13 @@ $logo-sizes: (
     background-size: contain;
     background-repeat: no-repeat;
     display: block;
+    margin-bottom: $layout-sm;
     margin-top: 0;
     max-width: 100%;
 
     &.mzp-t-wordmark-xs {
         height: $layout-xs;
+        margin-bottom: $layout-xs;
         width: 130px;
     }
 
@@ -40,11 +42,13 @@ $logo-sizes: (
 
     &.mzp-t-wordmark-lg {
         height: $layout-lg;
+        margin-bottom: $layout-md;
         width: 347px;
     }
 
     &.mzp-t-wordmark-xl {
         height: $layout-xl;
+        margin-bottom: $layout-lg;
         width: 521px;
     }
 }

--- a/src/pages/demos/split-visual.hbs
+++ b/src/pages/demos/split-visual.hbs
@@ -57,11 +57,31 @@ styles:
     {{/content}}
   {{/embed}}
 
-
   {{#embed "patterns.organisms.split.split" block_classes="mzp-l-split-reversed" body_classes="" media_classes="mzp-l-split-media-overflow" }}
     {{#content "content"}}
-      <h2 class="mzp-c-card-feature-title">mzp-l-split-reversed</h2>
-      <p class="mzp-c-card-feature-desc">A reversed block will have the media on the left.</p>
+      <h2>mzp-l-split-reversed</h2>
+      <p>A reversed block will have the media on the left.</p>
+    {{/content}}
+  {{/embed}}
+
+  {{#embed "patterns.organisms.split.split" block_classes="mzp-t-content-md" }}
+    {{#content "content"}}
+      <h1>mzp-t-content-md</h1>
+      <p>A block with a medium content width.</p>
+    {{/content}}
+  {{/embed}}
+
+  {{#embed "patterns.organisms.split.split" block_classes="mzp-t-content-lg" }}
+    {{#content "content"}}
+      <h1>mzp-t-content-lg</h1>
+      <p>A block with a large content width.</p>
+    {{/content}}
+  {{/embed}}
+
+  {{#embed "patterns.organisms.split.split" block_classes="mzp-t-content-xl" }}
+    {{#content "content"}}
+      <h1>mzp-t-content-xl</h1>
+      <p>A block with an extra-large content width.</p>
     {{/content}}
   {{/embed}}
 

--- a/src/pages/demos/split.hbs
+++ b/src/pages/demos/split.hbs
@@ -5,7 +5,6 @@ styles:
   - split
 ---
 
-
 {{#embed "patterns.organisms.split.split" body_classes="" media_classes="mzp-l-split-media-overflow" }}
   {{#content "content"}}
     <h1>Heading</h1>
@@ -41,6 +40,39 @@ styles:
 {{/embed}}
 
 
+{{#embed "patterns.organisms.split.split" block_classes="mzp-t-content-md" }}
+  {{#content "content"}}
+    <h1>Heading</h1>
+    <p>Some fake text so you can see how it looks. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae finibus elit. Maecenas maximus sodales finibus. In at eros sit amet eros placerat vestibulum sed et nisl.</p>
+    <p>
+      <a class="mzp-c-button" href="#">Call to action</a>
+    </p>
+  {{/content}}
+{{/embed}}
+
+
+{{#embed "patterns.organisms.split.split" block_classes="mzp-t-content-lg" }}
+  {{#content "content"}}
+    <h1>Heading</h1>
+    <p>Some fake text so you can see how it looks. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae finibus elit. Maecenas maximus sodales finibus. In at eros sit amet eros placerat vestibulum sed et nisl.</p>
+    <p>
+      <a class="mzp-c-button" href="#">Call to action</a>
+    </p>
+  {{/content}}
+{{/embed}}
+
+
+{{#embed "patterns.organisms.split.split" block_classes="mzp-t-content-xl" }}
+  {{#content "content"}}
+    <h1>Heading</h1>
+    <p>Some fake text so you can see how it looks. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae finibus elit. Maecenas maximus sodales finibus. In at eros sit amet eros placerat vestibulum sed et nisl.</p>
+    <p>
+      <a class="mzp-c-button" href="#">Call to action</a>
+    </p>
+  {{/content}}
+{{/embed}}
+
+
 {{#embed "patterns.organisms.split.split" has_bg="mzp-t-dark" media_classes="mzp-l-split-media-constrain-height" }}
   {{#content "content"}}
     <h2>{{#embed "patterns.atoms.logo.logo" size="md" product="firefox" label="Firefox Browser"}}{{/embed}}</h2>
@@ -54,10 +86,10 @@ styles:
 
 {{#embed "patterns.organisms.split.split" block_classes="mzp-l-split-pop-bottom" has_bg="mzp-t-dark mzp-t-background-alt" media_classes="mzp-l-split-v-end"}}
   {{#content "content"}}
-    <h2>{{#embed "patterns.atoms.logo.wordmark" size="md" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</h2>
-      <h2>Remember your passwords in Lockwise</h2>
-      <p>No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.</p>
-      <p><a href="#" class="mzp-c-cta-link">Get the lockwise app</a></p>
+    <div>{{#embed "patterns.atoms.logo.wordmark" size="md" product="lockwise" label="Firefox Lockwise"}}{{/embed}}</div>
+    <h3>Remember your passwords in Lockwise</h3>
+    <p>No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.</p>
+    <p><a href="#" class="mzp-c-cta-link">Get the lockwise app</a></p>
   {{/content}}
 {{/embed}}
 

--- a/src/patterns/atoms/logo/logo.hbs
+++ b/src/patterns/atoms/logo/logo.hbs
@@ -1,15 +1,30 @@
 ---
 name: Logos
 description: |
-  1. Add the CSS files to your bundle. You will need both the file for logo and for the product logo you want.
-  2. Add the component class `mzp-c-logo` the size class (eg: `mzp-t-logo-md`) and the product class (eg: `mzp-t-product-firefox`) to your markup
-     - For vertical spacing put the logo classes on or inside a heading or paragraph.
+  1. Add the CSS files to your bundle. You will need the files for both the logo component and for the particular product logo you want to display.
+  2. Add the component class `mzp-c-logo` the size class (eg: `mzp-t-logo-md`) and the product class (eg: `mzp-t-product-firefox`) to your markup.
 order: 2
 notes: |
 tips: |
   - Logos need both a size and product theme to display.
-    - Size classes are: `mzp-t-logo-xs`, `mzp-t-logo-sm`, `mzp-t-logo-md`, `mzp-t-logo-lg`, `mzp-t-logo-xl`.
-    - Product classes are: `mzp-t-product-family`, `mzp-t-product-firefox`, `mzp-t-product-beta`, `mzp-t-product-developer`, `mzp-t-product-nightly`, `mzp-t-product-focus`, `mzp-t-product-lockwise`, `mzp-t-product-monitor`, `mzp-t-product-mozilla`, `mzp-t-product-vpn`, `mzp-t-product-pocket`.
+  - Size classes are:
+    - `mzp-t-logo-xs`
+    - `mzp-t-logo-sm`
+    - `mzp-t-logo-md`
+    - `mzp-t-logo-lg`
+    - `mzp-t-logo-xl`
+  - Product classes are:
+    - `mzp-t-product-family`
+    - `mzp-t-product-firefox`
+    - `mzp-t-product-beta`
+    - `mzp-t-product-developer`
+    - `mzp-t-product-nightly`
+    - `mzp-t-product-focus`
+    - `mzp-t-product-lockwise`
+    - `mzp-t-product-monitor`
+    - `mzp-t-product-mozilla`
+    - `mzp-t-product-vpn`
+    - `mzp-t-product-pocket`
 ---
 
 <div class="mzp-c-logo mzp-t-logo-{{#if size}}{{size}}{{else}}md{{/if}} mzp-t-product-{{#if product}}{{product}}{{else}}firefox{{/if}}">

--- a/src/patterns/atoms/logo/wordmark.hbs
+++ b/src/patterns/atoms/logo/wordmark.hbs
@@ -3,15 +3,30 @@ name: Wordmarks
 description: |
   Wordmarks work a lot like the logos except they change when nested under a `.mzp-t-dark` class.
 
-  1. Add the CSS files to your bundle. You will need both the file for wordmark and for the product wordmark you want.
-  2. Add the component class `mzp-c-wordmark` the size class (eg: `mzp-t-wordmark-md`) and the product class (eg: `mzp-t-product-firefox`) to your markup
-     - For vertical spacing put the wordmark classes on or inside a heading or paragraph.
+  1. Add the CSS files to your bundle. You will need the files for both the wordmark component and for the particular product wordmark you want to display.
+  2. Add the component class `mzp-c-wordmark` the size class (eg: `mzp-t-wordmark-md`) and the product class (eg: `mzp-t-product-firefox`) to your markup.
 order: 3
 notes: |
 tips: |
   - Wordmarks need both a size and product theme to display.
-    - Size classes are: `mzp-t-wordmark-xs`, `mzp-t-wordmark-sm`, `mzp-t-wordmark-md`, `mzp-t-wordmark-lg`, `mzp-t-wordmark-xl`.
-    - Product classes are: `mzp-t-product-family`, `mzp-t-product-firefox`, `mzp-t-product-beta`, `mzp-t-product-developer`, `mzp-t-product-nightly`, `mzp-t-product-focus`, `mzp-t-product-lockwise`, `mzp-t-product-monitor`, `mzp-t-product-mozilla`, `mzp-t-product-vpn`, `mzp-t-product-pocket`.
+  - Size classes are:
+    - `mzp-t-wordmark-xs`
+    - `mzp-t-wordmark-sm`
+    - `mzp-t-wordmark-md`
+    - `mzp-t-wordmark-lg`
+    - `mzp-t-wordmark-xl`
+  - Product classes are:
+    - `mzp-t-product-family`
+    - `mzp-t-product-firefox`
+    - `mzp-t-product-beta`
+    - `mzp-t-product-developer`
+    - `mzp-t-product-nightly`
+    - `mzp-t-product-focus`
+    - `mzp-t-product-lockwise`
+    - `mzp-t-product-monitor`
+    - `mzp-t-product-mozilla`
+    - `mzp-t-product-vpn`
+    - `mzp-t-product-pocket`
 ---
 
 <div class="mzp-c-wordmark mzp-t-wordmark-{{#if size}}{{size}}{{else}}md{{/if}} mzp-t-product-{{#if product}}{{product}}{{else}}firefox{{/if}}">

--- a/src/patterns/molecules/feature-card/feature-card.hbs
+++ b/src/patterns/molecules/feature-card/feature-card.hbs
@@ -3,15 +3,17 @@ name: Feature Card
 description: A single large feature card with media, headline, description & link.
 order: 7
 notes: |
-    - Feature cards have a range of different layout options, including horizontal layout classes.
+    - **The horizontal variants for this component are deprecated. Use the new [Split component](/patterns/molecules/split.html) instead.**
+    - Feature cards have a range of different layout options, including horizontal layout classes (deprecated in favor of Split).
       - `mzp-l-card-feature-left-half`
       - `mzp-l-card-feature-right-half`
       - `mzp-l-card-feature-left-third`
       - `mzp-l-card-feature-right-third`
-    - For dark color backgrounds, a `.mzp-t-dark` theme color is supported.
     - See the [demo page](/demos/feature-card.html) for a full list of examples.
 links:
     Feature Card Demo: /demos/feature-card.html
+labels:
+  - deprecated
 ---
 
 <section class="mzp-c-card-feature mzp-has-aspect-3-2 {{#if class}}{{class}}{{/if}}">

--- a/src/patterns/organisms/split/split-bg.hbs
+++ b/src/patterns/organisms/split/split-bg.hbs
@@ -2,10 +2,15 @@
 name: Themes
 order: 2
 description: |
-  Theme the Split by wrapping an element with the class `mzp-c-split-bg` around the inner container.
+  Theme the Split by wrapping an element with the class `mzp-c-split-bg` around the inner container. This can carry a background color that fills the width of the window, but the split's inner container still defines the content width.
 tips: |
-  - Use any of the standard background theme classes: `mzp-t-background-alt`, `mzp-t-dark`, or both together `mzp-t-dark mzp-t-background-alt`, or apply a custom background color in your own CSS.
-  - To make the background butt against the content above or below the Split, without additional vertical spacing, add the class `mzp-t-split-nospace`. Note that images can't "pop out" of a Split without that additional space.
+  - Use any of the standard background theme classes:
+    - `mzp-t-background-alt`
+    - `mzp-t-dark`
+    - both together `mzp-t-dark mzp-t-background-alt`
+    - or apply a custom background color in your own CSS
+  - To make the background butt against the content above or below the Split, without additional vertical spacing, add the class `mzp-t-split-nospace` to the outer container (`mzp-c-split`). This is especially useful when using Split as a hero section at the very top of a page.
+  Note that images can't "pop out" of a Split without that additional space.
 ---
 
 {{#embed "patterns.organisms.split.split" has_bg="mzp-t-dark"}}

--- a/src/patterns/organisms/split/split.hbs
+++ b/src/patterns/organisms/split/split.hbs
@@ -2,21 +2,47 @@
 name: Split
 order: 1
 description: |
-  Split a row into text and a single piece of media (image or video).
+  A full-width page section with text on one side and a single piece of media (an image or video) on the other, hence "split" into two columns. It's highly customizable with a lot of optional classes to support different layout variations.
 notes: |
-  - Highly customizable positioning options
-    - layout sizing classes: (50/50 even by default), `mzp-l-split-body-narrow`, `mzp-l-split-body-wide` (only in larger viewports; medium viewports will be 50/50, small viewports will stack)
-    - layout positioning classes: `mzp-l-split-reversed`
-    - body positioning classes: (horizontally left aligned by default), `mzp-l-split-h-center`, `mzp-l-split-h-end`, `mzp-l-split-v-start`, (vertically centered by default), `mzp-l-split-v-end`
-    - media sizing classes: `mzp-l-split-media-overflow`, `mzp-l-split-media-constrain-height`
-    - media positioning classes: (horizontally left aligned by default), `mzp-l-split-h-center`, `mzp-l-split-h-end`, `mzp-l-split-v-start`, (vertically centered by default), `mzp-l-split-v-end`
-      - note that the media can only be positioned horizontally if it does not have a sizing class added
-      - "pop" the media out of the container with: `mzp-l-split-pop-top`, `mzp-l-split-pop-bottom`, `mzp-l-split-pop`
-    - mobile display classes: `mzp-l-split-center-on-sm-md`, `mzp-l-split-hide-media-on-sm-md`
-  - No default typography styles are applied to the body text; use atoms to achieve the desired content and appearance.
+  - No default typography styles are applied to the body text; use other components or CSS for text styling.
+  - The body and media will stack in small viewports, switching to the two-column split layout in larger viewports.
+  - You can choose your preferred source order, with the media before or after the body, to optimize how you'd like it to stack in small viewports.
+  - Set the maximum content width by adding a class to the outermost containing block (`mzp-c-split`):
+    - `mzp-t-content-md`
+    - `mzp-t-content-lg`
+    - `mzp-t-content-xl`
+    - Note the lack of a "small" option. Content in two columns in a narrow container is usually a bad idea so we're not providing it.
+  - The Split is an even 50/50 by default, but you can adjust the body width (the part with the text) to make a 33/66 proportion. Add one of these classes to the body container (`mzp-c-split-body`):
+    - `mzp-l-split-body-narrow` - body is one third, media is two thirds.
+    - `mzp-l-split-body-wide` - body is two thirds, media is one third.
+    - Note that the wide and narrow body variants only take effect in larger viewports; it will be 50/50 in medium viewports (mostly to preserve readable line lengths). It stacks in small viewports, as normal.
+  - The orientation of the body and media changes automatically in right-to-left languages. By default, the body is on the left in left-to-right languages on the right in RTL. You can reverse the layout explicitly with a class on the main container (`mzp-c-split`):
+    - `mzp-l-split-reversed`
+    - A reversed layout will *also* reverse automatically in right-to-left languages.
+  - Align the body, horizontally and vertically (it's aligned left by default in LTR, and vertically centered). Apply these classes to the body container (`mzp-c-split-body`):
+    - `mzp-l-split-h-center` - horizontally centered.
+    - `mzp-l-split-h-end` - aligned right in left-to-right languages, left in right-to-left.
+    - `mzp-l-split-v-start` - vertically aligned to the top.
+    - `mzp-l-split-v-end` - vertically aligned to the bottom.
+  - Align the media in different positions, horizontally and vertically (it's aligned left by default on LTR, and vertically centered). Apply these classes to the media container (`mzp-c-split-media`):
+    - `mzp-l-split-h-center` - horizontally centered.
+    - `mzp-l-split-h-end` - aligned right in left-to-right languages, left in right-to-left.
+    - `mzp-l-split-v-start` - vertically aligned to the top.
+    - `mzp-l-split-v-end` - vertically aligned to the bottom.
+    - Note that the media can only be positioned horizontally if it does _not_ have a sizing class added, such as `mzp-l-split-media-overflow` or `mzp-l-split-media-constrain-height`
+  - You can control the behavior of the media with a class on the media container (`mzp-c-split-media`):
+    - `mzp-l-split-media-overflow` - the image can be larger than the Split container and will "bleed" past the edges. This means some of the image will be hidden, so choose images wisely.
+    - `mzp-l-split-media-constrain-height` - the image will scale to fit the height of the container, which depends on the amount of content in the body.
+  - The media can "pop" out of the container, protruding past the top and bottom edges. Apply these classes to the outer container (`mzp-c-split`):
+    - `mzp-l-split-pop-top` - protrude from the top.
+    - `mzp-l-split-pop-bottom` - protrude from the bottom.
+    - `mzp-l-split-pop` - both.
+  - Choose how to treat the Split on small screens. Apply these classes to the outer container (`mzp-c-split`):
+    - `mzp-l-split-center-on-sm-md` - content is centered on small to medium screens.
+    - `mzp-l-split-hide-media-on-sm-md` - media is hidden on small to medium screens.
   - [See the demo page](/demos/split.html) for more examples in a full window context.
 nonos: |
-  - This component already has an inner container, so don't place it inside the `mzp-l-content` container. The nested spacing will get weird.
+  - **Note:** This component is intended to be a full-width section of a page, with an outer container that spans the width of the viewport and generous spacing above and below. Split has an inner container to define its content width, so don't place Split inside another `mzp-l-content` container. The nested spacing will get weird.
 links:
     Demo: /demos/split.html
     Layout visualization: /demos/split-visual.html


### PR DESCRIPTION
## Description

* Added content width classes to Split component. This will help it play nicer when combined with other widths on the same page.
* Add bottom margins to logos and wordmarks [see #712]
* Added an `mzp-u-title-3xs` utility class. We revised the type scale after these classes were created and added another heading size, but didn't add a class for the new one.
* Misc doc updates. Rewrote Split docs for better clarity and easier reference.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
#712 - add default bottom margins on logos

### Testing
http://localhost:3000/patterns/organisms/split.html
http://localhost:3000/demos/split.html
http://localhost:3000/patterns/atoms/logo.html