### PR TITLE
Fixed broken link in Content Containers page

### DIFF
--- a/src/patterns/templates/content-container/content-container.hbs
+++ b/src/patterns/templates/content-container/content-container.hbs
@@ -8,7 +8,7 @@ links:
 notes: |
     - The container's width isn't explicit; it's a fluid box with a minimum width of 304px and constrained to a maximum width that differs at different responsive breakpoints. If you want to know how wide this box is, the answer is: it depends. Refer to [the `$content-*` tokens](/fundamentals/tokens.html) for the maximum width values.
     - Side padding also adjusts at different breakpoints, with less padding in small windows and more padding in large windows. [Check out the demo](/demos/content-container-vis.html) and resize your browser to see how the width and padding responds to the viewport.
-    - You can apply theme classes to set a max-width narrower than the default, to constrain the maximum width even in larger viewports. [See the demo](/demos/content-container.html) for examples of these.
+    - You can apply theme classes to set a max-width narrower than the default, to constrain the maximum width even in larger viewports. [See the demo](/demos/content-containers.html) for examples of these.
         - `mzp-t-content-sm` : 432px
         - `mzp-t-content-md` : 688px
         - `mzp-t-content-lg` : 928px


### PR DESCRIPTION
## Description
The Content Containers page had a broken link, I fixed it

### Testing

- go to http://localhost:3000/patterns/templates/content-container.html
- Scroll down under `Notes` header where it says "See the demo for examples of these." and test the link
