### PR TITLE
Migrate download button

### DIFF
--- a/components/download-button/download-button--secondary.html
+++ b/components/download-button/download-button--secondary.html
@@ -1,0 +1,2 @@
+{% render '@download-button', { class: 'mzp-t-secondary' } %}
+{% render '@download-button', { class: 'mzp-t-secondary mzp-t-md' } %}

--- a/components/download-button/download-button.config.yml
+++ b/components/download-button/download-button.config.yml
@@ -1,0 +1,6 @@
+context:
+  class:
+  include_privacy_link: True
+variants:
+  - name: Secondary
+    notes: A more compact, hollow Download Button used as a secondary CTA in the Navigation component.

--- a/components/download-button/download-button.html
+++ b/components/download-button/download-button.html
@@ -1,0 +1,8 @@
+<div class="mzp-c-button-download-container">
+  <a href="#" class="mzp-c-button mzp-t-product {% if class %}{{ class }}{% endif %}">
+    Download Firefox
+  </a>{% if include_privacy_link %}
+  <small class="mzp-c-button-download-privacy-link">
+    <a href="https://www.mozilla.org/privacy/firefox/">Firefox Privacy Notice</a>
+  </small>{% endif %}
+</div>

--- a/components/download-button/readme.md
+++ b/components/download-button/readme.md
@@ -1,0 +1,1 @@
+Download button component with privacy policy link.


### PR DESCRIPTION
## Description

Migrate download button.

todo: once navigation is migrated, add link in Readme to navigation component

### Issue

https://github.com/mozilla/protocol/issues/759

### Testing

http://localhost:3000/components/detail/download-button--default
http://localhost:3000/components/detail/download-button--secondary

to compare with: https://protocol.mozilla.org/patterns/molecules/download-button.html
