### PR TITLE
had rules to card with mzp-t-dark class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # HEAD
 
 ## Features
-* **css:** Added overidding rules to the card component to enable dark mode with `.mzp-t-dark` class.
+* **css:** Add overidding rules to the card component to enable dark mode with `.mzp-t-dark` class.
 * **css:** Add content width classes to Split component.
 * **css:** Add default bottom margins to Logo and Wordmark components (#712)
 * **css:** Add `.mzp-u-title-3xs` utility class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # HEAD
 
 ## Features
-
+* **css:** Added overidding rules to the card component to enable dark mode with `.mzp-t-dark` class.
 * **css:** Add content width classes to Split component.
 * **css:** Add default bottom margins to Logo and Wordmark components (#712)
 * **css:** Add `.mzp-u-title-3xs` utility class.

--- a/src/assets/sass/protocol/components/_card.scss
+++ b/src/assets/sass/protocol/components/_card.scss
@@ -147,6 +147,10 @@
     }
 
     .mzp-c-card-block-link {
+        &:hover, &:active, &:focus {
+            box-shadow: 0 0 0 4px $color-marketing-gray-80;
+        }
+
         &:link, &:visited {
         color: get-theme('body-text-color-inverse');
 

--- a/src/assets/sass/protocol/components/_card.scss
+++ b/src/assets/sass/protocol/components/_card.scss
@@ -25,6 +25,7 @@
         @include aspect-ratio(3, 2);
     }
 
+
     .mzp-c-card-media-wrapper {
         background-color: $color-marketing-gray-20;
         border-radius: $border-radius-xs;
@@ -132,6 +133,24 @@
     @media #{$mq-md} {
         margin-bottom: $spacing-xl;
     }
+}
+
+//* -------------------------------------------------------------------------- */
+// Dark mode styling
+
+.mzp-c-card.mzp-t-dark {
+    background-color: get-theme('background-color-inverse');
+    color: get-theme('body-text-color-inverse');
+
+     .mzp-c-card-block-link {
+        &:link, &:visited {
+            color: get-theme('body-text-color-inverse');
+
+            .mzp-c-card-cta-text {
+                color: get-theme('body-text-color-inverse');
+            }
+        }
+     }
 }
 
 //* -------------------------------------------------------------------------- */

--- a/src/assets/sass/protocol/components/_card.scss
+++ b/src/assets/sass/protocol/components/_card.scss
@@ -137,7 +137,8 @@
 //* -------------------------------------------------------------------------- */
 // Dark mode styling
 
-.mzp-c-card.mzp-t-dark {
+.mzp-c-card.mzp-t-dark,
+.mzp-t-dark .mzp-c-card {
     background-color: get-theme('background-color-inverse');
     color: get-theme('body-text-color-inverse');
 

--- a/src/assets/sass/protocol/components/_card.scss
+++ b/src/assets/sass/protocol/components/_card.scss
@@ -25,7 +25,6 @@
         @include aspect-ratio(3, 2);
     }
 
-
     .mzp-c-card-media-wrapper {
         background-color: $color-marketing-gray-20;
         border-radius: $border-radius-xs;

--- a/src/assets/sass/protocol/components/_card.scss
+++ b/src/assets/sass/protocol/components/_card.scss
@@ -141,15 +141,19 @@
     background-color: get-theme('background-color-inverse');
     color: get-theme('body-text-color-inverse');
 
-     .mzp-c-card-block-link {
+    .mzp-c-card-tag, .mzp-c-card-meta {
+        color: get-theme('body-text-color-inverse');
+    }
+
+    .mzp-c-card-block-link {
         &:link, &:visited {
-            color: get-theme('body-text-color-inverse');
+        color: get-theme('body-text-color-inverse');
 
             .mzp-c-card-cta-text {
                 color: get-theme('body-text-color-inverse');
             }
         }
-     }
+    }
 }
 
 //* -------------------------------------------------------------------------- */

--- a/src/pages/demos/card-layout.hbs
+++ b/src/pages/demos/card-layout.hbs
@@ -85,7 +85,7 @@ styles:
   </div>
 </div>
 
-<div class="mzp-l-content">
+<div class="mzp-l-content mzp-t-dark">
   <header>
     <h2>2 Card Layout - dark mode</h2>
     <ul class="mzp-u-list-styled">
@@ -95,8 +95,8 @@ styles:
   </header>
 
   <div class="mzp-l-card-half">
-    {{#embed "patterns.molecules.card.small-card" class="mzp-t-dark"}}{{/embed}}
-    {{#embed "patterns.molecules.card.small-card" class="mzp-t-dark"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-c-card-medium mzp-has-aspect-3-2"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-c-card-medium mzp-has-aspect-3-2"}}{{/embed}}
   </div>
 </div>
 

--- a/src/pages/demos/card-layout.hbs
+++ b/src/pages/demos/card-layout.hbs
@@ -85,5 +85,21 @@ styles:
   </div>
 </div>
 
+<div class="mzp-l-content">
+  <header>
+    <h2>2 Card Layout - dark mode</h2>
+    <ul class="mzp-u-list-styled">
+      <li>To use dark mode either place the `.mzp-t-dark` class on the element that contains the `.mzp-c-card` class or place the card
+      within a container that is using the dark mode class.</li>
+    </ul>
+  </header>
+
+  <div class="mzp-l-card-half">
+    {{#embed "patterns.molecules.card.small-card" class="mzp-t-dark"}}{{/embed}}
+    {{#embed "patterns.molecules.card.small-card" class="mzp-t-dark"}}{{/embed}}
+  </div>
+</div>
+
+
 
 

--- a/src/patterns/molecules/card/dark-mode-card.hbs
+++ b/src/patterns/molecules/card/dark-mode-card.hbs
@@ -1,13 +1,13 @@
 ---
-name: Medium Card - Dark mode
+name: Card - Dark mode
 description: A medium card with image, headline, description, and link using the dark mode class `.mzp-t-dark`.
 order: 6
 notes: |
     - To use dark mode either place the `.mzp-t-dark` class on the element that contains the `.mzp-c-card` class or place the card within a container that is using the dark mode class.
 links:
-Card Layout Class: /patterns/templates/card-layout.html
-Card Layout Demo: /demos/card-layout.html
+    Card Layout Class: /patterns/templates/card-layout.html
+    Card Layout Demo: /demos/card-layout.html
 ---
 
-{{#embed "patterns.molecules.card.small-card" class="mzp-c-card-medium mzp-has-aspect-3-2 mzp-has-video"
+{{#embed "patterns.molecules.card.small-card" class="mzp-c-card-medium mzp-t-dark mzp-has-aspect-3-2"
 cta="true"}}{{/embed}}

--- a/src/patterns/molecules/card/dark-mode-card.hbs
+++ b/src/patterns/molecules/card/dark-mode-card.hbs
@@ -1,0 +1,13 @@
+---
+name: Medium Card - Dark mode
+description: A medium card with image, headline, description, and link using the dark mode class `.mzp-t-dark`.
+order: 6
+notes: |
+    - To use dark mode either place the `.mzp-t-dark` class on the element that contains the `.mzp-c-card` class or place the card within a container that is using the dark mode class.
+links:
+Card Layout Class: /patterns/templates/card-layout.html
+Card Layout Demo: /demos/card-layout.html
+---
+
+{{#embed "patterns.molecules.card.small-card" class="mzp-c-card-medium mzp-has-aspect-3-2 mzp-has-video"
+cta="true"}}{{/embed}}


### PR DESCRIPTION
## Description
Added some rules when adding the `.mzp-t-dark` class to enable dark mode styled cards. I used the same themes as in other areas of protocol, but let me know if anything should change. 

Added some rules to override the links and `p` tags in the card component so the color would be visible for dark mode. Since dark mode isn't listed outside of the themes section, I wasn't sure how it should be documented. 

<img width="328" alt="Screen Shot 2021-09-07 at 3 48 22 PM" src="https://user-images.githubusercontent.com/30009669/132420212-c69890b9-948a-4390-8f86-a58e06f1dcd3.png">

- [ ] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
#714

### Testing
Wasn't sure how we would want to add this card _variant_ to the documentation since dark mode is only referenced in the themes section of the docs. If you build this locally, you can just add the `.mzp-t-dark` class to any card to it's container. I created the rules so it would have to be on whichever element has the `mzp-c-card` class.
