### PR TITLE
Remove default mobile padding on nospace split component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # HEAD
 
 ## Features
-
+* **css:** Remove default mobile padding on nospace split component
 * **js:** Protocol JS components are now written using modern JS and published as ES5/UMD format (#255).
 * **js:** Removed pre-minified JS files from the published package. Consuming sites should handle their own minification.
 * **css:** Removed pre-minified CSS files from the published package Consuming sites should handle their own minification.

--- a/assets/sass/protocol/components/_split.scss
+++ b/assets/sass/protocol/components/_split.scss
@@ -122,6 +122,14 @@
     }
 }
 
+// Issue 779 - Remove default mobile padding on nospace split component
+@media screen and (max-width: $screen-md) {
+    .mzp-t-split-nospace {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+}
+
 // * -------------------------------------------------------------------------- */
 // side by side layout, float based fall back
 


### PR DESCRIPTION
## Description
Remove default mobile padding on nospace split component (backported to bedrock)
Related to a bedrock issue & PR:
https://github.com/mozilla/bedrock/issues/11457
https://github.com/mozilla/bedrock/pull/11512#issuecomment-1104545527

- [ ] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
#779 
