### PR TITLE
Switch from US-only MM/DD/YYYY date format to the unambiguous 'MMM DD, YYYY'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * **node:** Make sure to build NPM package using production mode.
 * **html:** Added accessible attributes to menu bar (#815).
 * **css:** Add style rule for the hidden attribute in global reset (#783).
+* **html:** Use unambiguous date format in sidebar.
 
 # 16.0.1
 

--- a/theme/index.js
+++ b/theme/index.js
@@ -32,7 +32,7 @@ const subTheme = mandelbrot({
             value: new Date(),
             type: 'time', // Outputs a <time /> HTML tag
             format: (value) => {
-                return value.toLocaleDateString('en');
+                return value.toLocaleDateString('en-US', {month: 'short', day: 'numeric', year: 'numeric'});
             }
         }
     ],


### PR DESCRIPTION
## Description

The 'Built on' date at the bottom of the sidebar uses the US-only date
format of MM/DD/YYYY.  This date format is ambiguous and is incorrect
for most of the world.

Fix this by replacing the month with its short name.
eg. `10/25/2022` becomes `Oct 25, 2022`.

- [X] I have recorded this change in `CHANGELOG.md`.