### PR TITLE
Use SVG instead of PNG for logos and wordmarks [#723]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* **assets** Refactored logo and wordmark mixins to use SVG assets instead of PNG
 * **component:** New responsive video container.
 
 ## Bug Fixes

--- a/src/assets/sass/protocol/components/logos/_logo.scss
+++ b/src/assets/sass/protocol/components/logos/_logo.scss
@@ -53,7 +53,7 @@ $logo-sizes: (
 }
 
 @mixin logo($product, $dir, $layout-size, $logo-size) {
-    $path : '#{$image-path}/logos/#{$dir}/logo-#{$logo-size}.svg';
+    $path : '#{$image-path}/logos/#{$dir}/logo.svg';
 
     .mzp-c-logo.mzp-t-product-#{$product}.mzp-t-logo-#{$layout-size} {
         background-image: url('#{$path}');

--- a/src/assets/sass/protocol/components/logos/_logo.scss
+++ b/src/assets/sass/protocol/components/logos/_logo.scss
@@ -53,17 +53,9 @@ $logo-sizes: (
 }
 
 @mixin logo($product, $dir, $layout-size, $logo-size) {
-    $path : '#{$image-path}/logos/#{$dir}/logo-#{$logo-size}.png';
-    $at2x_path: '#{$image-path}/logos/#{$dir}/logo-#{$logo-size}-high-res.png';
+    $path : '#{$image-path}/logos/#{$dir}/logo-#{$logo-size}.svg';
 
     .mzp-c-logo.mzp-t-product-#{$product}.mzp-t-logo-#{$layout-size} {
         background-image: url('#{$path}');
-
-        // xs does not need high res version, it's shrunk for low-res
-        @if $layout-size != 'xs' {
-            @media #{$mq-high-res} {
-                background-image: url('#{$at2x_path}');
-            }
-        }
     }
 }

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-vpn.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-vpn.scss
@@ -7,31 +7,14 @@
 
 // can't re-use wordmark mixin because VPN uses the "stack" version by default
 @each $layout-size, $logo-size in $logo-sizes {
-    $path : '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-#{$logo-size}.png';
-    $at2x_path: '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-#{$logo-size}-high-res.png';
-    $path_white : '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-white-#{$logo-size}.png';
-    $at2x_path_white: '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-white-#{$logo-size}-high-res.png';
+    $path : '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-#{$logo-size}.svg';
+    $path_white : '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-white-#{$logo-size}.svg';
 
     .mzp-c-wordmark.mzp-t-product-vpn.mzp-t-wordmark-#{$layout-size} {
         background-image: url('#{$path}');
 
-        // xs does not need high res version, it's shrunk for low-res
-        @if $layout-size != 'xs' {
-            @media #{$mq-high-res} {
-                background-image: url('#{$at2x_path}');
-            }
-        }
-
         .mzp-t-dark & {
             background-image: url('#{$path_white}');
-
-            // xs does not need high res version, it's shrunk for low-res
-            @if $layout-size != 'xs' {
-                @media #{$mq-high-res} {
-                    background-image: url('#{$at2x_path_white}');
-                }
-            }
-
         }
     }
 

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-vpn.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-vpn.scss
@@ -7,8 +7,8 @@
 
 // can't re-use wordmark mixin because VPN uses the "stack" version by default
 @each $layout-size, $logo-size in $logo-sizes {
-    $path : '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-#{$logo-size}.svg';
-    $path_white : '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-white-#{$logo-size}.svg';
+    $path : '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack.svg';
+    $path_white : '#{$image-path}/logos/mozilla/vpn/logo-word-hor-stack-white.svg';
 
     .mzp-c-wordmark.mzp-t-product-vpn.mzp-t-wordmark-#{$layout-size} {
         background-image: url('#{$path}');

--- a/src/assets/sass/protocol/components/logos/_wordmark.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark.scss
@@ -54,31 +54,14 @@ $logo-sizes: (
 }
 
 @mixin wordmark($product, $dir, $layout-size, $logo-size) {
-    $path : '#{$image-path}/logos/#{$dir}/logo-word-hor-#{$logo-size}.png';
-    $at2x_path: '#{$image-path}/logos/#{$dir}/logo-word-hor-#{$logo-size}-high-res.png';
-    $path_white : '#{$image-path}/logos/#{$dir}/logo-word-hor-white-#{$logo-size}.png';
-    $at2x_path_white: '#{$image-path}/logos/#{$dir}/logo-word-hor-white-#{$logo-size}-high-res.png';
+    $path : '#{$image-path}/logos/#{$dir}/logo-word-hor-#{$logo-size}.svg';
+    $path_white : '#{$image-path}/logos/#{$dir}/logo-word-hor-white-#{$logo-size}.svg';
 
     .mzp-c-wordmark.mzp-t-product-#{$product}.mzp-t-wordmark-#{$layout-size} {
         background-image: url('#{$path}');
 
-        // xs does not need high res version, it's shrunk for low-res
-        @if $layout-size != 'xs' {
-            @media #{$mq-high-res} {
-                background-image: url('#{$at2x_path}');
-            }
-        }
-
         .mzp-t-dark & {
             background-image: url('#{$path_white}');
-
-            // xs does not need high res version, it's shrunk for low-res
-            @if $layout-size != 'xs' {
-                @media #{$mq-high-res} {
-                    background-image: url('#{$at2x_path_white}');
-                }
-            }
-
         }
     }
 }

--- a/src/assets/sass/protocol/components/logos/_wordmark.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark.scss
@@ -54,8 +54,8 @@ $logo-sizes: (
 }
 
 @mixin wordmark($product, $dir, $layout-size, $logo-size) {
-    $path : '#{$image-path}/logos/#{$dir}/logo-word-hor-#{$logo-size}.svg';
-    $path_white : '#{$image-path}/logos/#{$dir}/logo-word-hor-white-#{$logo-size}.svg';
+    $path : '#{$image-path}/logos/#{$dir}/logo-word-hor.svg';
+    $path_white : '#{$image-path}/logos/#{$dir}/logo-word-hor-white.svg';
 
     .mzp-c-wordmark.mzp-t-product-#{$product}.mzp-t-wordmark-#{$layout-size} {
         background-image: url('#{$path}');


### PR DESCRIPTION
## Description

We are working towards a smaller protocol-assets dependency size. This will involve removing PNG assets, which will break our current logo and wordmark mixins. We want to preserve the use of these mixins, but return SVG assets instead of PNG.

~⚠️ Cannot merge until Focus logo is available in SVG with next protocol-assets version~ Merged! All clear

- [ ] I have documented this change in the design system. 
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

https://github.com/mozilla/protocol/issues/723

### Testing

http://localhost:3000/demos/logo.html

Check all logos look as expected

