### PR TITLE
Fix syntax error in legacy IE when compiling JS (Fixes #861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# HEAD
+
+## Bug Fixes
+* **js:** Fix syntax error in legacy IE when compiling JS (#861)
+
 # 16.1.0
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -51,5 +51,9 @@
     "karma-jasmine": "^5.1.0",
     "stylelint": "^14.16.1",
     "stylelint-config-standard-scss": "^6.1.0"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "IE 8"
+  ]
 }


### PR DESCRIPTION
## Description

Adds missing browser list targets in `package.json` to make sure we're bundling JS in a compatible way with older IE browsers.

- [ ] ~I have documented this change in the design system~.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#861

### Testing

I matched our browserlist targets in bedrock for parity: https://github.com/mozilla/bedrock/blob/main/package.json#L80-L83
