### PR TITLE
Correct Split docs, body width class goes on the container

### DIFF
--- a/src/patterns/organisms/split/split.hbs
+++ b/src/patterns/organisms/split/split.hbs
@@ -12,7 +12,7 @@ notes: |
     - `mzp-t-content-lg`
     - `mzp-t-content-xl`
     - Note the lack of a "small" option. Content in two columns in a narrow container is usually a bad idea so we're not providing it.
-  - The Split is an even 50/50 by default, but you can adjust the body width (the part with the text) to make a 33/66 proportion. Add one of these classes to the body container (`mzp-c-split-body`):
+  - The Split is an even 50/50 by default, but you can adjust the body width (the part with the text) to make a 33/66 proportion. Add one of these classes to the outermost container (`mzp-c-split`):
     - `mzp-l-split-body-narrow` - body is one third, media is two thirds.
     - `mzp-l-split-body-wide` - body is two thirds, media is one third.
     - Note that the wide and narrow body variants only take effect in larger viewports; it will be 50/50 in medium viewports (mostly to preserve readable line lengths). It stacks in small viewports, as normal.


### PR DESCRIPTION
## Description

Noticed a mistake in the Split notes. The body width class goes on the outer container, not the body container (because grid). Just a doc fix, doesn't need to go in the changelog.

### Testing

http://localhost:3000/patterns/organisms/split.html
