### PR TITLE
Add Firefox Relay logos and wordmarks (fixes #738)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+## Features
+
+* **assets** Add Firefox Relay logos and wordmarks
+
 # 15.0.0
 
 ## Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "14.1.0",
+  "version": "15.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -331,9 +331,9 @@
       }
     },
     "@mozilla-protocol/assets": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/assets/-/assets-5.0.0.tgz",
-      "integrity": "sha512-P+0jVGt5oSx5wjssKUeWAhJo5Q3nl1yEsF7G/JD4y20nvVnSonMdqCTQo2YKQmaJLEuT+rlSg+BJgfhZWFhNJw=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/assets/-/assets-5.1.0.tgz",
+      "integrity": "sha512-8q+3IwQUO57ZqpGDb+VI4CjDG9g39xcAuVTi1X77jfCJSmMweXAKFW1dhDpLC/Jdmv5LuclhAyWCieggf5Rdmw=="
     },
     "@mozilla-protocol/eslint-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@cloudfour/hbs-helpers": "^0.9.0",
-    "@mozilla-protocol/assets": "^5.0.0",
+    "@mozilla-protocol/assets": "^5.1.0",
     "@mozilla-protocol/tokens": "^5.0.5",
     "del": "^6.0.0",
     "drizzle-builder": "0.0.10",

--- a/src/assets/sass/protocol/components/logos/_logo-product-relay.scss
+++ b/src/assets/sass/protocol/components/logos/_logo-product-relay.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'relay';
+$dir: 'firefox/relay';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include logo($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/components/logos/_wordmark-product-relay.scss
+++ b/src/assets/sass/protocol/components/logos/_wordmark-product-relay.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import 'logo';
+
+$class: 'relay';
+$dir: 'firefox/relay';
+
+@each $layout-size, $logo-size in $logo-sizes {
+    @include wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/src/assets/sass/protocol/protocol-components.scss
+++ b/src/assets/sass/protocol/protocol-components.scss
@@ -56,6 +56,7 @@ $image-path: '../img' !default;
 @import 'components/logos/logo-product-family';
 @import 'components/logos/logo-product-lockwise';
 @import 'components/logos/logo-product-monitor';
+@import 'components/logos/logo-product-relay';
 
 @import 'components/logos/logo-product-mozilla';
 @import 'components/logos/logo-product-vpn';
@@ -72,6 +73,7 @@ $image-path: '../img' !default;
 @import 'components/logos/wordmark-product-family';
 @import 'components/logos/wordmark-product-lockwise';
 @import 'components/logos/wordmark-product-monitor';
+@import 'components/logos/wordmark-product-relay';
 
 @import 'components/logos/wordmark-product-mozilla';
 @import 'components/logos/wordmark-product-vpn';

--- a/src/pages/demos/logo.hbs
+++ b/src/pages/demos/logo.hbs
@@ -90,6 +90,12 @@ styles:
       <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="monitor" label="Firefox Monitor"}}{{/embed}}</td>
       <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="monitor" label="Firefox Monitor"}}{{/embed}}</td>
     </tr>
+    <tr>
+      <td><code>relay</code></td>
+      <td>{{#embed "patterns.atoms.logo.logo" size="lg" product="relay" label="Firefox Relay"}}{{/embed}}</td>
+      <td>{{#embed "patterns.atoms.logo.wordmark" size="lg" product="relay" label="Firefox Relay"}}{{/embed}}</td>
+      <td class="mzp-t-dark">{{#embed "patterns.atoms.logo.wordmark" size="lg" product="relay" label="Firefox Relay"}}{{/embed}}</td>
+    </tr>
 
     <tr>
       <td><code>mozilla</code></td>

--- a/src/patterns/atoms/logo/logo.hbs
+++ b/src/patterns/atoms/logo/logo.hbs
@@ -25,6 +25,7 @@ tips: |
     - `mzp-t-product-mozilla`
     - `mzp-t-product-vpn`
     - `mzp-t-product-pocket`
+    - `mzp-t-product-relay`
 ---
 
 <div class="mzp-c-logo mzp-t-logo-{{#if size}}{{size}}{{else}}md{{/if}} mzp-t-product-{{#if product}}{{product}}{{else}}firefox{{/if}}">

--- a/src/patterns/atoms/logo/wordmark.hbs
+++ b/src/patterns/atoms/logo/wordmark.hbs
@@ -27,6 +27,7 @@ tips: |
     - `mzp-t-product-mozilla`
     - `mzp-t-product-vpn`
     - `mzp-t-product-pocket`
+    - `mzp-t-product-relay`
 ---
 
 <div class="mzp-c-wordmark mzp-t-wordmark-{{#if size}}{{size}}{{else}}md{{/if}} mzp-t-product-{{#if product}}{{product}}{{else}}firefox{{/if}}">


### PR DESCRIPTION
## Description

Adds logo and wordmark components for Firefox Relay after [Protocol Assets update](https://github.com/mozilla/protocol-assets/pull/80).

Describe what this change does.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

https://github.com/mozilla/protocol/issues/738

### Testing

http://localhost:3000/demos/logo.html
