### PR TITLE
Fix modal "X" close cursor affordance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Features
 * **js:** Migrate tests from Karma to Jasmine browser runner (#899)
 
+## Bug Fixes
+* **css:** Modal close button pointer overridden by defaults (#955)
+
 # 19.2.0
 
 ## Features

--- a/assets/sass/protocol/components/_modal.scss
+++ b/assets/sass/protocol/components/_modal.scss
@@ -73,7 +73,6 @@ html.mzp-is-noscroll {
 
 .mzp-c-modal-close {
     @include bidi(((right, $spacing-sm, left, auto),));
-    cursor: pointer;
     position: absolute;
     top: 9px;
     z-index: 99;
@@ -88,6 +87,7 @@ html.mzp-is-noscroll {
         min-width: 0;
         padding: 0;
         width: 42px;
+        cursor: pointer;
 
         &:hover,
         &:focus {


### PR DESCRIPTION
## Description

Sets the cursor on the actual button element to avoid any UA defaults overriding it.

- [ ] ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Resolves #955

### Testing

https://fix-modal-close-pointer--mzp-dev.netlify.app/components/detail/modal