### PR TITLE
Added accessible attributes to menu bar (fixes #815)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ## Bug Fixes
 * **node:** Make sure to build NPM package using production mode.
-* **html:** Added accessible attributes to menu bar
+* **html:** Added accessible attributes to menu bar (#815).
+
 # 16.0.1
 
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug Fixes
 * **node:** Make sure to build NPM package using production mode.
-
+* **html:** Added accessible attributes to menu bar
 # 16.0.1
 
 ## Bug Fixes

--- a/theme/views/partials/header.nunj
+++ b/theme/views/partials/header.nunj
@@ -1,5 +1,5 @@
 <div class="Header">
-  <button class="Header-button Header-navToggle" data-action="toggle-sidebar">
+  <button class="Header-button Header-navToggle" data-action="toggle-sidebar" aria-label="menu">
       <div class="Header-navToggleIcon Header-navToggleIcon--open">
           {% include 'icons/close.svg' %}
       </div>
@@ -20,7 +20,7 @@
   {% endif %}
     <li>
       <a href="https://github.com/mozilla/protocol" title="Protocol on Github">
-        <img src="{{ path('/theme/img/github.svg') }}" height="30">
+        <img src="{{ path('/theme/img/github.svg') }}" height="30" alt="">
       </a>
     </li>
   </ul>

--- a/theme/views/partials/header.nunj
+++ b/theme/views/partials/header.nunj
@@ -1,5 +1,5 @@
 <div class="Header">
-  <button class="Header-button Header-navToggle" data-action="toggle-sidebar" aria-label="Toggle menu">
+  <button class="Header-button Header-navToggle" data-action="toggle-sidebar" aria-label="Toggle menu" aria-controls="navigation">
       <div class="Header-navToggleIcon Header-navToggleIcon--open">
           {% include 'icons/close.svg'%}
       </div>

--- a/theme/views/partials/header.nunj
+++ b/theme/views/partials/header.nunj
@@ -1,7 +1,7 @@
 <div class="Header">
-  <button class="Header-button Header-navToggle" data-action="toggle-sidebar" aria-label="menu">
+  <button class="Header-button Header-navToggle" data-action="toggle-sidebar" aria-label="Toggle menu">
       <div class="Header-navToggleIcon Header-navToggleIcon--open">
-          {% include 'icons/close.svg' %}
+          {% include 'icons/close.svg'%}
       </div>
       <div class="Header-navToggleIcon Header-navToggleIcon--closed">
           {% include 'icons/burger.svg' %}

--- a/theme/views/partials/navigation/navigation.nunj
+++ b/theme/views/partials/navigation/navigation.nunj
@@ -1,0 +1,27 @@
+{% set isVariantPanelVisible = false %}
+{% if entity and (entity.isComponent or entity.isVariant) %}
+    {% set item = entity.parent if entity.isVariant else entity %}
+    {% if item.variants().filter('isHidden', false).size > 1 and frctl.theme.get('navigation') == 'split' %}
+        {% set isVariantPanelVisible = true %}
+    {% endif %}
+{% endif %}
+
+<nav class="Navigation{% if isVariantPanelVisible %} in-variants-panel{% endif %}" data-behaviour="navigation">
+    <div class="Navigation-panel Navigation-panel--main" data-role="main-panel" id="navigation">
+    {% for navPartial in frctl.theme.get('nav') %}
+        {% include 'partials/navigation/' + navPartial + '.nunj' %}
+    {% endfor %}
+    </div>
+
+    {% if frctl.theme.get('navigation') == 'split' %}
+    <div class="Navigation-panel Navigation-panel--variants{% if isVariantPanelVisible %} is-visible{% endif %}" data-role="variant-panel">
+        <div class="Navigation-backButtonWrapper">
+            <button class="Navigation-backButton" data-role="back" type="button">
+                {% include 'icons/arrow-left.svg' %}
+                {{ frctl.theme.get('labels.navigation.back') }}
+            </button>
+        </div>
+        {% include 'partials/navigation/variants.nunj' %}
+    </div>
+    {% endif %}
+</nav>


### PR DESCRIPTION
## Description
Some areas in the menu bar lacked accessibility, notably a lack of an `alt` for the Github icon and a lack of a `role` for the nav toggle. Just patched that up!
There are still some accessibility issues that should be patched up, but it's not easy for us to pull that since they're coded within Fractal's codebase and dependencies, notably:
- The nav headers are defaulted to be `h3` but since there is no `h2` in the DOM all the time (depending on which page you're viewing), the hierarchy isn't very optimal
- The `iframe` tag isn't supposed to have a `title` attribute, mainly seen in the preview pages

- [x] I have recorded this change in `CHANGELOG.md`.

### Improvements:
Before this PR, accessibility was at 80% in Lighthouse, now it's at 98%:
<img width="588" alt="Screen Shot 2022-07-14 at 5 12 17 PM" src="https://user-images.githubusercontent.com/42309026/179086992-11bac371-9b69-4841-a998-635d5f99b600.png">

### Testing
I used MacOS' VoiceOver tool to see if it went through the menu's DOM reading correctly

### Issue
https://github.com/mozilla/protocol/issues/815
