### PR TITLE
Fix favicon mime type [fix #911]

### DIFF
--- a/theme/views/partials/head.nunj
+++ b/theme/views/partials/head.nunj
@@ -1,0 +1,3 @@
+<link rel="shortcut icon" href="{{ path(frctl.theme.get('favicon')) }}" type="image/png">
+{% include 'partials/stylesheets.nunj' %}
+<title>{% if page.title %}{{ page.title }} | {% endif %}{{ frctl.get('project.title') }}</title>


### PR DESCRIPTION
## Description

The Fractal base theme (Mandelbrot) has a hardcoded MIME type of `image/ico` in the head but we're using a PNG. We could, of course, just make a .ico file but we can also update the MIME type by overriding the base theme.

### Issue

#911 
