### PR TITLE
Bump protocol to v17.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
-# HEAD
+# 17.0.0
+
+## Bug Fixes
+* **js:** Moves the aria-expanded attribute to the mzp-c-navigation-menu-button (#860).
+* **css:** Remove default mobile padding on nospace split component (#875).
+* **css:** Removed min-width on the .mzp-c-split-container class on the split component (#843).
 
 ## Features
-* **css:** Moves the aria-expanded attribute to the mzp-c-navigation-menu-button (#860).
-* **css:** Remove default mobile padding on nospace split component
-* **css:** Removed min-width on the .mzp-c-split-container class on the split component
+
 * **js:** Protocol JS components are now written using modern JS and published as ES5/UMD format (#255).
-* **js:** Removed pre-minified JS files from the published package. Consuming sites should handle their own minification.
-* **css:** Removed pre-minified CSS files from the published package Consuming sites should handle their own minification.
+* **js:** Removed pre-minified JS files from the published package (#255).
+* **css:** Removed pre-minified CSS files from the published package (#255).
 
 ## Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ name. To publish a release to NPM, use the following steps:
     have permission). Once the changes have been merged to main:
 6. Tag a new release. You can do this either using [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging),
     or directly on the [GitHub website](https://github.com/mozilla/protocol/releases/latest).
-7. Run `npm test` to run the build script and front-end tests. The package contents
+7. Run `npm run build-package && npm test` to run the build script and front-end tests. The package contents
     will be located in `./package/`.
 8. If the build is successful and all tests pass, publish to NPM using `npm publish ./package/`.
 

--- a/assets/package/README.md
+++ b/assets/package/README.md
@@ -20,7 +20,7 @@ Install package with NPM and add it to your dependencies:
 </tr>
 <tr>
 <td>Version</td>
-<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">16.1.0</a></td>
+<td><a href="https://github.com/mozilla/protocol/blob/master/CHANGELOG.md">17.0.0</a></td>
 </tr>
 </table>
 

--- a/assets/package/package.json
+++ b/assets/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/core",
-  "version": "16.1.0",
+  "version": "17.0.0",
   "description": "A design system for Mozilla's websites.",
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "protocol",
-  "version": "16.1.0",
+  "version": "17.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "protocol",
-      "version": "16.1.0",
+      "version": "17.0.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol",
-  "version": "16.1.0",
+  "version": "17.0.0",
   "private": true,
   "author": "Mozilla",
   "description": "A design system for Mozilla's websites.",
@@ -19,7 +19,7 @@
     "lint": "npm run lint-js && npm run lint-css",
     "lint-css": "./node_modules/.bin/stylelint \"**/*.scss\"",
     "lint-js": "./node_modules/.bin/eslint .",
-    "prepublishOnly": "npm run webpack-package",
+    "prepublishOnly": "npm run build-package",
     "start": "ENV=development fractal start --sync",
     "test": "npm run lint && ./node_modules/.bin/karma start ./tests/karma.conf.js",
     "webpack": "npm run lint && webpack --config webpack.docs.static.config.js --mode development && webpack --config webpack.docs.build.config.js --watch --mode development"


### PR DESCRIPTION
Once this is merged, I'll tag a new release and add the following migration notes:

## Breaking changes ⚠️

- Protocol JS components are now published in [UMD format](https://github.com/umdjs/umd) for easier consumption. They can now be imported directly using common build tools such as Webpack (see the docs), but are still available as a global variable for sites that need it. There's no longer a global `window.Mzp.*` name space however, so in your code `window.Mzp.Notification` should now become `window.MzpNotification` (as an example).
- We no longer publish pre-minified CSS and JS files in the NPM package. If you want minified assets, then it is now your responsibility to take care of that in your site's build process.
