### PR TITLE
Fix keyboard focus capture on modal open animation (Fixes #749)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # HEAD
 
+## Bug Fixes
+* **js:** Fix keyboard focus capture on modal open animation (#749).
+
 ## Features
 
-* **node:**  Create a standalone Webpack config for compiling the Protocol NPM package (#746).
-* **js:**  Update protocol to extend standard ESLint configs (#753)
-* **js:**  Move Karma test command to NPM script (#748).
+* **node:** Create a standalone Webpack config for compiling the Protocol NPM package (#746).
+* **js:** Update protocol to extend standard ESLint configs (#753).
+* **js:** Move Karma test command to NPM script (#748).
 
 ## Bug Fixes
 

--- a/src/assets/js/protocol/protocol-modal.js
+++ b/src/assets/js/protocol/protocol-modal.js
@@ -88,7 +88,11 @@ if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
             }
         }, false);
 
-        modal.focus();
+        // add a short delay is need before calling focus() to give
+        // time for the fade-in animation to complete (issue #749).
+        setTimeout(function() {
+            modal.focus();
+        }, 300);
 
         // close with escape key
         document.addEventListener('keyup', _onDocumentKeyUp, false);


### PR DESCRIPTION
## Description

Adds a small delay before calling `modal.focus()` when opening the Modal component.

- ~[ ] I have documented this change in the design system~.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#749

### Testing

The bug is hard to reproduce on the Protocol demo page below, because I'm assuming it's a less intensive page to animate? You can reproduce the bug in the www.mozilla.org links in the attached issue.

I tested locally in bedrock that this fix works (feel free to do the same in review).

http://localhost:3000/patterns/organisms/modal.html
