### PR TITLE
Add pointer to ‹details› element ‹summary›

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+* **css:** Apply hover cursor from Details component to Details element (#948)
+
 ## Bug Fixes
 
 * **assets:** Update @mozilla-protocol/assets to 5.4.0

--- a/assets/sass/protocol/base/elements/_details.scss
+++ b/assets/sass/protocol/base/elements/_details.scss
@@ -30,6 +30,10 @@ details .is-summary button[aria-expanded='true']::before,
     @include summary-open;
 }
 
+summary  {
+    cursor: pointer;
+}
+
 summary::-webkit-details-marker {
     display: none;
 }


### PR DESCRIPTION
## Description

Details _element_ gets styled very close to Details _component_ with many of the enhancements, just the hover affordance is missing for this plan HTML5 use case. This sets the cursor to pointer, as the full component does.

- ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Resolves #948

### Testing

https://patch-2--mzp-dev.netlify.app/components/detail/details

1. I have not fenced this behind any `@supports not (-ms-ime-align: auto)` of sorts for things like IE that don't provide the functionality as that adds extra cruft (and [false positives](https://github.com/mozilla/protocol/issues/948#issuecomment-2218321222)) for not much benefit, when MzpDetails actually provides a polyfill for such browsers.
2. I have opted for a plain extra declaration instead of the `@summary` mixin (which gets included within half a dozen of things) not to apply such styling to places that render it own ways.