### PR TITLE
Fix incorrect rem value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # HEAD
-
+* **css:** Fix incorrect value for `text-body-lg` in firefox theme.
 # 18.0.0
 
 ## Features

--- a/assets/sass/protocol/includes/themes/_firefox.scss
+++ b/assets/sass/protocol/includes/themes/_firefox.scss
@@ -52,7 +52,7 @@
     --title-3xs-size: 1rem;
     --title-3xs-line-height: 1.25;
     --body-xl-size: 1.313rem;
-    --body-lg-size: 1.1rem;
+    --body-lg-size: 1.125rem;
     --body-md-size: 1rem;
     --body-sm-size: 0.875rem;
     --body-xs-size: 0.75rem;


### PR DESCRIPTION
## Description
Protocol v18 had an incorrect value for `test-body-lg` variable in the firefox theme.

- [ x] I have documented this change in the design system.
- [ x] I have recorded this change in `CHANGELOG.md`.

### Testing
`text-body-lg` should be 1.125rem instead of 1.1rem
