### PR TITLE
Make sure to build package using production mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bug Fixes
 * **js:** Fix keyboard focus capture on modal open animation (#749).
+* **node:** Make sure to build NPM package using production mode.
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run webpack-package",
     "start": "ENV=development fractal start --sync",
     "webpack-docs": "npm run lint && webpack --config webpack.docs.static.config.js --mode development && webpack --config webpack.docs.build.config.js --watch --mode development",
-    "webpack-package": "webpack --config webpack.package.static.config.js --mode development && webpack --config webpack.package.build.config.js --mode development"
+    "webpack-package": "webpack --config webpack.package.static.config.js --mode production && webpack --config webpack.package.build.config.js --mode production"
   },
   "dependencies": {
     "@frctl/fractal": "^1.5.13",


### PR DESCRIPTION
## Description

I'm not sure this technically makes any difference to our generated code, since we're manually creating both minified and non-minified JS files, but we should probably still set`--mode production` explicitly whenever we build the NPM package.

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

N/A

### Testing
- [ ] `npm test` should build the package and successfully run tests against the generated files.
- [ ] Generated files should still look the same.
