### PR TITLE
Add `text-wrap: balance` to all headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # HEAD
 
 ## Features
-* **assets:** Upgrade Inter font to version 4.1, drop support for Inter `woff` (bedrock #15999)
 
+* **fonts:** Upgrade Inter font to version 4.1, drop WOFF 1.0 format (#1026)
+* **css:** Add `text-wrap: balance` to all headings (#910)
 * **css:** Apply hover cursor from Details component to Details element (#948)
 
 ## Bug Fixes
@@ -11,21 +12,24 @@
 
 ## Migration Tips
 
+* Headings are now [balanced](https://developer.mozilla.org/docs/Web/CSS/text-wrap-style#balanced_text), which can impact other wrapping rules. Make sure any changes to `h1`–`h6` rendering end up styled as expected, especially if you apply any `white-space`, `word-break` or `hyphens` customizations.
 * See notes for [Protocol Assets 5.4.0](https://github.com/mozilla/protocol-assets/blob/main/CHANGELOG.md#540)
 
 # 19.3.0
 
 ## Features
+
 * **js:** Migrate tests from Karma to Jasmine browser runner (#899)
 
-
 ## Bug Fixes
+
 * **css:** Form select elements don't match styling when disabled (#885)
 * **css:** Modal close button pointer overridden by defaults (#955)
 
 # 19.2.0
 
 ## Features
+
 * **component:** Add Firefox Klar wordmark for the Wordmark component (#932)
 * **js:** Migrate ESLint to use flat config file (#906)
 

--- a/assets/sass/protocol/base/elements/_titles.scss
+++ b/assets/sass/protocol/base/elements/_titles.scss
@@ -15,6 +15,7 @@ h6 {
     font-family: $title-font-family;
     color: $title-text-color;
     font-weight: bold;
+    text-wrap: balance;
     margin: 0 0 0.5em;
 
     .mzp-t-dark & {


### PR DESCRIPTION
## Description

> ![css-ui_css-text-wrap-balance](https://developer.chrome.com/static/docs/css-ui/css-text-wrap-balance/image/the-previous-exaples-are-c9809697f2f6a_856.png)

https://caniuse.com/css-text-wrap-balance is pretty well supported now with no real downside, known bugs or performance issues documented.

- ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Resolves #910

### Testing

Safari 16 vs. 17.5+
Firefox 115 (ESR) vs. 122+

PR: https://preview--mzp-dev.netlify.app/components/detail/headings

_(before:)_
![Screenshot 2025-03-28 at 2 32 45 Large](https://github.com/user-attachments/assets/2e77fa18-21cc-4090-8805-413a137782f8)

_(after:)_
![Screenshot 2025-03-28 at 2 32 59 Large](https://github.com/user-attachments/assets/42d8fbbd-cc70-4d97-8d9b-9a7d05b0d243)
