### PR TITLE
Update Node version in build.sh

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -7,5 +7,5 @@ docker run --rm --label=node \
     -v $(pwd)/.config:/.config \
     -v $(pwd)/.npm:/.npm \
     -v $(pwd):/app -w /app\
-    node:10-alpine \
+    node:14-alpine \
     npm run-script build


### PR DESCRIPTION
## Description

Recent deployments have been failing because our versions of some dependencies no longer work in Node 10, which is what the build script is using. This updates the build to Node 14 which should support the other dependencies.

Recent failure: https://gitlab.com/mozmeao/protocol/-/jobs/1589827585

`Error: yargs supports a minimum Node.js version of 12. Read our version support policy: https://github.com/yargs/yargs#supported-nodejs-versions`