### PR TITLE
Darkened notification bar font color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * **css:** Add style rule for the hidden attribute in global reset (#783).
 * **html:** Use unambiguous date format in sidebar.
 * **docs:** Remove aria-disabled from disabled form inputs.
+* **css:** Update font color for Notification Bar variants to black for better visual accessibility (#848).
 
 # 16.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * **css:** Add style rule for the hidden attribute in global reset (#783).
 * **html:** Use unambiguous date format in sidebar.
 * **docs:** Remove aria-disabled from disabled form inputs.
-* **css:** Update font color for Notification Bar variants to black for better visual accessibility (#848).
+* **css:** Update font color for Notification Bar variants to black and error-variant background color to a lighter red for better visual accessibility (#848).
 
 # 16.0.1
 

--- a/assets/sass/protocol/components/_notification-bar.scss
+++ b/assets/sass/protocol/components/_notification-bar.scss
@@ -12,7 +12,7 @@
     border-radius: $border-radius-sm;
     border: 1px;
     box-shadow: $box-shadow-md;
-    color: $color-ink-80;
+    color: $color-black;
     font-weight: normal;
     margin: $layout-xs $spacing-md 0;
     padding: $spacing-md $spacing-2xl;

--- a/assets/sass/protocol/components/_notification-bar.scss
+++ b/assets/sass/protocol/components/_notification-bar.scss
@@ -116,7 +116,7 @@
     }
 
     &.mzp-t-error {
-        background-color: $color-red-40;
+        background-color: $color-red-30;
 
         @media #{$mq-sm} {
             .mzp-c-notification-bar-button {


### PR DESCRIPTION
## Description

Related to issue #848, @maureenlholland and I spoke about how either increasing the `font-size` or  changing the `color` of the text in the notification bar would be slightly better for visual accessibility.
In the issue, I tested changes by:
- Increasing `font-size` to `16px`, and
- Changing `color` to `#000000`

Both seemed to be viable options for visual clarify on the component. However, a change in one of the notification bars would usually mean a change to the rest for sake of consistency. The increase in `font-size`, most notably on the success notification bar in the WNPs, seemed to jumble the order of the page's content hierarchy by just a bit. 

So instead of going with increasing `font-size` we opted to select to just change `color` to `#000000` for all notification bars. Not a significant change in itself, but still positively noticeable.

Describe what this change does.

- [ ] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
#848 

### Testing
http://localhost:3000/components/detail/notification-bar--error (and the rest of the variants)
