### PR TITLE
Add more robust polyfill (fixes #736)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+## Bug Fixes
+
+* **js:** use more robust polyfill for `e.matches` (#736)
+
 # 16.0.0
 
 ## Features

--- a/src/assets/js/protocol/protocol-utils.js
+++ b/src/assets/js/protocol/protocol-utils.js
@@ -13,9 +13,24 @@ if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
 
     var Utils = {};
 
-    // matches() vendorfill, used by nextUntil
+    /**
+     * Element.matches() polyfill (IE8 support)
+     * https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
+     * - https://vanillajstoolkit.com/polyfills/matches-ie8/
+     */
     if (!Element.prototype.matches) {
-        Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
+        Element.prototype.matches =
+            Element.prototype.matchesSelector ||
+            Element.prototype.mozMatchesSelector ||
+            Element.prototype.msMatchesSelector ||
+            Element.prototype.oMatchesSelector ||
+            Element.prototype.webkitMatchesSelector ||
+            function (s) {
+                var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+                    i = matches.length;
+                while (--i >= 0 && matches.item(i) !== this) { } // eslint-disable-line no-empty
+                return i > -1;
+            };
     }
 
     /**


### PR DESCRIPTION
## Description

Adds a more robust polyfill (particularly `mozMatchesSelector`) to catch more e.matches errors and avoid overly noisy Sentry reporting.

- [ ] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

https://github.com/mozilla/protocol/issues/736

### Testing

https://sentry.prod.mozaws.net/operations/bedrock-prod/issues/9874490/tags/

Test on browserstack
Win 7 + Firefox 30 (most frequent tags in this error)
Win 10 + IE 8

Live site should show `.matches` error in console on an older browser: https://protocol.mozilla.org/patterns/molecules/details.html
<img width="409" alt="live" src="https://user-images.githubusercontent.com/19650432/145069762-c20c5788-b6c7-49f4-bebc-99735af0d5c4.png">

Local site should show no error with same browser: http://localhost:3000/patterns/molecules/details.html
<img width="378" alt="local" src="https://user-images.githubusercontent.com/19650432/145069797-b643371d-7cc5-41d0-85e6-cbc8e8f7b9f8.png">


