### PR TITLE
Move from depracated `addListener` to `addEventListener` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * **docs:** Migrate Protocol documentation site to Fractal.
 * **node:** Create a Webpack config for compiling docs using Fractal.
 * **css:** Updated stylelint ruleset to match Bedrock's linting pattern. (#814)
+* **js** Updated `addListener` method, which is now deprecated, to be replaced by `addEventListener`. `addListener` will be used as a fallback for older browsers.
 
 ## Bug Fixes
 * **js:** Ensure focus is moved to modal after animation completes (#829)

--- a/assets/js/protocol/protocol-footer.js
+++ b/assets/js/protocol/protocol-footer.js
@@ -32,7 +32,7 @@
                 }
 
                 if (window.matchMedia('all').addEventListener) {
-                    _mqWide.addEventListener('change', screenChange);
+                    _mqWide.addEventListener('change', screenChange, false);
                 } else if (window.matchMedia('all').addListener) {
                     _mqWide.addListener(screenChange);
                 }

--- a/assets/js/protocol/protocol-footer.js
+++ b/assets/js/protocol/protocol-footer.js
@@ -5,6 +5,15 @@
 (function() {
     'use strict';
 
+    // removes Details component if screen size is big
+    function screenChange(mq) {
+        if (mq.matches) {
+            Mzp.Details.init(footerHeadings);
+        } else {
+            Mzp.Details.destroy(footerHeadings);
+        }
+    }
+
     // check we have global variable
     if (typeof window.Mzp !== 'undefined') {
         var Mzp = window.Mzp;
@@ -14,7 +23,7 @@
         if (typeof Mzp.Supports !== 'undefined' && typeof Mzp.Details !== 'undefined') {
 
             // check browser supports matchMedia
-            if(Mzp.Supports.matchMedia) {
+            if (Mzp.Supports.matchMedia) {
                 var _mqWide = matchMedia('(max-width: 479px)');
 
                 // initialize details if screen is small
@@ -22,14 +31,11 @@
                     Mzp.Details.init(footerHeadings);
                 }
 
-                // remove details if screen is big
-                _mqWide.addListener(function(mq) {
-                    if (mq.matches) {
-                        Mzp.Details.init(footerHeadings);
-                    } else {
-                        Mzp.Details.destroy(footerHeadings);
-                    }
-                });
+                if (window.matchMedia('all').addEventListener) {
+                    _mqWide.addEventListener('change', screenChange);
+                } else if (window.matchMedia('all').addListener) {
+                    _mqWide.addListener(screenChange);
+                }
             }
         }
     }

--- a/assets/js/protocol/protocol-menu.js
+++ b/assets/js/protocol/protocol-menu.js
@@ -187,7 +187,7 @@ if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
      * Convenience function for checking `matchMedia` state.
      * @return {Boolean}
      */
-    Menu.isWideViewport = function() {
+    Menu.isWideViewport = function () {
         return _mqWideNav.matches;
     };
 
@@ -197,7 +197,7 @@ if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
     Menu.handleState = function() {
         _mqWideNav = matchMedia('(min-width: ' + _wideBreakpoint + ')');
 
-        _mqWideNav.addListener(function(mq) {
+        function menuBind(mq) {
             Menu.close();
 
             if (mq.matches) {
@@ -207,7 +207,13 @@ if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
                 Menu.unbindEventsWide();
                 Menu.bindEventsSmall();
             }
-        });
+        }
+
+        if (window.matchMedia('all').addEventListener) {
+            _mqWideNav.addEventListener('change', menuBind);
+        } else if (window.matchMedia('all').addListener) {
+            _mqWideNav.addListener(menuBind);
+        }
 
         if (Menu.isWideViewport()) {
             Menu.bindEventsWide();
@@ -228,7 +234,6 @@ if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
             items[i].addEventListener('mouseenter', Menu.onMouseEnter, false);
             items[i].addEventListener('mouseleave', Menu.onMouseLeave, false);
             items[i].addEventListener('focusout', Menu.onFocusOut, false);
-
             link = items[i].querySelector('.mzp-c-menu-title');
             link.addEventListener('click', Menu.onClickWide, false);
 

--- a/assets/js/protocol/protocol-menu.js
+++ b/assets/js/protocol/protocol-menu.js
@@ -210,7 +210,7 @@ if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
         }
 
         if (window.matchMedia('all').addEventListener) {
-            _mqWideNav.addEventListener('change', menuBind);
+            _mqWideNav.addEventListener('change', menuBind, false);
         } else if (window.matchMedia('all').addListener) {
             _mqWideNav.addListener(menuBind);
         }

--- a/assets/js/protocol/protocol-navigation.js
+++ b/assets/js/protocol/protocol-navigation.js
@@ -104,7 +104,7 @@ if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
         }
 
         if (window.matchMedia('all').addEventListener) {
-            _mqLargeNav.addEventListener('change', makeStickyNav);
+            _mqLargeNav.addEventListener('change', makeStickyNav, false);
         } else if (window.matchMedia('all').addListener) {
             _mqLargeNav.addListener(makeStickyNav);
         }

--- a/assets/js/protocol/protocol-navigation.js
+++ b/assets/js/protocol/protocol-navigation.js
@@ -95,13 +95,19 @@ if (typeof window.Mzp === 'undefined') { // eslint-disable-line block-scoped-var
     Navigation.initSticky = function() {
         _mqLargeNav = matchMedia('(min-width: ' + _wideBreakpoint + ') and (min-height: ' + _tallBreakpoint + ')');
 
-        _mqLargeNav.addListener(function(mq) {
+        function makeStickyNav(mq) {
             if (mq.matches) {
                 Navigation.createSticky();
             } else {
                 Navigation.destroySticky();
             }
-        });
+        }
+
+        if (window.matchMedia('all').addEventListener) {
+            _mqLargeNav.addEventListener('change', makeStickyNav);
+        } else if (window.matchMedia('all').addListener) {
+            _mqLargeNav.addListener(makeStickyNav);
+        }
 
         if (Navigation.isLargeViewport()) {
             Navigation.createSticky();


### PR DESCRIPTION
## Description

`MediaQueryList.addListener()` is deprecated and we should be replacing it with a more supported alternative, which is `EventTarget.addEventListener()`. 

Check this [compatibility list](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility) (`MediaQueryList` inherits `EventTarget`) for the browser versions were keeping the fall back for (i.e. < Safari 14)

**Things to note:**
I'm using a `change` event to detect there has been a resize, and I got that from reading this in MDN: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/change_event

However, it should be noted that this event isn't listed in MDN's event references page: https://developer.mozilla.org/en-US/docs/Web/Events . I'll be filing an issue for this.

- [ ] ~~I have documented this change in the design system.~~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
https://github.com/mozilla/protocol/issues/854

### Testing
 I tested this on old browser versions as listed in the compatibility table I shared above:
- [x] Firefox version 54
- [x] Safari version 13
- [x] IE 10/11

### Testing URLs
- http://localhost:3000/components/detail/footer
- http://localhost:3000/components/detail/navigation--default
- http://localhost:3000/components/detail/menu
