### PR TITLE
remove split min-width to prevent overflow on small viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 * **css:** Remove default mobile padding on nospace split component
+* **css:** Removed min-width on the .mzp-c-split-container class on the split component
 * **js:** Protocol JS components are now written using modern JS and published as ES5/UMD format (#255).
 * **js:** Removed pre-minified JS files from the published package. Consuming sites should handle their own minification.
 * **css:** Removed pre-minified CSS files from the published package Consuming sites should handle their own minification.

--- a/assets/sass/protocol/components/_split.scss
+++ b/assets/sass/protocol/components/_split.scss
@@ -32,7 +32,6 @@
     @include clearfix;
     margin: 0 auto;
     max-width: $content-max;
-    min-width: $content-xs;
 
     // horizontal spacing should match mzp-l-content's horizontal spacing
     padding: 0 get-theme('h-grid-xs');


### PR DESCRIPTION
## Description
Removed the min-width on `.mzp-c-split-container` to prevent overflow on very small viewports - I tried to see if it broke anything but it seemed ok on my testing

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#843 

### Testing
- `npm run webpack`
- `npm run start`
- http://localhost:3000/components/detail/split
