### PR TITLE
Update aria roles on mzp navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # HEAD
 
 ## Features
+* **css:** Moves the aria-expanded attribute to the mzp-c-navigation-menu-button (#860).
 * **css:** Remove default mobile padding on nospace split component
 * **css:** Removed min-width on the .mzp-c-split-container class on the split component
 * **js:** Protocol JS components are now written using modern JS and published as ES5/UMD format (#255).

--- a/assets/js/protocol/navigation.js
+++ b/assets/js/protocol/navigation.js
@@ -8,7 +8,7 @@ let _navItemsLists;
 let _navMenuButtons;
 const _options = {
     onNavOpen: null,
-    onNavClose: null,
+    onNavClose: null
 };
 let _ticking = false;
 let _lastKnownScrollPosition = 0;
@@ -185,26 +185,28 @@ MzpNavigation.onClick = (e) => {
  * use Intersection Observer API to keep track of when the mobile
  * nav menu is displayed to handle aria roles better
  */
-(MzpNavigation.menuButtonVisible = (callback) => {
+MzpNavigation.menuButtonVisible = (callback) => {
     // check if Intersection observer is supported
     if (MzpSupports !== 'undefined' && MzpSupports.intersectionObserver) {
         const observer = new IntersectionObserver(
             (entries) => {
-                entries.forEach((entry) => {
+                for (let index = 0; index < entries.length; index++) {
+                    const entry = entries[index];
                     callback(entry.intersectionRatio > 0, entry.target);
-                });
+                }
             },
             { root: document.documentElement }
         );
-        _navMenuButtons.forEach((button) => {
+        for (let index = 0; index < _navMenuButtons.length; index++) {
+            const button = _navMenuButtons[index];
             observer.observe(button);
-        });
+        }
     }
-}),
+},
 /**
-     * Set initial ARIA navigation states.
-     */
-(MzpNavigation.setAria = () => {
+ * Set initial ARIA navigation states.
+ */
+MzpNavigation.setAria = () => {
     if (MzpSupports !== 'undefined' && MzpSupports.intersectionObserver) {
         MzpNavigation.menuButtonVisible((isVisible, menuButton) => {
             if (isVisible) {
@@ -227,7 +229,7 @@ MzpNavigation.onClick = (e) => {
             menuButton.setAttribute('aria-expanded', isActive);
         }
     }
-});
+};
 
 /**
  * Bind navigation event handlers.

--- a/assets/js/protocol/supports.js
+++ b/assets/js/protocol/supports.js
@@ -67,4 +67,12 @@ MzpSupports.details = (function() {
     return diff;
 }());
 
+MzpSupports.intersectionObserver = (function () {
+    return (
+        'IntersectionObserver' in window &&
+        'IntersectionObserverEntry' in window &&
+        'intersectionRatio' in window.IntersectionObserverEntry.prototype
+    );
+})();
+
 module.exports = MzpSupports;


### PR DESCRIPTION
## Description

Moves the `aria-expanded` attribute to the `mzp-c-navigation-menu-button` instead of the menu items as explained in #847. Also removes the aria-expanded attribute on desktop since the element is not displayed, so firefox no longer includes it in the accessibility tree.

### Issue

#847 

### Testing
You can test this by running a local server and navigating to this page: http://localhost:3000/components/preview/navigation--default and using the inspector to view the element and make sure that the aria-expanded role is toggling correctly.

