### PR TITLE
Center-align button text [fix #826]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Bug Fixes
 * **css:** Fix incorrect value for `text-body-lg` in Firefox theme.
 * **js:** Fix typo at `lang-switcher.js` comment
+* **css:** Center-align button text (#826)
 
 ## Migration Tips
 * Rename instances of `mzp-c-call-out` to `mzp-c-callout` (note the removed dash).

--- a/assets/sass/protocol/components/_button.scss
+++ b/assets/sass/protocol/components/_button.scss
@@ -89,6 +89,7 @@ a.mzp-c-button {
     font-weight: bold;
     line-height: $body-line-height;
     padding: 6px $spacing-lg;
+    text-align: center;
     text-decoration: none !important;  /* stylelint-disable-line declaration-no-important */
 
     &::-moz-focus-inner {


### PR DESCRIPTION
## Description

Explicitly sets `text-align: center;` for `.mzp-c-button` to compensate for button-styled links inheriting their alignment from their parent. This only really manifests when a button-style link is set to the full width of its container, but that does happen sometimes.

- [ ] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
#826 
