### PR TITLE
Bump version to 16.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# HEAD
+# 16.0.0
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "15.1.0",
+  "version": "16.0.0",
   "private": true,
   "author": "Mozilla",
   "description": "A design system for Mozilla's websites.",

--- a/src/assets/package/README.md
+++ b/src/assets/package/README.md
@@ -20,7 +20,7 @@ Install package with NPM and add it to your dependencies:
 </tr>
 <tr>
 <td>Version</td>
-<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">15.1.0</a></td>
+<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">16.0.0</a></td>
 </tr>
 </table>
 

--- a/src/assets/package/package.json
+++ b/src/assets/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/core",
-  "version": "15.1.0",
+  "version": "16.0.0",
   "description": "A design system for Mozilla's websites.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This release includes the new breadcrumb component, new tertiary theme colors, and renames "alt" theme colors to "secondary" (which makes it a breaking change and hence a major version).