### PR TITLE
Added documentation for card layout templating

### DIFF
--- a/src/patterns/templates/card-layout/card-layout.hbs
+++ b/src/patterns/templates/card-layout/card-layout.hbs
@@ -14,6 +14,7 @@ tips: |
     - `mzp-l-card-quarter`
   - These CSS classes can be applied to any suitable parent element e.g. `<main>`, `<section>`, `<div>`.
   - The grid layout is reversed in right to left (RTL) languages.
+  - If using the `mzp-l-card-hero` parent class, make sure to indicate which child card element is to be the large hero card by giving it a `mzp-c-card-large` class.
 links:
     Card Layout Demo: /demos/card-layout.html
     Picto Card Layout Demo: /demos/card-picto-layout.html


### PR DESCRIPTION
## Description

Added documentation detailing that we should add mzp-c-card-large class to the larger sized image in the mzp-l-card-hero class in the card layout template page.

### Issue

#774 

### Testing

![mozilla](https://user-images.githubusercontent.com/102278822/160741607-6d917be0-adcf-4a8c-a732-712f67dddecc.png)

