### PR TITLE
Fix image overlapping content in a reversed Split with media overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * **css:** (breaking) Rename "alt" theme colors to "secondary."
 * **component:** New breadcrumb component.
 
+## Bug Fixes
+
+* **css:** Fix image overlapping content in a reversed Split with media overflow.
+
 ## Migration Tips
 
 * Update any uses of the theme variable `background-color-alt` (in the `get-theme()` function) to `background-color-secondary`.

--- a/src/assets/sass/protocol/components/_split.scss
+++ b/src/assets/sass/protocol/components/_split.scss
@@ -268,6 +268,12 @@
 
                 .mzp-c-split-media-asset {
                     max-width: none;
+
+                    .mzp-l-split-reversed & {
+                        @include bidi((
+                            (float, right, left),
+                        ));
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description

A Split component with both reversed layout *and* overflowing media allows the media to overlap the content. The layout is reversed but when the image has no max-width, it's naturally left-aligned and expands to the right, often covering some of the text.

Floating the image to the right in this scenario aligns it to the right and lets it overflow to the left (or flippity-floppity in RTL).

- [ ] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Testing
See it in action on http://localhost:3000/demos/split-visual.html in the fifth example down.
