### PR TITLE
Update sass-loader to @16.0.3

### DIFF
--- a/assets/sass/protocol/includes/_tokens.scss
+++ b/assets/sass/protocol/includes/_tokens.scss
@@ -1,1 +1,1 @@
-@forward './node_modules/@mozilla-protocol/tokens/dist';
+@forward '~@mozilla-protocol/tokens/dist';

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "mini-css-extract-plugin": "^2.9.1",
         "postcss-scss": "^4.0.9",
         "sass": "^1.77.6",
-        "sass-loader": "^14.2.1",
+        "sass-loader": "^16.0.3",
         "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
         "webpack-remove-empty-scripts": "^1.0.4"
@@ -10320,9 +10320,9 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-14.2.1.tgz",
-      "integrity": "sha512-G0VcnMYU18a4N7VoNDegg2OuMjYtxnqzQWARVWCIVSZwJeiL9kg8QMsuIZOplsJgTzZLF6jGxI3AClj8I9nRdQ==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.3.tgz",
+      "integrity": "sha512-gosNorT1RCkuCMyihv6FBRR7BMV06oKRAs+l4UMp1mlcVg9rWN6KMmUj3igjQwmYys4mDP3etEYJgiHRbgHCHA==",
       "dependencies": {
         "neo-async": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "mini-css-extract-plugin": "^2.9.1",
     "postcss-scss": "^4.0.9",
     "sass": "^1.77.6",
-    "sass-loader": "^14.2.1",
+    "sass-loader": "^16.0.3",
     "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4",
     "webpack-remove-empty-scripts": "^1.0.4"

--- a/theme/assets/sass/preview.scss
+++ b/theme/assets/sass/preview.scss
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Styles for the component preview frame
-@use 'assets/sass/protocol/includes/themes';
+@use '/assets/sass/protocol/includes/themes';
 
 html,
 body {

--- a/theme/assets/sass/theme.scss
+++ b/theme/assets/sass/theme.scss
@@ -7,7 +7,7 @@
 @use '/assets/sass/protocol/includes/fonts/inter';
 @use '/assets/sass/protocol/includes/fonts/metropolis';
 @use '/assets/sass/protocol/includes/fonts/zilla-slab';
-@use 'assets/sass/protocol/includes/themes';
+@use '/assets/sass/protocol/includes/themes';
 
 // Settings
 @use 'settings/settings';

--- a/webpack.package.static.config.js
+++ b/webpack.package.static.config.js
@@ -34,7 +34,7 @@ module.exports = {
                         // This is required so that _lib.scss can load the tokens package
                         // using a relative @import, as opposed to the main Protocol package
                         // needing to distribute its own set of node_modules dependencies.
-                        return content.toString().replace('./node_modules/@mozilla-protocol/', '');
+                        return content.toString().replace('~@mozilla-protocol/', '');
                     }
                 },
                 {


### PR DESCRIPTION
## Description

Replaces https://github.com/mozilla/protocol/pull/995 due to some breaking changes in sass-loader 15.0

### Issue

N/A

### Testing

Please try building both the package and the docs locally to make sure everything still seems to work ok.
