### PR TITLE
Create new breadcrumb component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Features
+
+* **component:** New breadcrumb component.
+
 # 15.1.0
 
 ## Features

--- a/src/assets/sass/protocol/components/_breadcrumb.scss
+++ b/src/assets/sass/protocol/components/_breadcrumb.scss
@@ -7,30 +7,30 @@
 .mzp-c-breadcrumb {
     background-color: #f3f3f3;
     margin-bottom: 0;
-    padding: 8px 18px;
+    padding: $spacing-sm $spacing-md;
 
     .mzp-c-breadcrumb-item {
-        display: inline;
+        font-weight: bold;
+        &:before {
+            @include bidi(((content, "\2192", "\2190"),));
+            font-weight: normal;
+            margin: 0 0.25em;
+        }
+    }
+
+    .mzp-c-breadcrumb-item, .mzp-c-breadcrumb-title {
+        display: inline-block;
         font-weight: 400;
 
         .mzp-c-breadcrumb-item-link {
             text-decoration: none;
-        }
-
-        &:not(.mzp-c-breadcrumb-title) {
-            font-weight: bold;
-            &:before {
-                content: ">";
-                font-weight: normal;
-                margin: 0 2px;
-            }
         }
     }
     &.mzp-t-dark {
         background-color: $color-black;
     }
     @media #{$mq-md} {
-        padding: 8px 80px;
+        padding: $spacing-sm $layout-xl - $spacing-md;
     }
 
 }

--- a/src/assets/sass/protocol/components/_breadcrumb.scss
+++ b/src/assets/sass/protocol/components/_breadcrumb.scss
@@ -5,24 +5,23 @@
 @import '../includes/lib';
 
 .mzp-c-breadcrumb {
-    background-color: $color-light-gray-20;
+    background-color: get-theme('background-color-alt');
     margin-bottom: 0;
     padding: $spacing-sm $spacing-md;
 
     .mzp-c-breadcrumb-item {
         display: inline-block;
+        font-weight: 400;
 
-        &:first-child {
-            font-weight: 400;
+        &:last-child {
+            font-weight: bold;
         }
 
         + .mzp-c-breadcrumb-item {
-            font-weight: bold;
-
             &:before {
-                @include bidi(((content, "\003E", "\003C"),));
+                @include bidi(((content, "\2192", "\2190"),));
                 font-weight: normal;
-                margin: 0 0.25em;
+                margin: 0 .25em;
             }
         }
 
@@ -31,10 +30,8 @@
         }
     }
 
-
-
     &.mzp-t-dark {
-        background-color: $color-black;
+        background-color: get-theme('background-color-alt');
     }
 
     @media #{$mq-md} {
@@ -44,5 +41,4 @@
     @media #{$mq-lg} {
         padding: $spacing-sm $layout-xl - $spacing-md;
     }
-
 }

--- a/src/assets/sass/protocol/components/_breadcrumb.scss
+++ b/src/assets/sass/protocol/components/_breadcrumb.scss
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../includes/lib';
+
+.mzp-c-breadcrumb {
+    background-color: #f3f3f3;
+    margin-bottom: 0;
+    padding: 8px 18px;
+
+    .mzp-c-breadcrumb-item {
+        display: inline;
+        font-weight: 400;
+
+        .mzp-c-breadcrumb-item-link {
+            text-decoration: none;
+        }
+
+        &:not(.mzp-c-breadcrumb-title) {
+            font-weight: bold;
+            &:before {
+                content: ">";
+                font-weight: normal;
+                margin: 0 2px;
+            }
+        }
+    }
+    &.mzp-t-dark {
+        background-color: $color-black;
+    }
+    @media #{$mq-md} {
+        padding: 8px 80px;
+    }
+
+}

--- a/src/assets/sass/protocol/components/_breadcrumb.scss
+++ b/src/assets/sass/protocol/components/_breadcrumb.scss
@@ -6,39 +6,41 @@
 
 .mzp-c-breadcrumb {
     background-color: get-theme('background-color-alt');
-    margin-bottom: 0;
-    padding: $spacing-sm $spacing-md;
 
-    .mzp-c-breadcrumb-item {
-        display: inline-block;
-        font-weight: 400;
+    .mzp-c-breadcrumb-list {
+        margin-bottom: 0;
+        padding: $spacing-sm $spacing-md;
 
-        &:last-child {
-            font-weight: bold;
-        }
+        .mzp-c-breadcrumb-item {
+            display: inline-block;
 
-        + .mzp-c-breadcrumb-item {
-            &:before {
-                @include bidi(((content, "\2192", "\2190"),));
-                font-weight: normal;
-                margin: 0 .25em;
+            &:last-child {
+                font-weight: bold;
+            }
+
+            + .mzp-c-breadcrumb-item {
+                &:before {
+                    @include bidi(((content, "\2192", "\2190"),));
+                    font-weight: normal;
+                    margin: 0 .25em;
+                }
+            }
+
+            a {
+                text-decoration: none;
             }
         }
 
-        .mzp-c-breadcrumb-item-link {
-            text-decoration: none;
+        @media #{$mq-md} {
+            padding: $spacing-sm $layout-sm;
+        }
+
+        @media #{$mq-lg} {
+            padding: $spacing-sm $layout-xl - $spacing-md;
         }
     }
 
     &.mzp-t-dark {
-        background-color: get-theme('background-color-alt');
-    }
-
-    @media #{$mq-md} {
-        padding: $spacing-sm $layout-sm;
-    }
-
-    @media #{$mq-lg} {
-        padding: $spacing-sm $layout-xl - $spacing-md;
+        background-color: get-theme('background-color-alt-inverse');
     }
 }

--- a/src/assets/sass/protocol/components/_breadcrumb.scss
+++ b/src/assets/sass/protocol/components/_breadcrumb.scss
@@ -5,31 +5,43 @@
 @import '../includes/lib';
 
 .mzp-c-breadcrumb {
-    background-color: #f3f3f3;
+    background-color: $color-light-gray-20;
     margin-bottom: 0;
     padding: $spacing-sm $spacing-md;
 
     .mzp-c-breadcrumb-item {
-        font-weight: bold;
-        &:before {
-            @include bidi(((content, "\2192", "\2190"),));
-            font-weight: normal;
-            margin: 0 0.25em;
-        }
-    }
-
-    .mzp-c-breadcrumb-item, .mzp-c-breadcrumb-title {
         display: inline-block;
-        font-weight: 400;
+
+        &:first-child {
+            font-weight: 400;
+        }
+
+        + .mzp-c-breadcrumb-item {
+            font-weight: bold;
+
+            &:before {
+                @include bidi(((content, "\003E", "\003C"),));
+                font-weight: normal;
+                margin: 0 0.25em;
+            }
+        }
 
         .mzp-c-breadcrumb-item-link {
             text-decoration: none;
         }
     }
+
+
+
     &.mzp-t-dark {
         background-color: $color-black;
     }
+
     @media #{$mq-md} {
+        padding: $spacing-sm $layout-sm;
+    }
+
+    @media #{$mq-lg} {
         padding: $spacing-sm $layout-xl - $spacing-md;
     }
 

--- a/src/assets/sass/protocol/protocol-components.scss
+++ b/src/assets/sass/protocol/protocol-components.scss
@@ -16,6 +16,7 @@ $image-path: '../img' !default;
 @import 'components/article';
 @import 'components/billboard';
 @import 'components/button';
+@import 'components/breadcrumb';
 @import 'components/call-out';
 @import 'components/emphasis-box';
 @import 'components/feature-card';

--- a/src/patterns/molecules/breadcrumb/breadcrumb.hbs
+++ b/src/patterns/molecules/breadcrumb/breadcrumb.hbs
@@ -9,11 +9,11 @@ notes: |
 ---
 
 <ol class="mzp-c-breadcrumb">
-  <li class="mzp-c-breadcrumb-item mzp-c-breadcrumb-title">
+  <li class="mzp-c-breadcrumb-title">
     <a class="mzp-c-breadcrumb-item-link" href="#">Parent page</a>
   </li>
   <li class="mzp-c-breadcrumb-item">
-    <a class="mzp-c-breadcrumb-item-link" href="#">Child page</a>
+    <a class="mzp-c-breadcrumb-item-link" href="#">Child page longer title a little bit longer now</a>
   </li>
 </ol>
 

--- a/src/patterns/molecules/breadcrumb/breadcrumb.hbs
+++ b/src/patterns/molecules/breadcrumb/breadcrumb.hbs
@@ -1,19 +1,19 @@
 ---
 name: Breadcrumb
-description: A type of navigation menu used to provide a list of links based on current page within the site heirarchy, allowing users to visit previous pages from the current page.
+description: A type of navigation menu used to provide a list of links based on current page within the site hierarchy, allowing users to visit previous pages from the current page.
 order: 1
 notes: |
-    - Current implementation was designed for only one child item. Additional items have not been tested.
     - Use the `.mzp-t-dark` options to use dark mode.
     - Use a `<ol>` to use semantic HTML and structure.
+    - Using the `nav` element is optional, but reccomended.
 ---
 <nav aria-label="breadcrumb">
-  <ol class="mzp-c-breadcrumb mzp-u-list-styled">
+  <ol class="mzp-c-breadcrumb">
     <li class="mzp-c-breadcrumb-item">
       <a class="mzp-c-breadcrumb-item-link" href="#">Parent page</a>
     </li>
     <li aria-current="page" class="mzp-c-breadcrumb-item">
-      <a class="mzp-c-breadcrumb-item-link" href="#">Child page</a>
+      Child page
     </li>
   </ol>
 </nav>

--- a/src/patterns/molecules/breadcrumb/breadcrumb.hbs
+++ b/src/patterns/molecules/breadcrumb/breadcrumb.hbs
@@ -1,0 +1,20 @@
+---
+name: Breadcrumb
+description: A type of navigation menu used to provide a list of links based on current page within the site heirarchy, allowing users to visit previous pages from the current page. Current implementation is to use this component as a header.
+order: 1
+notes: |
+    - Current implementation was designed for only one child item. Additional items have not been tested.
+    - Use the `.mzp-t-dark` options to use dark mode.
+    - Use a `<ol>` to use semantic HTML and structure.
+---
+
+<ol class="mzp-c-breadcrumb">
+  <li class="mzp-c-breadcrumb-item mzp-c-breadcrumb-title">
+    <a class="mzp-c-breadcrumb-item-link" href="#">Parent page</a>
+  </li>
+  <li class="mzp-c-breadcrumb-item">
+    <a class="mzp-c-breadcrumb-item-link" href="#">Child page</a>
+  </li>
+</ol>
+
+

--- a/src/patterns/molecules/breadcrumb/breadcrumb.hbs
+++ b/src/patterns/molecules/breadcrumb/breadcrumb.hbs
@@ -1,20 +1,21 @@
 ---
 name: Breadcrumb
-description: A type of navigation menu used to provide a list of links based on current page within the site heirarchy, allowing users to visit previous pages from the current page. Current implementation is to use this component as a header.
+description: A type of navigation menu used to provide a list of links based on current page within the site heirarchy, allowing users to visit previous pages from the current page.
 order: 1
 notes: |
     - Current implementation was designed for only one child item. Additional items have not been tested.
     - Use the `.mzp-t-dark` options to use dark mode.
     - Use a `<ol>` to use semantic HTML and structure.
 ---
-
-<ol class="mzp-c-breadcrumb">
-  <li class="mzp-c-breadcrumb-title">
-    <a class="mzp-c-breadcrumb-item-link" href="#">Parent page</a>
-  </li>
-  <li class="mzp-c-breadcrumb-item">
-    <a class="mzp-c-breadcrumb-item-link" href="#">Child page longer title a little bit longer now</a>
-  </li>
-</ol>
+<nav aria-label="breadcrumb">
+  <ol class="mzp-c-breadcrumb mzp-u-list-styled">
+    <li class="mzp-c-breadcrumb-item">
+      <a class="mzp-c-breadcrumb-item-link" href="#">Parent page</a>
+    </li>
+    <li aria-current="page" class="mzp-c-breadcrumb-item">
+      <a class="mzp-c-breadcrumb-item-link" href="#">Child page</a>
+    </li>
+  </ol>
+</nav>
 
 

--- a/src/patterns/molecules/breadcrumb/breadcrumb.hbs
+++ b/src/patterns/molecules/breadcrumb/breadcrumb.hbs
@@ -3,14 +3,13 @@ name: Breadcrumb
 description: A type of navigation menu used to provide a list of links based on current page within the site hierarchy, allowing users to visit previous pages from the current page.
 order: 1
 notes: |
+    - Use a `<ol>` nested within a `<nav>` to use semantic HTML and structure.
     - Use the `.mzp-t-dark` options to use dark mode.
-    - Use a `<ol>` to use semantic HTML and structure.
-    - Using the `nav` element is optional, but reccomended.
 ---
-<nav aria-label="breadcrumb">
-  <ol class="mzp-c-breadcrumb">
+<nav aria-label="breadcrumb" class="mzp-c-breadcrumb">
+  <ol class="mzp-c-breadcrumb-list">
     <li class="mzp-c-breadcrumb-item">
-      <a class="mzp-c-breadcrumb-item-link" href="#">Parent page</a>
+      <a href="#">Parent page</a>
     </li>
     <li aria-current="page" class="mzp-c-breadcrumb-item">
       Child page


### PR DESCRIPTION
## Description
Created a new breadcrumb component which will be initially used in theVPN Resource Center, but will most likely be used in other areas on mozilla.org. 

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

### Testing

Start your local server and navigate to http://localhost:3000/patterns/molecules/breadcrumb.html# and compare to current Figma [design](https://www.figma.com/file/xo5JhiQIlpGWkb9lgh0ccZ/VPN-Resource-Guide?node-id=16%3A256)
![Screen Shot 2021-09-29 at 5 16 55 PM](https://user-images.githubusercontent.com/30009669/135365757-ba6f91db-95f9-483c-af50-712cef0e5194.png)
Short text on mobile sizing:
![Screen Shot 2021-09-29 at 5 17 05 PM](https://user-images.githubusercontent.com/30009669/135365775-6a465239-d138-4b4d-a55a-54768da44c63.png)


