### PR TITLE
Add tertiary theme color, rename alt to secondary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
+# HEAD
+
 ## Features
 
+* **css:** Add tertiary theme colors.
+* **css:** (breaking) Rename "alt" theme colors to "secondary."
 * **component:** New breadcrumb component.
+
+## Migration Tips
+
+* Update any uses of the theme variable `background-color-alt` (in the `get-theme()` function) to `background-color-secondary`.
+* Update any uses of the `mzp-t-background-alt` class to `mzp-t-background-secondary`.
 
 # 15.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ## Migration Tips
 
 * Update any uses of the theme variable `background-color-alt` (in the `get-theme()` function) to `background-color-secondary`.
+* Update any uses of the theme variable `background-color-alt-inverse` (in the `get-theme()` function) to `background-color-secondary-inverse`.
+* Update any uses of the theme variable `body-text-color-alt` (in the `get-theme()` function) to `body-text-color-secondary`.
+* Update any uses of the theme variable `body-text-color-alt-inverse` (in the `get-theme()` function) to `body-text-color-secondary-inverse`.
 * Update any uses of the `mzp-t-background-alt` class to `mzp-t-background-secondary`.
 
 # 15.1.0

--- a/src/assets/sass/demos/theme-firefox.scss
+++ b/src/assets/sass/demos/theme-firefox.scss
@@ -15,38 +15,13 @@ $brand-theme: 'firefox';
     @include text-title-xl;
 }
 
-.background-secondary {
-    background: get-theme('background-color-secondary');
+.mzp-t-background-secondary,
+.mzp-t-background-tertiary,
+.mzp-t-dark:not(.mzp-c-button) {
     padding: $spacing-md;
 }
 
-.background-tertiary {
-    background: get-theme('background-color-tertiary');
-    padding: $spacing-md;
-}
-
-.background-inverse {
-    @include light-links;
-    background: get-theme('background-color-inverse');
-    color: get-theme('body-text-color-inverse');
-    padding: $spacing-md;
-}
-
-.background-secondary-inverse {
-    @include light-links;
-    background: get-theme('background-color-secondary-inverse');
-    color: get-theme('body-text-color-secondary-inverse');
-    padding: $spacing-md;
-}
-
-.background-accent-inverse {
-    @include light-links;
-    background: get-theme('background-color-tertiary-inverse');
-    color: get-theme('body-text-color-inverse');
-    padding: $spacing-md;
-}
-
-.text-alt {
+.text-secondary {
     color: get-theme('body-text-color-secondary');
 }
 

--- a/src/assets/sass/demos/theme-firefox.scss
+++ b/src/assets/sass/demos/theme-firefox.scss
@@ -15,8 +15,13 @@ $brand-theme: 'firefox';
     @include text-title-xl;
 }
 
-.background-alt {
-    background: get-theme('background-color-alt');
+.background-secondary {
+    background: get-theme('background-color-secondary');
+    padding: $spacing-md;
+}
+
+.background-tertiary {
+    background: get-theme('background-color-tertiary');
     padding: $spacing-md;
 }
 
@@ -27,15 +32,22 @@ $brand-theme: 'firefox';
     padding: $spacing-md;
 }
 
-.background-alt-inverse {
+.background-secondary-inverse {
     @include light-links;
-    background: get-theme('background-color-alt-inverse');
-    color: get-theme('body-text-color-alt-inverse');
+    background: get-theme('background-color-secondary-inverse');
+    color: get-theme('body-text-color-secondary-inverse');
+    padding: $spacing-md;
+}
+
+.background-accent-inverse {
+    @include light-links;
+    background: get-theme('background-color-tertiary-inverse');
+    color: get-theme('body-text-color-inverse');
     padding: $spacing-md;
 }
 
 .text-alt {
-    color: get-theme('body-text-color-alt');
+    color: get-theme('body-text-color-secondary');
 }
 
 .body-xl {

--- a/src/assets/sass/demos/theme-mozilla.scss
+++ b/src/assets/sass/demos/theme-mozilla.scss
@@ -15,8 +15,13 @@ $brand-theme: 'mozilla';
     @include text-title-xl;
 }
 
-.background-alt {
-    background: get-theme('background-color-alt');
+.background-secondary {
+    background: get-theme('background-color-secondary');
+    padding: $spacing-md;
+}
+
+.background-accent {
+    background: get-theme('background-color-accent');
     padding: $spacing-md;
 }
 
@@ -27,15 +32,22 @@ $brand-theme: 'mozilla';
     padding: $spacing-md;
 }
 
-.background-alt-inverse {
+.background-secondary-inverse {
     @include light-links;
-    background: get-theme('background-color-alt-inverse');
-    color: get-theme('body-text-color-alt-inverse');
+    background: get-theme('background-color-secondary-inverse');
+    color: get-theme('body-text-color-secondary-inverse');
     padding: $spacing-md;
 }
 
-.text-alt {
-    color: get-theme('body-text-color-alt');
+.background-accent-inverse {
+    @include light-links;
+    background: get-theme('background-color-accent-inverse');
+    color: get-theme('body-text-color-inverse');
+    padding: $spacing-md;
+}
+
+.text-secondary {
+    color: get-theme('body-text-color-secondary');
 }
 
 .body-xl {

--- a/src/assets/sass/demos/theme-mozilla.scss
+++ b/src/assets/sass/demos/theme-mozilla.scss
@@ -15,34 +15,9 @@ $brand-theme: 'mozilla';
     @include text-title-xl;
 }
 
-.background-secondary {
-    background: get-theme('background-color-secondary');
-    padding: $spacing-md;
-}
-
-.background-accent {
-    background: get-theme('background-color-accent');
-    padding: $spacing-md;
-}
-
-.background-inverse {
-    @include light-links;
-    background: get-theme('background-color-inverse');
-    color: get-theme('body-text-color-inverse');
-    padding: $spacing-md;
-}
-
-.background-secondary-inverse {
-    @include light-links;
-    background: get-theme('background-color-secondary-inverse');
-    color: get-theme('body-text-color-secondary-inverse');
-    padding: $spacing-md;
-}
-
-.background-accent-inverse {
-    @include light-links;
-    background: get-theme('background-color-accent-inverse');
-    color: get-theme('body-text-color-inverse');
+.mzp-t-background-secondary,
+.mzp-t-background-tertiary,
+.mzp-t-dark:not(.mzp-c-button) {
     padding: $spacing-md;
 }
 

--- a/src/assets/sass/protocol/base/elements/_quotes.scss
+++ b/src/assets/sass/protocol/base/elements/_quotes.scss
@@ -17,7 +17,7 @@ blockquote {
 
     cite {
         @include text-title-xs;
-        color: get-theme('body-text-color-alt');
+        color: get-theme('body-text-color-secondary');
 
         &:before {
             content: '— ';

--- a/src/assets/sass/protocol/base/utilities/_backgrounds.scss
+++ b/src/assets/sass/protocol/base/utilities/_backgrounds.scss
@@ -27,5 +27,5 @@
 
 .mzp-t-dark.mzp-t-background-tertiary,
 .mzp-t-dark .mzp-t-background-tertiary {
-    background-color: get-theme('background-color-accent-inverse');
+    background-color: get-theme('background-color-tertiary-inverse');
 }

--- a/src/assets/sass/protocol/base/utilities/_backgrounds.scss
+++ b/src/assets/sass/protocol/base/utilities/_backgrounds.scss
@@ -7,8 +7,12 @@
 
 // Theme classes for background colors
 
-.mzp-t-background-alt {
-    background-color: get-theme('background-color-alt');
+.mzp-t-background-secondary {
+    background-color: get-theme('background-color-secondary');
+}
+
+.mzp-t-background-tertiary {
+    background-color: get-theme('background-color-tertiary');
 }
 
 .mzp-t-dark {
@@ -16,7 +20,12 @@
     color: get-theme('body-text-color-inverse');
 }
 
-.mzp-t-dark.mzp-t-background-alt,
-.mzp-t-dark .mzp-t-background-alt {
-    background-color: get-theme('background-color-alt-inverse');
+.mzp-t-dark.mzp-t-background-secondary,
+.mzp-t-dark .mzp-t-background-secondary {
+    background-color: get-theme('background-color-secondary-inverse');
+}
+
+.mzp-t-dark.mzp-t-background-tertiary,
+.mzp-t-dark .mzp-t-background-tertiary {
+    background-color: get-theme('background-color-accent-inverse');
 }

--- a/src/assets/sass/protocol/components/_breadcrumb.scss
+++ b/src/assets/sass/protocol/components/_breadcrumb.scss
@@ -5,7 +5,7 @@
 @import '../includes/lib';
 
 .mzp-c-breadcrumb {
-    background-color: get-theme('background-color-alt');
+    background-color: get-theme('background-color-secondary');
 
     .mzp-c-breadcrumb-list {
         margin-bottom: 0;
@@ -41,6 +41,6 @@
     }
 
     &.mzp-t-dark {
-        background-color: get-theme('background-color-alt-inverse');
+        background-color: get-theme('background-color-secondary-inverse');
     }
 }

--- a/src/assets/sass/protocol/components/_call-out.scss
+++ b/src/assets/sass/protocol/components/_call-out.scss
@@ -8,11 +8,11 @@
 // Call Out component
 
 .mzp-c-call-out {
-    background-color: get-theme('background-color-alt');
+    background-color: get-theme('background-color-accent');
     text-align: center;
 
     &.mzp-t-dark {
-        background-color: get-theme('background-color-alt-inverse');
+        background-color: get-theme('background-color-accent-inverse');
         color: get-theme('body-text-color-inverse');
 
         .mzp-c-call-out-desc {
@@ -97,10 +97,10 @@
 // Compact Call Out component
 
 .mzp-c-call-out-compact {
-    background-color: get-theme('background-color-alt');
+    background-color: get-theme('background-color-accent');
 
     &.mzp-t-dark {
-        background-color: get-theme('background-color-alt-inverse');
+        background-color: get-theme('background-color-accent-inverse');
         color: get-theme('body-text-color-inverse');
 
         .mzp-c-call-out-desc {

--- a/src/assets/sass/protocol/components/_call-out.scss
+++ b/src/assets/sass/protocol/components/_call-out.scss
@@ -8,11 +8,11 @@
 // Call Out component
 
 .mzp-c-call-out {
-    background-color: get-theme('background-color-accent');
+    background-color: get-theme('background-color-secondary');
     text-align: center;
 
     &.mzp-t-dark {
-        background-color: get-theme('background-color-accent-inverse');
+        background-color: get-theme('background-color-secondary-inverse');
         color: get-theme('body-text-color-inverse');
 
         .mzp-c-call-out-desc {
@@ -97,10 +97,10 @@
 // Compact Call Out component
 
 .mzp-c-call-out-compact {
-    background-color: get-theme('background-color-accent');
+    background-color: get-theme('background-color-secondary');
 
     &.mzp-t-dark {
-        background-color: get-theme('background-color-accent-inverse');
+        background-color: get-theme('background-color-secondary-inverse');
         color: get-theme('body-text-color-inverse');
 
         .mzp-c-call-out-desc {

--- a/src/assets/sass/protocol/components/_feature-card.scss
+++ b/src/assets/sass/protocol/components/_feature-card.scss
@@ -66,7 +66,7 @@
         color: get-theme('body-text-color-inverse');
 
         .mzp-c-card-feature-desc {
-            color: get-theme('body-text-color-alt-inverse');
+            color: get-theme('body-text-color-secondary-inverse');
         }
     }
 

--- a/src/assets/sass/protocol/components/_hero.scss
+++ b/src/assets/sass/protocol/components/_hero.scss
@@ -35,7 +35,7 @@
         color: get-theme('body-text-color-inverse');
 
         .mzp-c-hero-desc {
-            color: get-theme('body-text-color-alt-inverse');
+            color: get-theme('body-text-color-secondary-inverse');
         }
     }
 }

--- a/src/assets/sass/protocol/components/_picto-card.scss
+++ b/src/assets/sass/protocol/components/_picto-card.scss
@@ -36,7 +36,7 @@
 
     .mzp-c-card-picto-desc {
         @include text-body-md;
-        color: get-theme('body-text-color-alt');
+        color: get-theme('body-text-color-secondary');
         margin-bottom: 0;
     }
 
@@ -45,7 +45,7 @@
         color: get-theme('body-text-color-inverse');
 
         .mzp-c-card-picto-desc {
-            color: get-theme('body-text-color-alt-inverse');
+            color: get-theme('body-text-color-secondary-inverse');
         }
     }
 

--- a/src/assets/sass/protocol/components/forms/_form.scss
+++ b/src/assets/sass/protocol/components/forms/_form.scss
@@ -20,7 +20,7 @@
 
     &.mzp-t-dark,
     .mzp-t-dark & {
-        color: get-theme('body-text-color-alt-inverse');
+        color: get-theme('body-text-color-secondary-inverse');
     }
 
     // if we're using the form component bottom spacing comes from `field` and `choice` components

--- a/src/assets/sass/protocol/includes/_themes.scss
+++ b/src/assets/sass/protocol/includes/_themes.scss
@@ -52,12 +52,14 @@ $theme-fonts-mozilla: (
 // Colors
 
 $theme-colors-firefox: (
-    background-color-alt-inverse: $color-ink-50,
-    background-color-alt: $color-light-gray-10,
+    background-color-tertiary-inverse: $color-ink-20,
+    background-color-tertiary: $color-marketing-gray-20,
+    background-color-secondary-inverse: $color-ink-50,
+    background-color-secondary: $color-light-gray-10,
     background-color-inverse: $color-ink-80,
     background-color: $color-white,
-    body-text-color-alt-inverse: $color-marketing-gray-30,
-    body-text-color-alt: $color-marketing-gray-70,
+    body-text-color-secondary-inverse: $color-marketing-gray-30,
+    body-text-color-secondary: $color-marketing-gray-70,
     body-text-color-inverse: $color-white,
     body-text-color: $color-marketing-gray-80,
     link-color-hover-inverse: $color-blue-05,
@@ -73,12 +75,14 @@ $theme-colors-firefox: (
 );
 
 $theme-colors-mozilla: (
-    background-color-alt-inverse: $color-dark-gray-60,
-    background-color-alt: $color-light-gray-10,
+    background-color-tertiary-inverse: $color-dark-gray-40,
+    background-color-tertiary: $color-light-gray-30,
+    background-color-secondary-inverse: $color-dark-gray-60,
+    background-color-secondary: $color-light-gray-10,
     background-color-inverse: $color-black,
     background-color: $color-white,
-    body-text-color-alt-inverse: $color-light-gray-30,
-    body-text-color-alt: $color-dark-gray-90,
+    body-text-color-secondary-inverse: $color-light-gray-30,
+    body-text-color-secondary: $color-dark-gray-90,
     body-text-color-inverse: $color-white,
     body-text-color: $color-black,
     link-color-hover-inverse: $color-blue-05,
@@ -217,7 +221,7 @@ $theme-type-scale-condensed-mozilla: (
 
 // Collect the maps for easier reference, so you don't have to refer to a specific submap.
 // Usage:
-//    map-get($theme-firefox, 'background-color-alt');
+//    map-get($theme-firefox, 'background-color-secondary');
 
 $theme-firefox: map-collect($theme-spacing, $theme-fonts-firefox, $theme-colors-firefox, $theme-type-scale-firefox);
 $theme-mozilla: map-collect($theme-spacing, $theme-fonts-mozilla, $theme-colors-mozilla, $theme-type-scale-mozilla);

--- a/src/assets/sass/protocol/includes/forms/_lib.scss
+++ b/src/assets/sass/protocol/includes/forms/_lib.scss
@@ -13,7 +13,7 @@
 
 // colors
 $form-red: #D70022;
-$form-text: get-theme('body-text-color-alt');
+$form-text: get-theme('body-text-color-secondary');
 
 // fields
 $field-border-color: $color-marketing-gray-50;

--- a/src/pages/demos/theme-firefox.hbs
+++ b/src/pages/demos/theme-firefox.hbs
@@ -9,50 +9,50 @@ styles:
 <div class="mzp-l-content mzp-t-content-md">
   <h1 class="title">Firefox theme</h1>
 
-  <div class="background-alt">
+  <div class="mzp-t-background-secondary">
     <p>Secondary background color</p>
 
-    <p class="background-accent">Accent background color on secondary background</p>
+    <p class="mzp-t-background-tertiary">Tertiary background color on secondary background</p>
   </div>
 
-  <p class="background-accent">Accent background color</p>
+  <p class="mzp-t-background-tertiary">Tertiary background color</p>
 
   <p>Body text including a <a href="https://example.com">normal link</a>. {{ sentence }}</p>
 
-  <p class="text-alt">Secondary text color</p>
+  <p class="text-secondary">Secondary text color</p>
 
   <p><a class="mzp-c-cta-link" href="https://example.com">CTA link</a></p>
 
   <p>
-    <button class="mzp-c-button mzp-t-md">Button</button>
-    <a href="#" class="mzp-c-button mzp-t-secondary mzp-t-md">Button</a>
-    <button class="mzp-c-button mzp-t-product mzp-t-lg">Button</button>
-    <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg">Button</a>
+    <button class="mzp-c-button">Button</button>
+    <a href="#" class="mzp-c-button mzp-t-secondary">Button</a>
+    <button class="mzp-c-button mzp-t-product">Button</button>
+    <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary">Button</a>
     <button class="mzp-c-button mzp-t-neutral">Button</button>
   </p>
 
-  <div class="background-inverse">
+  <div class="mzp-t-dark">
     <p>Inverse colors, including a <a href="https://example.com">normal link</a>. {{ sentence }}</p>
     <p>
-      <button class="mzp-c-button mzp-t-md mzp-t-dark">Button</button>
-      <a href="#" class="mzp-c-button mzp-t-secondary mzp-t-md mzp-t-dark">Button</a>
-      <button class="mzp-c-button mzp-t-product mzp-t-lg mzp-t-dark">Button</button>
-      <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg mzp-t-dark">Button</a>
+      <button class="mzp-c-button mzp-t-dark">Button</button>
+      <a href="#" class="mzp-c-button mzp-t-secondary mzp-t-dark">Button</a>
+      <button class="mzp-c-button mzp-t-product mzp-t-dark">Button</button>
+      <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-dark">Button</a>
       <button class="mzp-c-button mzp-t-neutral mzp-t-dark">Button</button>
     </p>
-    <p class="background-accent-inverse">Inverse accent background color</p>
+    <p class="mzp-t-background-tertiary">Inverse tertiary background color</p>
   </div>
 
-  <div class="background-alt-inverse">
+  <div class="mzp-t-background-secondary mzp-t-dark">
     <p>Secondary inverse colors, including a <a href="https://example.com">normal link</a>. {{ sentence }}</p>
     <p>
-      <button class="mzp-c-button mzp-t-md mzp-t-dark">Button</button>
-      <a href="#" class="mzp-c-button mzp-t-secondary mzp-t-md mzp-t-dark">Button</a>
-      <button class="mzp-c-button mzp-t-product mzp-t-lg mzp-t-dark">Button</button>
-      <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg mzp-t-dark">Button</a>
+      <button class="mzp-c-button mzp-t-dark">Button</button>
+      <a href="#" class="mzp-c-button mzp-t-secondary mzp-t-dark">Button</a>
+      <button class="mzp-c-button mzp-t-product mzp-t-dark">Button</button>
+      <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-dark">Button</a>
       <button class="mzp-c-button mzp-t-neutral mzp-t-dark">Button</button>
     </p>
-    <p class="background-accent-inverse">Inverse accent background color</p>
+    <p class="mzp-t-background-tertiary">Inverse tertiary background color</p>
   </div>
 
   <hr>

--- a/src/pages/demos/theme-firefox.hbs
+++ b/src/pages/demos/theme-firefox.hbs
@@ -9,7 +9,13 @@ styles:
 <div class="mzp-l-content mzp-t-content-md">
   <h1 class="title">Firefox theme</h1>
 
-  <p class="background-alt">Secondary background color</p>
+  <div class="background-alt">
+    <p>Secondary background color</p>
+
+    <p class="background-accent">Accent background color on secondary background</p>
+  </div>
+
+  <p class="background-accent">Accent background color</p>
 
   <p>Body text including a <a href="https://example.com">normal link</a>. {{ sentence }}</p>
 
@@ -34,6 +40,7 @@ styles:
       <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg mzp-t-dark">Button</a>
       <button class="mzp-c-button mzp-t-neutral mzp-t-dark">Button</button>
     </p>
+    <p class="background-accent-inverse">Inverse accent background color</p>
   </div>
 
   <div class="background-alt-inverse">
@@ -45,6 +52,7 @@ styles:
       <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg mzp-t-dark">Button</a>
       <button class="mzp-c-button mzp-t-neutral mzp-t-dark">Button</button>
     </p>
+    <p class="background-accent-inverse">Inverse accent background color</p>
   </div>
 
   <hr>

--- a/src/pages/demos/theme-mozilla.hbs
+++ b/src/pages/demos/theme-mozilla.hbs
@@ -9,7 +9,13 @@ styles:
 <div class="mzp-l-content mzp-t-content-md">
   <h1 class="title">Mozilla theme</h1>
 
-  <p class="background-alt">Secondary background color</p>
+  <div class="background-alt">
+    <p>Secondary background color</p>
+
+    <p class="background-accent">Accent background color</p>
+  </div>
+
+  <p class="background-accent">Accent background color</p>
 
   <p>Body text including a <a href="https://example.com">normal link</a>. {{ sentence }}</p>
 
@@ -34,6 +40,7 @@ styles:
       <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg mzp-t-dark">Button</a>
       <button class="mzp-c-button mzp-t-neutral mzp-t-dark">Button</button>
     </p>
+    <p class="background-accent-inverse">Inverse accent background color</p>
   </div>
 
   <div class="background-alt-inverse">
@@ -45,6 +52,7 @@ styles:
       <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg mzp-t-dark">Button</a>
       <button class="mzp-c-button mzp-t-neutral mzp-t-dark">Button</button>
     </p>
+    <p class="background-accent-inverse">Inverse accent background color</p>
   </div>
 
   <hr>

--- a/src/pages/demos/theme-mozilla.hbs
+++ b/src/pages/demos/theme-mozilla.hbs
@@ -9,50 +9,50 @@ styles:
 <div class="mzp-l-content mzp-t-content-md">
   <h1 class="title">Mozilla theme</h1>
 
-  <div class="background-alt">
+  <div class="mzp-t-background-secondary">
     <p>Secondary background color</p>
 
-    <p class="background-accent">Accent background color</p>
+    <p class="mzp-t-background-tertiary">Tertiary background color</p>
   </div>
 
-  <p class="background-accent">Accent background color</p>
+  <p class="mzp-t-background-tertiary">Tertiary background color</p>
 
   <p>Body text including a <a href="https://example.com">normal link</a>. {{ sentence }}</p>
 
-  <p class="text-alt">Secondary text color</p>
+  <p class="text-secondary">Secondary text color</p>
 
   <p><a class="mzp-c-cta-link" href="https://example.com">CTA link</a></p>
 
   <p>
-    <button class="mzp-c-button mzp-t-md">Button</button>
-    <a href="#" class="mzp-c-button mzp-t-secondary mzp-t-md">Button</a>
-    <button class="mzp-c-button mzp-t-product mzp-t-lg">Button</button>
-    <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg">Button</a>
+    <button class="mzp-c-button">Button</button>
+    <a href="#" class="mzp-c-button mzp-t-secondary">Button</a>
+    <button class="mzp-c-button mzp-t-product">Button</button>
+    <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary">Button</a>
     <button class="mzp-c-button mzp-t-neutral">Button</button>
   </p>
 
-  <div class="background-inverse">
+  <div class="mzp-t-dark">
     <p>Inverse colors, including a <a href="https://example.com">normal link</a>. {{ sentence }}</p>
     <p>
-      <button class="mzp-c-button mzp-t-md mzp-t-dark">Button</button>
-      <a href="#" class="mzp-c-button mzp-t-secondary mzp-t-md mzp-t-dark">Button</a>
-      <button class="mzp-c-button mzp-t-product mzp-t-lg mzp-t-dark">Button</button>
-      <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg mzp-t-dark">Button</a>
+      <button class="mzp-c-button mzp-t-dark">Button</button>
+      <a href="#" class="mzp-c-button mzp-t-secondary mzp-t-dark">Button</a>
+      <button class="mzp-c-button mzp-t-product mzp-t-dark">Button</button>
+      <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-dark">Button</a>
       <button class="mzp-c-button mzp-t-neutral mzp-t-dark">Button</button>
     </p>
-    <p class="background-accent-inverse">Inverse accent background color</p>
+    <p class="mzp-t-background-tertiary">Inverse accent background color</p>
   </div>
 
-  <div class="background-alt-inverse">
+  <div class="mzp-t-background-secondary mzp-t-dark">
     <p>Secondary inverse colors, including a <a href="https://example.com">normal link</a>. {{ sentence }}</p>
     <p>
-      <button class="mzp-c-button mzp-t-md mzp-t-dark">Button</button>
-      <a href="#" class="mzp-c-button mzp-t-secondary mzp-t-md mzp-t-dark">Button</a>
-      <button class="mzp-c-button mzp-t-product mzp-t-lg mzp-t-dark">Button</button>
-      <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg mzp-t-dark">Button</a>
+      <button class="mzp-c-button mzp-t-dark">Button</button>
+      <a href="#" class="mzp-c-button mzp-t-secondary mzp-t-dark">Button</a>
+      <button class="mzp-c-button mzp-t-product mzp-t-dark">Button</button>
+      <a href="#" class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-dark">Button</a>
       <button class="mzp-c-button mzp-t-neutral mzp-t-dark">Button</button>
     </p>
-    <p class="background-accent-inverse">Inverse accent background color</p>
+    <p class="mzp-t-background-tertiary">Inverse tertiary background color</p>
   </div>
 
   <hr>

--- a/src/pages/docs/contributing.md
+++ b/src/pages/docs/contributing.md
@@ -502,13 +502,15 @@ for each brand theme, but here are the variable names in a handy list:
 
 ```
 background-color
-background-color-alt
-background-color-alt-inverse
+background-color-tertiary
+background-color-tertiary-inverse
+background-color-secondary
+background-color-secondary-inverse
 background-color-inverse
 body-font-family
 body-text-color
-body-text-color-alt
-body-text-color-alt-inverse
+body-text-color-secondary
+body-text-color-secondary-inverse
 body-text-color-inverse
 button-font-family
 link-color

--- a/src/pages/fundamentals/themes.md
+++ b/src/pages/fundamentals/themes.md
@@ -57,3 +57,4 @@ Many components have an inverse color variant that applies a dark background col
 ### Section backgrounds
 
 There's a basic `mzp-t-background-alt` class that applies a secondary background color to most elements or components, especially useful for alternating sections of a page.
+


### PR DESCRIPTION
## Description

Adds a tertiary "accent" background color to the Firefox and Mozilla themes. I'm not sure if "accent" is actually the best name for this, happy to discuss alternatives.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Testing
https://demo1--mozilla-protocol.netlify.app/demos/theme-firefox.html
https://demo1--mozilla-protocol.netlify.app/demos/theme-mozilla.html