### PR TITLE
Add build command for deploying the docs (Issue #746)

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -8,4 +8,4 @@ docker run --rm --label=node \
     -v $(pwd)/.npm:/.npm \
     -v $(pwd):/app -w /app\
     node:16-alpine \
-    npm run-script build
+    npm run-script build-docs

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "start": "gulp --dev",
     "webpack": "webpack --config webpack.static.config.js --mode development && webpack --config webpack.build.config.js --mode development",
     "build": "npm run prestart && npm run webpack",
+    "build-docs": "npm run prestart && gulp build",
     "lint-css": "./node_modules/.bin/stylelint \"src/assets/sass/**/*.scss\" ",
     "lint-js": "./node_modules/.bin/eslint \"src/assets/js/**/*.js\" \"gulpfile.js/**/*.js\" \"webpack.static.config.js\" \"webpack.build.config.js\" ",
     "lint": "npm run lint-js && npm run lint-css ",
     "test": "./node_modules/.bin/karma start ./tests/karma.conf.js",
     "pretest": "npm run build",
-    "docs": "doctoc --title \"### Contents\" --maxlevel 2 docs/README.md",
+    "readme": "doctoc --title \"### Contents\" --maxlevel 2 docs/README.md",
     "prepublishOnly": "npm run webpack"
   },
   "dependencies": {
@@ -76,5 +77,9 @@
     "tar": ">=4.4.18",
     "trim": ">=0.0.3",
     "trim-newlines": ">=3.0.1"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "IE 10"
+  ]
 }


### PR DESCRIPTION
## Description

In #746 I neglected that we use a separate systems for deploying stage/prod to how we build demos. This should hopefully fix: https://gitlab.com/mozmeao/protocol/-/pipelines/429718118/failures

- [ ] ~I have documented this change in the design system.~
- [ ] ~I have recorded this change in `CHANGELOG.md`.~

### Issue

#746

### Testing

- [ ] Running `npm run build-docs` should build the docs site only.
