### PR TITLE
Fix notification bar link spacing

### DIFF
--- a/assets/sass/protocol/components/_notification-bar.scss
+++ b/assets/sass/protocol/components/_notification-bar.scss
@@ -35,7 +35,6 @@
         display: inline-block;
         font-size: inherit;
         font-weight: 700;
-        margin: 0 $spacing-sm;
 
         &:hover,
         &:active,


### PR DESCRIPTION
## Description

Removes margin that breaks natural flow of sentences in case the link is inside a text.

- ~I have documented this change in the design system.~
- [ ] I have recorded this change in `CHANGELOG.md`.

### Issue

Resolves #1000

### Testing

https://patch-1--mzp-dev.netlify.app/components/detail/notification-bar--error