### PR TITLE
Add Firefox Klar wordmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+# HEAD
+
+## Features
+* **component:** Add Firefox Klar wordmark for the Wordmark component
+
 # 19.1.0
 
 ## Features
 
-* **component** Remove the format option from Newsletter component (#926)
+* **component:** Remove the format option from Newsletter component (#926)
 * **component:** Allow an optional icon in buttons (#893)
 
 # 19.0.0

--- a/assets/sass/protocol/components/logos/_wordmark-product-klar.scss
+++ b/assets/sass/protocol/components/logos/_wordmark-product-klar.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@use 'wordmark';
+
+$class: 'klar';
+$dir: 'firefox/browser/klar';
+
+@each $layout-size, $logo-size in wordmark.$logo-sizes {
+    @include wordmark.wordmark($class, $dir, $layout-size, $logo-size);
+}

--- a/assets/sass/protocol/protocol-components.scss
+++ b/assets/sass/protocol/protocol-components.scss
@@ -66,6 +66,7 @@
 @use 'components/logos/wordmark-product-developer';
 @use 'components/logos/wordmark-product-nightly';
 @use 'components/logos/wordmark-product-focus';
+@use 'components/logos/wordmark-product-klar';
 
 @use 'components/logos/wordmark-product-family';
 @use 'components/logos/wordmark-product-lockwise';

--- a/components/branding/wordmark/wordmark--products.html
+++ b/components/branding/wordmark/wordmark--products.html
@@ -4,6 +4,7 @@
 {% render '@wordmark', { product: 'developer', label: 'Firefox Developer Edition' }  %}
 {% render '@wordmark', { product: 'nightly', label: 'Firefox Nightly' }  %}
 {% render '@wordmark', { product: 'focus', label: 'Firefox Focus' }  %}
+{% render '@wordmark', { product: 'klar', label: 'Firefox Klar' }  %}
 {% render '@wordmark', { product: 'lockwise', label: 'Firefox Lockwise' }  %}
 {% render '@wordmark', { product: 'monitor', label: 'Firefox Monitor' }  %}
 {% render '@wordmark', { product: 'relay', label: 'Firefox Relay' }  %}

--- a/components/branding/wordmark/wordmark--products.readme.md
+++ b/components/branding/wordmark/wordmark--products.readme.md
@@ -5,6 +5,7 @@ Product classes:
 - `mzp-t-product-developer`
 - `mzp-t-product-nightly`
 - `mzp-t-product-focus`
+- `mzp-t-product-klar`
 - `mzp-t-product-lockwise`
 - `mzp-t-product-monitor`
 - `mzp-t-product-mozilla`


### PR DESCRIPTION
## Description
We do not have a CSS class defined for Firefox Klar wordmark to be used for German locales in Bedrock. Instead, we've been using the English Firefox Focus wordmark. This PR adds that classname so it can be used (with a `{% if LANG=='de' %}` conditional.

i.e. (example used from @janbrasna's [PR in Bedrock](https://github.com/mozilla/bedrock/pull/14490/files#diff-f97847d5549ff9ef28dc0eabf97fe4f7b7a13d41a355fa1c7d8537c967d7604aR60):

```
<div class="mzp-c-wordmark mzp-t-wordmark-md {% if LANG=='de' %} mzp-t-product-klar {% else %}mzp-t-product-focus{% endif %}">{{ ftl('mobile-focus-firefox-focus') }}</div>
```

>[!NOTE]
> I didn't need to add a new logo component to support Klar since it's just Firefox Focus in German, so it uses the same logo.

## Describe what this change does.

- [x] Imports the Firefox Klar wordmark
- [x] Creates a class for Firefox Klar to be used in Bedrock (`mzp-t-product-klar` in conjunction with `mzp-c-wordmark`)
- [x] I have recorded this change in `CHANGELOG.md`.

## Issue

Fixes https://github.com/mozilla/protocol/issues/930
Refs https://github.com/mozilla/bedrock/pull/14490

## Testing

http://localhost:3000/components/detail/wordmark--default -- change the `firefox` string to `klar` and you should see the wordmark appear on the page
