### PR TITLE
Fix typo at lang-switcher.js comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug Fixes
 * **css:** Fix incorrect value for `text-body-lg` in Firefox theme.
+* **js:** Fix typo at `lang-switcher.js` comment
 
 ## Migration Tips
 * Rename instances of `mzp-c-call-out` to `mzp-c-callout` (note the removed dash).

--- a/assets/js/protocol/lang-switcher.js
+++ b/assets/js/protocol/lang-switcher.js
@@ -5,7 +5,7 @@
 const MzpLangSwitcher = {};
 
 /**
- * Returns URL pathname with preceded by a new page locale.
+ * Returns URL pathname preceded by a new page locale.
  * Assumes first path immediately after hostname is the page locale.
  * @param {Object} Location interface
  * @param {String} Newly selected language code e.g. `de`


### PR DESCRIPTION
## Description

Describe what this change does.

- [ ] I have documented this change in the design system.
- [X] I have recorded this change in `CHANGELOG.md`.

### Issue

Add a link to a related GitHub issue if applicable.

Not applicable.

### Testing

Enter helpful notes for whoever code reviews this change.

Just a typo at `lang-switcher.js` comment, line 14.