### PR TITLE
Remove aria-disabled from disabled input docs and example (fixes #823)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * **html:** Added accessible attributes to menu bar (#815).
 * **css:** Add style rule for the hidden attribute in global reset (#783).
 * **html:** Use unambiguous date format in sidebar.
+* **docs:** Remove aria-disabled from disabled form inputs.
 
 # 16.0.1
 

--- a/components/forms/01-input/input.config.yml
+++ b/components/forms/01-input/input.config.yml
@@ -63,9 +63,8 @@ variants:
       id: search
   - name: Disabled
     notes: |
-      Disabled controls should have both the `disabled` attribute and `aria-disabled="true"`
+      Disabled controls should have the `disabled` attribute.
 
       ### Links
 
       - [MDN `disabled`](https://developer.mozilla.org/docs/Web/HTML/Attributes/disabled)
-      - [MDN `aria-disabled`](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-disabled)

--- a/components/forms/01-input/input.html
+++ b/components/forms/01-input/input.html
@@ -12,4 +12,4 @@
 # disabled        - boolean
 #}
 <label for="{{ id }}">{{ label|default('Label') }}</label>
-<input type="{{ type|default('text') }}" id="{{ id }}" name="{% if name %}{{ name }}{% else %}{{ id }}{% endif %}"{% if class %} class="{{ class }}"{% endif %}{% if attrs %} {{ attrs|safe }}{% endif %}{% if placeholder %} placeholder="{{ placeholder }}"{% endif %}{% if required %} required aria-required="true"{% endif %}{% if disabled %} disabled aria-disabled="true"{% endif %}>
+<input type="{{ type|default('text') }}" id="{{ id }}" name="{% if name %}{{ name }}{% else %}{{ id }}{% endif %}"{% if class %} class="{{ class }}"{% endif %}{% if attrs %} {{ attrs|safe }}{% endif %}{% if placeholder %} placeholder="{{ placeholder }}"{% endif %}{% if required %} required aria-required="true"{% endif %}{% if disabled %} disabled{% endif %}>


### PR DESCRIPTION
## Description

Removes `aria-disabled` from disabled input docs notes and HTML. It is not applicable for the use case we are demonstrating. `disabled` attribute only is what we want.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

https://github.com/mozilla/protocol/issues/823

### Testing

`npm run webpack-docs`
(in another terminal tab, same path) `npm start`

http://localhost:3000/components/detail/input--disabled
