### PR TITLE
Fix breadcrumb styling

### DIFF
--- a/assets/sass/protocol/components/_breadcrumb.scss
+++ b/assets/sass/protocol/components/_breadcrumb.scss
@@ -6,10 +6,12 @@
 
 .mzp-c-breadcrumb {
     background-color: $background-color-secondary;
+    padding: $spacing-sm 0;
 
     .mzp-c-breadcrumb-list {
-        margin-bottom: 0;
-        padding: $spacing-sm $spacing-md;
+        max-width: $content-max;
+        margin: 0 auto;
+        padding: 0 $h-grid-xs;
 
         .mzp-c-breadcrumb-item {
             display: inline-block;
@@ -32,11 +34,15 @@
         }
 
         @media #{$mq-md} {
-            padding: $spacing-sm $layout-sm;
+            padding: 0 $h-grid-md;
         }
 
         @media #{$mq-lg} {
             padding: $spacing-sm $layout-xl - $spacing-md;
+        }
+
+        @media #{$mq-xl} {
+            padding: 0 $h-grid-xl;
         }
     }
 


### PR DESCRIPTION
## Description

Fixes positioning bug in wider layouts and makes the overall alignment more consistent with other navigation items.

- TBD design/padding & default link decorations…
- for $mq-lg also consider $spacing vs $layout vs $h-grid

TODO:

- [ ] I have documented this change in the design system.
- [ ] I have recorded this change in `CHANGELOG.md`.

### Issue

Resolves #933

### Testing

xref bedrock issues and pages to test