### PR TITLE
[rebased] Update aria roles on mzp navigation (Fixes #860)

### DIFF
--- a/assets/js/protocol/supports.js
+++ b/assets/js/protocol/supports.js
@@ -67,4 +67,12 @@ MzpSupports.details = (function() {
     return diff;
 }());
 
+MzpSupports.intersectionObserver = (function() {
+    return (
+        ('IntersectionObserver' in window) &&
+        ('IntersectionObserverEntry' in window) &&
+        ('intersectionRatio' in window.IntersectionObserverEntry.prototype)
+    );
+}());
+
 module.exports = MzpSupports;


### PR DESCRIPTION
## Description

Moves the `aria-expanded` attribute to the `mzp-c-navigation-menu-button` instead of the menu items as explained in #847. Also removes the aria-expanded attribute on desktop since the element is not displayed, so firefox no longer includes it in the accessibility tree.

### Issue

#847 

### Testing
You can test this by running a local server and navigating to this page: http://localhost:3000/components/preview/navigation--default and using the inspector to view the element and make sure that the aria-expanded role is toggling correctly.