### PR TITLE
fix url for heading element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 * **js:** Fix keyboard focus capture on modal open animation (#749).
-
+* **docs:** Fix URL to heading elements in docs(#763). 
 ## Features
 
 * **node:** Create a standalone Webpack config for compiling the Protocol NPM package (#746).

--- a/src/patterns/atoms/section-heading/heading.hbs
+++ b/src/patterns/atoms/section-heading/heading.hbs
@@ -3,7 +3,7 @@ name: Section Heading
 description: |
   Use section headings help organize your page content into sections.
 
-  Section headings get more space around them than a plain [heading element](/patterns/atoms/typographic.html#heading-elements).
+  Section headings get more space around them than a plain [heading element](https://protocol.mozilla.org/patterns/atoms/typographic.html#heading-elements).
 order: 1
 tips: |
   - usually first thing inside a `mzp-l-content`


### PR DESCRIPTION
## Description

Fix url in https://protocol.mozilla.org/patterns/atoms/section-heading.html that was routing to localhost

- [ ] I have documented this change in the design system.
- [X] I have recorded this change in `CHANGELOG.md`.

### Issue

#763 
