### PR TITLE
Add package details to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ Mozillians) or in #protocol-design-system on [Matrix](https://chat.mozilla.org/)
 (open to the public). Also feel free to
 [file an issue on GitHub](https://github.com/mozilla/protocol/issues).
 
-![Current npm package version.](https://img.shields.io/npm/v/@mozilla-protocol/core)
-![Total downloads on npm.](https://img.shields.io/npm/dt/@mozilla-protocol/core)
-![Pull requests welcome!](https://img.shields.io/badge/PRs-welcome-brightgreen)
+[![Current npm package version.](https://img.shields.io/npm/v/@mozilla-protocol/core)](https://www.npmjs.com/package/@mozilla-protocol/core)
+[![Total downloads on npm.](https://img.shields.io/npm/dt/@mozilla-protocol/core)](https://github.com/mozilla/protocol/releases)
+[![Pull requests welcome!](https://img.shields.io/badge/PRs-welcome-93c?logo=github
+)](https://protocol.mozilla.org/docs/contributing/overview)
 
 ## Getting Started
 
 Protocol is built on the [Node.js](https://nodejs.org/) platform and published
-to [NPM](https://www.npmjs.com/), so be sure to have both installed before
+to [NPM](https://www.npmjs.com/package/@mozilla-protocol/core), so be sure to have both installed before
 proceeding.
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,8 @@ title: Mozilla Protocol
 hidden: true
 ---
 
+[![Current npm package version](https://img.shields.io/npm/v/@mozilla-protocol/core)](https://www.npmjs.com/package/@mozilla-protocol/core)
+
 Protocol is a design system for Mozilla and Firefox websites. It establishes a common design language, provides reusable coded components, and outlines high level guidelines for content and accessibility.
 
 Protocol is still an evolving project. Currently it’s used primarily by the Mozilla Marketing Websites team as the front-end for [www.mozilla.org](https://www.mozilla.org). The long term goal is to provide a robust, unified design system that anyone at Mozilla can use to build an on-brand website.

--- a/theme/views/partials/head.nunj
+++ b/theme/views/partials/head.nunj
@@ -1,3 +1,3 @@
 <link rel="shortcut icon" href="{{ path(frctl.theme.get('favicon')) }}" type="image/png">
 {% include 'partials/stylesheets.nunj' %}
-<title>{% if page.title %}{{ page.title }} | {% endif %}{{ frctl.get('project.title') }}</title>
+<title>{% if page.title and page.title !== frctl.get('project.title') %}{{ page.title }} | {% endif %}{{ frctl.get('project.title') }}</title>


### PR DESCRIPTION
## Description

Adds current npm version and link to docs homepage.
Also adds meaningful links to repo readme badges, to link somewhere instead of the badge img itself.
As a bonus also fixes homepage title repeating itself…

- [ ] ~I have documented this change in the design system.~
- [ ] ~I have recorded this change in `CHANGELOG.md`.~

### Issue

Fixes #230

### Testing

https://add-package-details--mzp-dev.netlify.app/