### PR TITLE
MzpDetails component should be explicitly initialized (Fixes #879)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,11 +74,5 @@ module.exports = {
         // Disallow the use of `console`
         // https://eslint.org/docs/rules/no-console
         'no-console': 'error'
-    },
-    globals: {
-        'MzpDetails': 'readable',
-        'MzpMenu': 'readable',
-        'MzpSupports': 'readable',
-        'MzpUtils': 'readable',
     }
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+# HEAD
+
+## Bug Fixes
+
+* **js:** MzpDetails component should be explicitly initialized (Fixes #879)
+
 # 17.0.0
 
 ## Bug Fixes
+
 * **js:** Moves the aria-expanded attribute to the mzp-c-navigation-menu-button (#860).
 * **css:** Remove default mobile padding on nospace split component (#875).
 * **css:** Removed min-width on the .mzp-c-split-container class on the split component (#843).
@@ -22,7 +29,7 @@
 * **component:** Add centering classes for Logo and Wordmark. (#718)
 * **docs:** Migrate Protocol documentation site to Fractal.
 * **node:** Create a Webpack config for compiling docs using Fractal.
-* **css:** Updated stylelint ruleset to match Bedrock's linting pattern. (#814)
+* **css:** Updated stylelint rules to match Bedrock's linting pattern. (#814)
 * **js** Updated `addListener` method, which is now deprecated, to be replaced by `addEventListener`. `addListener` will be used as a fallback for older browsers.
 * **css** Updated focus states for buttons. (#864)
 *  **docs:** Added 404 page
@@ -108,7 +115,7 @@
 
 ## Features
 
-* **css:** Add overiding rules to the card component to enable dark mode with `.mzp-t-dark` class. (#714)
+* **css:** Add overriding rules to the card component to enable dark mode with `.mzp-t-dark` class. (#714)
 * **css:** Add content width classes to Split component.
 * **css:** Add default bottom margins to Logo and Wordmark components (#712)
 * **css:** Add `.mzp-u-title-3xs` utility class.
@@ -283,7 +290,7 @@
 ## Features
 
 * **css:** Update form label styles (#430)
-* **js:** Implement sticky scrolling behaviour for navigation component as an opt-in feature (#560).
+* **js:** Implement sticky scrolling behavior for navigation component as an opt-in feature (#560).
 * **utility:** Add title size utility classes. Rename `text-display-` to `text-title-`, keep `text-display-` as an alias (#297).
 * **component:** Updates to emphasis box, with additional documentation and usage guidelines.
 * **css:** Notification bar updates; use border-box, fix image replacement bug, add focus styles, tweak spacing (#549).
@@ -419,7 +426,7 @@
 * **css:** blockquote needs mzp-t-firefox theme #303
 * **css:** Summary button text over laps icon #331
 * **css:** Make summary and details widget styles into mixins #332
-* **css:** Visited link colour in t-dark themes too dark #335
+* **css:** Visited link color in t-dark themes too dark #335
 
 # 5.0.0
 

--- a/assets/js/protocol/details.js
+++ b/assets/js/protocol/details.js
@@ -6,8 +6,8 @@ const MzpDetails = {};
 let _count = 0;
 
 MzpDetails.isSupported = () => {
-    if (typeof MzpSupports !== 'undefined' && typeof MzpUtils !== 'undefined') {
-        return MzpSupports.classList;
+    if (typeof window.MzpSupports !== 'undefined' && typeof window.MzpUtils !== 'undefined') {
+        return window.MzpSupports.classList;
     } else {
         return false;
     }
@@ -92,7 +92,7 @@ MzpDetails.initItem = (el, selector, options) => {
 
     // Expand
     // siblings of the summary, until next summary
-    const summarySiblings = MzpUtils.nextUntil(summary, selector);
+    const summarySiblings = window.MzpUtils.nextUntil(summary, selector);
 
     // look to see if all children are already in a wrapper we can use
     if (summarySiblings.length === 1) {
@@ -213,20 +213,5 @@ MzpDetails.destroy = (selector, options) => {
         MzpDetails.destroyItem(summaries[i], selector, options);
     }
 };
-
-// check if details is supported, if not, init this as a polyfill
-if (typeof MzpSupports !== 'undefined') {
-    // not supported, add support
-    if(!MzpSupports.details) {
-        MzpDetails.init('summary');
-    }
-}
-
-// init generic class indicating headings should be made into open/close component
-MzpDetails.init('.mzp-c-details > h2');
-MzpDetails.init('.mzp-c-details > h3');
-MzpDetails.init('.mzp-c-details > h4');
-MzpDetails.init('.mzp-c-details > h5');
-MzpDetails.init('.mzp-c-details > h6');
 
 module.exports = MzpDetails;

--- a/assets/js/protocol/footer.js
+++ b/assets/js/protocol/footer.js
@@ -10,22 +10,22 @@ MzpFooter.init = () => {
     // removes Details component if screen size is big
     function screenChange(mq) {
         if (mq.matches) {
-            MzpDetails.init(footerHeadings);
+            window.MzpDetails.init(footerHeadings);
         } else {
-            MzpDetails.destroy(footerHeadings);
+            window.MzpDetails.destroy(footerHeadings);
         }
     }
 
     // check we have global Supports and Details library
-    if (typeof MzpSupports !== 'undefined' && typeof MzpDetails !== 'undefined') {
+    if (typeof window.MzpSupports !== 'undefined' && typeof window.MzpDetails !== 'undefined') {
 
         // check browser supports matchMedia
-        if (MzpSupports.matchMedia) {
+        if (window.MzpSupports.matchMedia) {
             const _mqWide = matchMedia('(max-width: 479px)');
 
             // initialize details if screen is small
             if (_mqWide.matches) {
-                MzpDetails.init(footerHeadings);
+                window.MzpDetails.init(footerHeadings);
             }
 
             if (window.matchMedia('all').addEventListener) {

--- a/assets/js/protocol/menu.js
+++ b/assets/js/protocol/menu.js
@@ -313,8 +313,8 @@ MzpMenu.enhanceJS = () => {
  * Basic feature detect for 1st class menu JS support.
  */
 MzpMenu.isSupported = () => {
-    if (typeof MzpSupports !== 'undefined') {
-        return MzpSupports.matchMedia && MzpSupports.classList;
+    if (typeof window.MzpSupports !== 'undefined') {
+        return window.MzpSupports.matchMedia && window.MzpSupports.classList;
     } else {
         return false;
     }

--- a/assets/js/protocol/navigation.js
+++ b/assets/js/protocol/navigation.js
@@ -33,12 +33,12 @@ MzpNavigation.isLargeViewport = () => {
  * @returns {Boolean}
  */
 MzpNavigation.supportsSticky = () => {
-    if (typeof MzpSupports !== 'undefined') {
+    if (typeof window.MzpSupports !== 'undefined') {
         return (
-            MzpSupports.matchMedia &&
-            MzpSupports.classList &&
-            MzpSupports.requestAnimationFrame &&
-            MzpSupports.cssFeatureQueries &&
+            window.MzpSupports.matchMedia &&
+            window.MzpSupports.classList &&
+            window.MzpSupports.requestAnimationFrame &&
+            window.MzpSupports.cssFeatureQueries &&
             CSS.supports('position', 'sticky')
         );
     } else {
@@ -132,8 +132,8 @@ MzpNavigation.checkScrollPosition = () => {
         // hide the sticky nav shortly after scrolling down the viewport.
         if (window.scrollY > _stickyScrollOffset) {
             // if there's a menu currently open, close it.
-            if (typeof MzpMenu !== 'undefined') {
-                MzpMenu.close();
+            if (typeof window.MzpMenu !== 'undefined') {
+                window.MzpMenu.close();
             }
 
             _navElem.classList.add('mzp-is-hidden');
@@ -187,7 +187,7 @@ MzpNavigation.onClick = (e) => {
  */
 MzpNavigation.menuButtonVisible = (callback) => {
     // check if Intersection observer is supported
-    if (MzpSupports !== 'undefined' && MzpSupports.intersectionObserver) {
+    if (window.MzpSupports !== 'undefined' && window.MzpSupports.intersectionObserver) {
         const observer = new IntersectionObserver(
             (entries) => {
                 for (let index = 0; index < entries.length; index++) {
@@ -207,7 +207,7 @@ MzpNavigation.menuButtonVisible = (callback) => {
  * Set initial ARIA navigation states.
  */
 MzpNavigation.setAria = () => {
-    if (MzpSupports !== 'undefined' && MzpSupports.intersectionObserver) {
+    if (window.MzpSupports !== 'undefined' && window.MzpSupports.intersectionObserver) {
         MzpNavigation.menuButtonVisible((isVisible, menuButton) => {
             if (isVisible) {
                 // if the menu button is visible -  set the 'aria-expanded' role based on whether the menu is open or not

--- a/components/details-component/details-component--custom.readme.md
+++ b/components/details-component/details-component--custom.readme.md
@@ -7,13 +7,13 @@ tacky).
 
 You can initiate using a custom class name like so:
 
-```
+```javascript
 MzpDetails.init('.demo-heading');
 ```
 
 Callbacks are supported for open and close events:
 
-```
+```javascript
 MzpDetails.init('.demo-heading', {
   onDetailsOpen: function(){
     console.log('open');
@@ -26,6 +26,6 @@ MzpDetails.init('.demo-heading', {
 
 A custom component can also be destroyed using:
 
-```
+```javascript
 MzpDetails.destroy('.demo-heading');
 ```

--- a/components/details-component/details-component.html
+++ b/components/details-component/details-component.html
@@ -16,3 +16,20 @@
 </section>
 
 <script src="{{ '/protocol/js/details.js' | path }}"></script>
+
+<script>
+  // check if details is supported, if not, init this as a polyfill
+  if (typeof window.MzpSupports !== 'undefined') {
+      // not supported, add support
+      if(!window.MzpSupports.details) {
+          window.MzpDetails.init('summary');
+      }
+  }
+
+  // init generic class indicating headings should be made into open/close component
+  window.MzpDetails.init('.mzp-c-details > h2');
+  window.MzpDetails.init('.mzp-c-details > h3');
+  window.MzpDetails.init('.mzp-c-details > h4');
+  window.MzpDetails.init('.mzp-c-details > h5');
+  window.MzpDetails.init('.mzp-c-details > h6');
+</script>

--- a/components/details-component/readme.md
+++ b/components/details-component/readme.md
@@ -7,24 +7,40 @@ apply to any element.
 
 Import using Webpack as an ES module:
 
-```
+```javascript
 import MzpDetails from '@mozilla-protocol/core/protocol/js/details';
 ```
 
 Import using Webpack as CommonJS:
 
-```
+```javascript
 const MzpDetails = require('@mozilla-protocol/core/protocol/js/details');
 ```
 
 Import as a global variable via a `<script>` tag:
 
-```
+```javascript
 const MzpDetails = window.MzpDetails;
 ```
 
-The Details component will be automatically initialized in a page for any HTML elements that contain
-a `.mzp-c-details` class name and a child `h2` to `h6` heading element.
+Then initialize the component:
+
+```javascript
+// check if details is supported, if not, init this as a polyfill
+if (typeof window.MzpSupports !== 'undefined') {
+    // not supported, add support
+    if(!window.MzpSupports.details) {
+        window.MzpDetails.init('summary');
+    }
+}
+
+// init generic class indicating headings should be made into open/close component
+window.MzpDetails.init('.mzp-c-details > h2');
+window.MzpDetails.init('.mzp-c-details > h3');
+window.MzpDetails.init('.mzp-c-details > h4');
+window.MzpDetails.init('.mzp-c-details > h5');
+window.MzpDetails.init('.mzp-c-details > h6');
+```
 
 ### Dependencies
 
@@ -32,7 +48,7 @@ The Details component depends on both the `MzpSupports` and `MzpUtils` libraries
 and DOM traversal. It is recommended that both are included in your page and accessible via a global
 object before loading your Details component script.
 
-```
+```javascript
 import MzpSupports from '@mozilla-protocol/core/protocol/js/supports';
 import MzpUtils from '@mozilla-protocol/core/protocol/js/utils';
 

--- a/components/footer/01-footer/readme.md
+++ b/components/footer/01-footer/readme.md
@@ -6,25 +6,25 @@ as it’s meant to take up the full width of the page.
 
 Import using Webpack as an ES module:
 
-```
+```javascript
 import MzpFooter from '@mozilla-protocol/core/protocol/js/footer';
 ```
 
 Import using Webpack as CommonJS:
 
-```
+```javascript
 const MzpFooter = require('@mozilla-protocol/core/protocol/js/footer');
 ```
 
 Import as a global variable via a `<script>` tag:
 
-```
+```javascript
 const MzpFooter = window.MzpFooter;
 ```
 
 You can then initialize the component using `init()`.
 
-```
+```javascript
 MzpFooter.init();
 ```
 
@@ -33,7 +33,7 @@ MzpFooter.init();
 The Footer component depends on the Details component in order to support expandable sections on small viewports.
 It is recommended to include `MzpDetails` in your page as a global object before loading your Footer component script.
 
-```
+```javascript
 import MzpDetails from '@mozilla-protocol/core/protocol/js/details');
 
 window.MzpDetails = MzpDetails;

--- a/components/language-switcher/readme.md
+++ b/components/language-switcher/readme.md
@@ -4,31 +4,31 @@ A component for changing the language of the current page.
 
 Import using Webpack as an ES module:
 
-```
+```javascript
 import MzpLangSwitcher from '@mozilla-protocol/core/protocol/js/lang-switcher';
 ```
 
 Import using Webpack as CommonJS:
 
-```
+```javascript
 const MzpLangSwitcher = require('@mozilla-protocol/core/protocol/js/lang-switcher');
 ```
 
 Import as a global variable via a `<script>` tag:
 
-```
+```javascript
 const MzpLangSwitcher = window.MzpLangSwitcher;
 ```
 
 You can then initialize the component using `init()`.
 
-```
+```javascript
 MzpLangSwitcher.init();
 ```
 
 You can also pass a custom callback for when a language selection takes place:
 
-```
+```javascript
 MzpLangSwitcher.init((previousLanguage, newLanguage) => {
   console.log('Previous language:', previousLanguage);
   console.log('New language:', newLanguage)

--- a/components/modal/readme.md
+++ b/components/modal/readme.md
@@ -5,19 +5,19 @@ a title, image/video, and description.
 
 Import using Webpack as an ES module:
 
-```
+```javascript
 import MzpModal from '@mozilla-protocol/core/protocol/js/modal';
 ```
 
 Import using Webpack as CommonJS:
 
-```
+```javascript
 const MzpModal = require('@mozilla-protocol/core/protocol/js/modal');
 ```
 
 Import as a global variable via a `<script>` tag:
 
-```
+```javascript
 const MzpModal = window.MzpModal;
 ```
 
@@ -25,13 +25,13 @@ You can then initialize the component using `createModal()`. For the modal to wo
 references to the DOM element that triggered the modal, and a DOM element containing the content you wish to
 display.
 
-```
+```javascript
 MzpModal.createModal(origin, content, options);
 ```
 
 You can also pass a range of configuration options:
 
-```
+```javascript
 MzpModal.createModal(origin, content, {
   title: 'Example headline with 35 characters',
   className: 'mzp-has-media',

--- a/components/navigation/01-navigation/readme.md
+++ b/components/navigation/01-navigation/readme.md
@@ -5,31 +5,31 @@ Main site Navigation, containing [Menu](menu) and
 
 Import using Webpack as an ES module:
 
-```
+```javascript
 import MzpNavigation from '@mozilla-protocol/core/protocol/js/navigation';
 ```
 
 Import using Webpack as CommonJS:
 
-```
+```javascript
 const MzpNavigation = require('@mozilla-protocol/core/protocol/js/navigation');
 ```
 
 Import as a global variable via a `<script>` tag:
 
-```
+```javascript
 const MzpNavigation = window.MzpNavigation;
 ```
 
 You can then initialize the component using `init()`.
 
-```
+```javascript
 MzpNavigation.init();
 ```
 
 You can also pass custom callbacks for nav open and close events as a configuration object like so:
 
-```
+```javascript
 MzpNavigation.init({
   onNavOpen: function () {
     console.log('Navigation opened');
@@ -43,12 +43,14 @@ MzpNavigation.init({
 ### Dependencies
 
 The Menu component is a child of the Navigation component, and is therefore a dependency. You need to
-import and initialize the `MzpMenu` component when also initializing `MzpNavigation`.
+import the `MzpMenu` component as a global variable and initialize it along side `MzpNavigation`.
 
-```
+```javascript
 import MzpMenu from '@mozilla-protocol/core/protocol/js/menu');
 
-MzpMenu.init();
+window.MzpMenu = MzpMenu;
+
+window.MzpMenu.init();
 ```
 
 ### Tips

--- a/components/navigation/02-menu/readme.md
+++ b/components/navigation/02-menu/readme.md
@@ -5,31 +5,31 @@ An expandable menu used in the [Navigation](navigation) component, consisting of
 
 Import using Webpack as an ES module:
 
-```
+```javascript
 import MzpMenu from '@mozilla-protocol/core/protocol/js/menu';
 ```
 
 Import using Webpack as CommonJS:
 
-```
+```javascript
 const MzpMenu = require('@mozilla-protocol/core/protocol/js/menu');
 ```
 
 Import as a global variable via a `<script>` tag:
 
-```
+```javascript
 const MzpMenu = window.MzpMenu;
 ```
 
 You can then initialize the component using `init()`.
 
-```
+```javascript
 MzpMenu.init();
 ```
 
 You can also pass custom callbacks for menu open and close events as a configuration object like so:
 
-```
+```javascript
 MzpMenu.init({
   onMenuOpen: function () {
     console.log('Menu opened');

--- a/components/newsletter/readme.md
+++ b/components/newsletter/readme.md
@@ -8,25 +8,25 @@ the [Basket example](https://github.com/mozilla/basket-example/) for more.
 
 Import using Webpack as an ES module:
 
-```
+```javascript
 import MzpNewsletter from '@mozilla-protocol/core/protocol/js/newsletter';
 ```
 
 Import using Webpack as CommonJS:
 
-```
+```javascript
 const MzpNewsletter = require('@mozilla-protocol/core/protocol/js/newsletter');
 ```
 
 Import as a global variable via a `<script>` tag:
 
-```
+```javascript
 const MzpNewsletter = window.MzpNewsletter;
 ```
 
 You can then initialize the component using `init()`.
 
-```
+```javascript
 MzpNewsletter.init();
 ```
 

--- a/components/notification-bar/notification-bar--scripted.readme.md
+++ b/components/notification-bar/notification-bar--scripted.readme.md
@@ -5,32 +5,32 @@ bar.
 
 Import using Webpack as an ES module:
 
-```
+```javascript
 import MzpNotification from '@mozilla-protocol/core/protocol/js/notification-bar';
 ```
 
 Import using Webpack as CommonJS:
 
-```
+```javascript
 const MzpNotification = require('@mozilla-protocol/core/protocol/js/notification-bar');
 ```
 
 Import as a global variable via a `<script>` tag:
 
-```
+```javascript
 const MzpNotification = window.MzpNotification;
 ```
 
 You can then initialize the component using `init()`. For the notification to work it is required that you pass
 a reference to the DOM element that triggered the modal, as well as a title to display.
 
-```
+```javascript
 MzpNotification.init(origin, options);
 ```
 
 You can also pass a range of configuration options:
 
-```
+```javascript
 MzpNotification.init(origin, {
   title: 'This is the title.',
   cta: {

--- a/components/sidebar-menu/readme.md
+++ b/components/sidebar-menu/readme.md
@@ -10,25 +10,25 @@ small viewports. The menu label should be the title of the site section.
 
 Import using Webpack as an ES module:
 
-```
+```javascript
 import MzpSideMenu from '@mozilla-protocol/core/protocol/js/sidemenu';
 ```
 
 Import using Webpack as CommonJS:
 
-```
+```javascript
 const MzpSideMenu = require('@mozilla-protocol/core/protocol/js/sidemenu');
 ```
 
 Import as a global variable via a `<script>` tag:
 
-```
+```javascript
 const MzpSideMenu = window.MzpSideMenu;
 ```
 
 You can then initialize the component using `init()`.
 
-```
+```javascript
 MzpSideMenu.init();
 ```
 

--- a/components/sticky-promo/readme.md
+++ b/components/sticky-promo/readme.md
@@ -15,25 +15,25 @@ make the promo excessively tall and cover too much of the page.
 
 Import using Webpack as an ES module:
 
-```
+```javascript
 import MzpStickyPromo from '@mozilla-protocol/core/protocol/js/sticky-promo';
 ```
 
 Import using Webpack as CommonJS:
 
-```
+```javascript
 const MzpStickyPromo = require('@mozilla-protocol/core/protocol/js/sticky-promo');
 ```
 
 Import as a global variable via a `<script>` tag:
 
-```
+```javascript
 const MzpStickyPromo = window.MzpStickyPromo;
 ```
 
 You can then show the component using `open()`.
 
-```
+```javascript
 MzpStickyPromo.open();
 ```
 


### PR DESCRIPTION
## Description

Updates `MzpDetails` component so we have to explicitly initialize it after importing.
Updates components that have dependencies to make sure they exist on the global (`window`) object.

- [ ] ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#879

### Testing

Details component should still initialize as expected: http://localhost:3000/components/detail/details-component--default
