### PR TITLE
Remove sticky nav for reduced motion (fixes #733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Bug Fixes
 
+* **js** when navigation has `mzp-is-sticky` class, respect user preference for reduced motion (#733)
 * **css:** Replace deprecated `/` division operator with `math.div()` (#722)
 * **css:** Set Split media width to 100% to accommodate responsive video (#711)
 

--- a/src/assets/js/protocol/protocol-navigation.js
+++ b/src/assets/js/protocol/protocol-navigation.js
@@ -213,13 +213,20 @@ if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
          * If there are multiple navigation organisms on a single page,
          * assume only the first (and hence top-most) instance can and
          * will be sticky.
+         *
+         * Do not init sticky navigation if user prefers reduced motion
          */
-        _navElem = document.querySelector('.mzp-c-navigation');
 
-        if (_navElem && _navElem.classList.contains('mzp-is-sticky')) {
-            if (Navigation.supportsSticky()) {
-                Navigation.initSticky();
-            }
+        _navElem = document.querySelector('.mzp-c-navigation');
+        var _navIsSticky =
+            _navElem &&
+            _navElem.classList.contains('mzp-is-sticky') &&
+            Navigation.supportsSticky();
+
+        if (_navIsSticky && matchMedia('(prefers-reduced-motion)').matches) {
+            _navElem.classList.remove('mzp-is-sticky');
+        } else if (_navIsSticky) {
+            Navigation.initSticky();
         }
     };
 

--- a/src/patterns/organisms/navigation/navigation.hbs
+++ b/src/patterns/organisms/navigation/navigation.hbs
@@ -14,6 +14,7 @@ notes: |
       - `onNavClose` [Function] A callback when the small screen navigation icon is clicked to close (optional).
   - Navigation can opt-in to sticky scroll behaviour by adding the class `mzp-is-sticky`.
       - Sticky behaviour will only be applied to viewports that are wider than `$mq-md` and taller than `$mq-tall`.
+      - Sticky behaviour will never be applied for users who prefer reduced motion.
 links:
     Navigation Demo: /demos/navigation.html
 ---

--- a/tests/unit/protocol-navigation.js
+++ b/tests/unit/protocol-navigation.js
@@ -91,5 +91,15 @@ describe('protocol-navigation.js', function() {
             Mzp.Navigation.init();
             expect(Mzp.Navigation.createSticky).not.toHaveBeenCalled();
         });
+
+        it('should not create sticky behaviour for users who prefer reduced motion', function() {
+            var nav = document.querySelector('.mzp-c-navigation');
+            nav.classList.add('mzp-is-sticky');
+            spyOn(window, 'matchMedia').withArgs('(prefers-reduced-motion)').and.returnValue({ matches: true });
+            spyOn(Mzp.Navigation, 'initSticky');
+            Mzp.Navigation.init();
+            expect(Mzp.Navigation.initSticky).not.toHaveBeenCalled();
+            expect(nav.classList.contains('mzp-is-sticky')).toBeFalse();
+        });
     });
 });


### PR DESCRIPTION
## Description

We want to remove sticky behaviour from the nav for users who prefer reduced motion.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
https://github.com/mozilla/protocol/issues/733

### Testing

You'll have to toggle your preference for reduced motion according to your user agent: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences

http://localhost:3000/demos/navigation.html

When you prefer reduced motion, the nav should be static.
When you do not prefer reduced motion, the nav should be sticky with animations to scroll in and out of view on page scroll (current behaviour all the time on https://www.mozilla.org/en-US/).

ℹ️ I have a fix for this specifically in bedrock: https://github.com/mozilla/bedrock/pull/10592
Do we want to merge that fix for now and save this until we can fully backport the bedrock nav as well?
