### PR TITLE
Bump version to 15.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# HEAD
+# 15.0.0
 
 ## Features
 
@@ -14,7 +14,7 @@
 
 ## Migration Tips
 
-* See notes for [Protocol Assets 5.0.0](https://github.com/mozilla/protocol-assets/blob/main/CHANGELOG.md#migration-tips)
+* This version updates the included assets, removing the PNG versions of logos and wordmarks. If you're relying on those assets via Protocol, you'll need to update or find alternative sources. See notes for [Protocol Assets 5.0.0](https://github.com/mozilla/protocol-assets/blob/main/CHANGELOG.md#500)
 
 # 14.1.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "14.1.0",
+  "version": "15.0.0",
   "private": true,
   "author": "Mozilla",
   "description": "A design system for Mozilla's websites.",

--- a/src/assets/package/README.md
+++ b/src/assets/package/README.md
@@ -20,7 +20,7 @@ Install package with NPM and add it to your dependencies:
 </tr>
 <tr>
 <td>Version</td>
-<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">14.1.0</a></td>
+<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">15.0.0</a></td>
 </tr>
 </table>
 

--- a/src/assets/package/package.json
+++ b/src/assets/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/core",
-  "version": "14.1.0",
+  "version": "15.0.0",
   "description": "A design system for Mozilla's websites.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
Updates to 15.0.0. This is a breaking change because it includes the upstream breaking change to assets, hence the major version numbering.

- [x] I have recorded this change in `CHANGELOG.md`.
