### PR TITLE
Add workflow to publish docs on release

### DIFF
--- a/.github/workflows/docs-prod.yml
+++ b/.github/workflows/docs-prod.yml
@@ -1,0 +1,22 @@
+name: Publish docs
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Push prod
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git push origin ${GITHUB_SHA}:prod


### PR DESCRIPTION
## Description

Pushes the tag/sha used for creating a Release to `prod` branch for Netlify to pick it up, building and publishing the production site.

- [ ] ~~I have documented this change in the design system.~~
- [ ] ~~I have recorded this change in `CHANGELOG.md`.~~

### Testing

This aims to do no lint/tests, as that all should have been sorted out merging into main, and when the Release author selects the commit~ish for releasing/tagging, they ought to have verified everything a-ok in staging and pipeline already.

If a changeset failing to build is pushed, nothing really happens as Netlify deployment will just fail the build but still keep the previous stable deployment available so until addressed, the previous version will be served.

Pushes are ff-only otherwise rejected so are foolproof, no destructive operation can happen.

Failures as releasing older versions than already published etc. are not skipped silently, but visibly fail the run to show it didn't get published, and for what reason (diverging histories, pushing older ref, nothing in common etc.) keeping it as low level as possible. [[ex](https://github.com/janbrasna/gha-test-prod-release-push/actions/runs/9782647642/job/27009462150#step:3:1)]

This intentionally doesn't add a manual workflow_trigger to only really enforce tagged release _sha_ refs not allowing arbitrary refs being pushed to prod. If a manual correction is needed, this won't interfere with any git operations undertaken, just trying to push the next released tag to the linear history of prod again. [[ex](https://github.com/janbrasna/gha-test-prod-release-push/actions/runs/9783082461/job/27010849087#step:3:1)]

Repository activity correctly shows when a bot updates a branch, so it can be easily distinguished if the prod push was manual or automated. [[ex](https://github.com/janbrasna/gha-test-prod-release-push/activity)]

![Screen Shot 2024-07-03 at 21 13 01](https://github.com/mozilla/protocol/assets/1784648/eef0e01b-a6a2-456f-a213-f11b91c2c6d7)