### PR TITLE
[WIP] Reduce base link specificity 

### DIFF
--- a/assets/sass/protocol/base/elements/_links.scss
+++ b/assets/sass/protocol/base/elements/_links.scss
@@ -4,12 +4,6 @@
 
 @use '../../includes/lib' as *;
 
-// check support and fallback of :where
-a:where(:visited) {
-    --link-color: var(--link-color-visited);
-    --link-color-hover: var(--link-color-visited-hover);
-}
-
 a {
     color: var(--link-color);
     text-decoration: underline;
@@ -21,6 +15,14 @@ a {
 
     &:where(:active) {
         background-color: rgba(0, 0, 0, 0.05);
+    }
+}
+
+a:where(:visited) {
+    color: var(--link-color-visited);
+
+    &:where(:hover, :focus, :active) {
+        color: var(--link-color-visited-hover);
     }
 }
 

--- a/assets/sass/protocol/base/elements/_links.scss
+++ b/assets/sass/protocol/base/elements/_links.scss
@@ -4,61 +4,42 @@
 
 @use '../../includes/lib' as *;
 
-:link {
-    color: $link-color;
+a {
+    color: var(--link-color);
     text-decoration: underline;
 
     &:hover,
     &:focus,
     &:active {
-        color: $link-color-hover;
+        color: var(--link-color-hover);
         text-decoration: none;
     }
 
     &:active {
         background-color: rgba(0, 0, 0, 0.05);
     }
-
-    @supports (--css: variables) {
-        color: var(--link-color);
-
-        &:hover,
-        &:focus,
-        &:active {
-            color: var(--link-color-hover);
-        }
-    }
 }
 
 :visited {
-    color: $link-color-visited;
-
-    &:hover,
-    &:focus,
-    &:active {
-        color: $link-color-visited-hover;
-    }
-
-    @supports (--css: variables) {
-        color: var(--link-color-visited);
-
-        &:hover,
-        &:focus,
-        &:active {
-            color: var(--link-color-visited-hover);
-        }
-    }
+    --link-color: var(--link-color-visited);
+    --link-color-hover: var(--link-color-visited-hover);
 }
 
 .mzp-t-dark {
-    @include light-links;
+    --link-color: var(--link-color-inverse);
+    --link-color-hover: var(--link-color-hover-inverse);
+    --link-color-visited: var(--link-color-visited-inverse);
+    --link-color-visited-hover:var(--link-color-visited-hover-inverse);
+}
+
+.mzp-t-white-links {
+    --link-color: $color-white;
+    --link-color-hover: $color-white;
+    --link-color-visited: $color-white;
+    --link-color-visited-hover: $color-white;
 }
 
 .mzp-c-cta-link {
-    font-family: $button-font-family;
+    font-family: var(--button-font-family);
     font-weight: bold;
-
-    @supports (--css: variables) {
-        font-family: var(--button-font-family);
-    }
 }

--- a/assets/sass/protocol/base/elements/_links.scss
+++ b/assets/sass/protocol/base/elements/_links.scss
@@ -4,6 +4,12 @@
 
 @use '../../includes/lib' as *;
 
+// check support and fallback of :where
+a:where(:visited) {
+    --link-color: var(--link-color-visited);
+    --link-color-hover: var(--link-color-visited-hover);
+}
+
 a {
     color: var(--link-color);
     text-decoration: underline;
@@ -15,12 +21,6 @@ a {
 
     &:where(:active) {
         background-color: rgba(0, 0, 0, 0.05);
-    }
-
-    // check support and fallback of :where
-    &:where(:visited) {
-        --link-color: var(--link-color-visited);
-        --link-color-hover: var(--link-color-visited-hover);
     }
 }
 
@@ -36,10 +36,10 @@ a {
 // any descendant link will inherit white theming (replace white-links mixin)
 // link-specific theme class
 .mzp-t-white-links {
-    --link-color: $color-white;
-    --link-color-hover: $color-white;
-    --link-color-visited: $color-white;
-    --link-color-visited-hover: $color-white;
+    --link-color: #{$color-white};
+    --link-color-hover: #{$color-white};
+    --link-color-visited: #{$color-white};
+    --link-color-visited-hover: #{$color-white};
 }
 
 // this might belong in a different CTA file?

--- a/assets/sass/protocol/base/elements/_links.scss
+++ b/assets/sass/protocol/base/elements/_links.scss
@@ -8,21 +8,19 @@ a {
     color: var(--link-color);
     text-decoration: underline;
 
-    &:hover,
-    &:focus,
-    &:active {
+    &:where(:hover, :focus, :active) {
         color: var(--link-color-hover);
         text-decoration: none;
     }
 
-    &:active {
+    &:where(:active) {
         background-color: rgba(0, 0, 0, 0.05);
     }
-}
 
-:visited {
-    --link-color: var(--link-color-visited);
-    --link-color-hover: var(--link-color-visited-hover);
+    &:where(:visited) {
+        --link-color: var(--link-color-visited);
+        --link-color-hover: var(--link-color-visited-hover);
+    }
 }
 
 .mzp-t-dark {

--- a/assets/sass/protocol/base/elements/_links.scss
+++ b/assets/sass/protocol/base/elements/_links.scss
@@ -17,12 +17,15 @@ a {
         background-color: rgba(0, 0, 0, 0.05);
     }
 
+    // check support and fallback of :where
     &:where(:visited) {
         --link-color: var(--link-color-visited);
         --link-color-hover: var(--link-color-visited-hover);
     }
 }
 
+// any descendant link will inherit dark theming (replace light-links mixin)
+// this might belong in root file? site-wide dark theme class
 .mzp-t-dark {
     --link-color: var(--link-color-inverse);
     --link-color-hover: var(--link-color-hover-inverse);
@@ -30,6 +33,8 @@ a {
     --link-color-visited-hover:var(--link-color-visited-hover-inverse);
 }
 
+// any descendant link will inherit white theming (replace white-links mixin)
+// link-specific theme class
 .mzp-t-white-links {
     --link-color: $color-white;
     --link-color-hover: $color-white;
@@ -37,6 +42,9 @@ a {
     --link-color-visited-hover: $color-white;
 }
 
+// this might belong in a different CTA file?
+// it's not meant to apply to `a` elements unless they have the class added directly
+// the other classes in this file are theme containers that select `a` elements inside them
 .mzp-c-cta-link {
     font-family: var(--button-font-family);
     font-weight: bold;

--- a/assets/sass/protocol/base/elements/_links.scss
+++ b/assets/sass/protocol/base/elements/_links.scss
@@ -20,7 +20,8 @@ a {
     }
 
     &:hover, &:active, &:focus {
-        color: var(--link-color-hover);
+        /* stylelint-disable-next-line color-function-notation */
+        color: var(--link-color-with-state, hsl(from var(--link-color) h s calc(l - 10)));
         text-decoration: none;
     }
 
@@ -33,18 +34,17 @@ a {
 // this might belong in root file? site-wide dark theme class
 .mzp-t-dark {
     --link-color: var(--link-color-inverse);
-    --link-color-hover: var(--link-color-hover-inverse);
     --link-color-visited: var(--link-color-visited-inverse);
-    --link-color-visited-hover: var(--link-color-visited-hover-inverse);
+    /* stylelint-disable-next-line color-function-notation */
+    --link-color-with-state: hsl(from var(--link-color-inverse) h s calc(l + 10));
 }
 
 // any descendant link will inherit white theming (replace white-links mixin)
 // link-specific theme class
 .mzp-t-white-links {
     --link-color: #{$color-white};
-    --link-color-hover: #{$color-white};
     --link-color-visited: #{$color-white};
-    --link-color-visited-hover: #{$color-white};
+    --link-color-with-state: #{$color-white};
 }
 
 // apply directly to link

--- a/assets/sass/protocol/base/elements/_links.scss
+++ b/assets/sass/protocol/base/elements/_links.scss
@@ -4,25 +4,28 @@
 
 @use '../../includes/lib' as *;
 
+// Rely on source order for the stateful style overrides
+// 1. Visited
+// 2. Hover
+// 3. Active
+// 4. Focus
+
+
 a {
     color: var(--link-color);
     text-decoration: underline;
 
-    &:where(:hover, :focus, :active) {
+    &:visited {
+        color: var(--link-color-visited);
+    }
+
+    &:hover, &:active, &:focus {
         color: var(--link-color-hover);
         text-decoration: none;
     }
 
-    &:where(:active) {
+    &:active {
         background-color: rgba(0, 0, 0, 0.05);
-    }
-}
-
-a:where(:visited) {
-    color: var(--link-color-visited);
-
-    &:where(:hover, :focus, :active) {
-        color: var(--link-color-visited-hover);
     }
 }
 

--- a/assets/sass/protocol/base/elements/_links.scss
+++ b/assets/sass/protocol/base/elements/_links.scss
@@ -32,7 +32,7 @@ a:where(:visited) {
     --link-color: var(--link-color-inverse);
     --link-color-hover: var(--link-color-hover-inverse);
     --link-color-visited: var(--link-color-visited-inverse);
-    --link-color-visited-hover:var(--link-color-visited-hover-inverse);
+    --link-color-visited-hover: var(--link-color-visited-hover-inverse);
 }
 
 // any descendant link will inherit white theming (replace white-links mixin)
@@ -44,9 +44,7 @@ a:where(:visited) {
     --link-color-visited-hover: #{$color-white};
 }
 
-// this might belong in a different CTA file?
-// it's not meant to apply to `a` elements unless they have the class added directly
-// the other classes in this file are theme containers that select `a` elements inside them
+// apply directly to link
 .mzp-c-cta-link {
     font-family: var(--button-font-family);
     font-weight: bold;

--- a/assets/sass/protocol/components/_button.scss
+++ b/assets/sass/protocol/components/_button.scss
@@ -76,8 +76,7 @@
 // * -------------------------------------------------------------------------- */
 // Button shape and size
 
-.mzp-c-button, /* stylelint-disable-line no-duplicate-selectors */
-a.mzp-c-button {
+.mzp-c-button /* stylelint-disable-line no-duplicate-selectors */ {
     @include border-box;
     @include font-size(16px);
     @include transition(background-color 100ms, box-shadow 100ms, color 100ms);
@@ -139,8 +138,7 @@ a.mzp-c-button {
 // Primary
 
 /* stylelint-disable-next-line no-duplicate-selectors */
-.mzp-c-button,
-a.mzp-c-button {
+.mzp-c-button {
     background-color: $color-black;
     border: 2px solid $color-black;
     color: $color-white;
@@ -161,8 +159,7 @@ a.mzp-c-button {
 // Secondary
 
 /* stylelint-disable-next-line no-duplicate-selectors */
-.mzp-c-button,
-a.mzp-c-button {
+.mzp-c-button {
     &.mzp-t-secondary {
         background-color: transparent;
         border-color: $color-black;
@@ -184,8 +181,7 @@ a.mzp-c-button {
 // * -------------------------------------------------------------------------- */
 // Product Buttons
 
-.mzp-c-button.mzp-t-product,
-a.mzp-c-button.mzp-t-product {
+.mzp-c-button.mzp-t-product {
     background-color: $color-blue-50;
     border-color: transparent;
     color: $color-white;
@@ -217,8 +213,7 @@ a.mzp-c-button.mzp-t-product {
 // Neutral Buttons
 
 /* stylelint-disable-next-line no-duplicate-selectors */
-.mzp-c-button,
-a.mzp-c-button {
+.mzp-c-button {
     &.mzp-t-neutral {
         background-color: transparent;
         border-color: $color-marketing-gray-30;

--- a/assets/sass/protocol/components/_button.scss
+++ b/assets/sass/protocol/components/_button.scss
@@ -76,7 +76,7 @@
 // * -------------------------------------------------------------------------- */
 // Button shape and size
 
-.mzp-c-button /* stylelint-disable-line no-duplicate-selectors */ {
+.mzp-c-button {
     @include border-box;
     @include font-size(16px);
     @include transition(background-color 100ms, box-shadow 100ms, color 100ms);

--- a/assets/sass/protocol/components/_button.scss
+++ b/assets/sass/protocol/components/_button.scss
@@ -158,23 +158,20 @@
 // * -------------------------------------------------------------------------- */
 // Secondary
 
-/* stylelint-disable-next-line no-duplicate-selectors */
-.mzp-c-button {
-    &.mzp-t-secondary {
+.mzp-c-button.mzp-t-secondary {
+    background-color: transparent;
+    border-color: $color-black;
+    color: $color-black;
+
+    @include default-states;
+
+    // dark
+    &.mzp-t-dark {
         background-color: transparent;
-        border-color: $color-black;
-        color: $color-black;
+        border-color: $color-white;
+        color: $color-white;
 
-        @include default-states;
-
-        // dark
-        &.mzp-t-dark {
-            background-color: transparent;
-            border-color: $color-white;
-            color: $color-white;
-
-            @include default-states-dark;
-        }
+        @include default-states-dark;
     }
 }
 
@@ -212,50 +209,47 @@
 // * -------------------------------------------------------------------------- */
 // Neutral Buttons
 
-/* stylelint-disable-next-line no-duplicate-selectors */
-.mzp-c-button {
-    &.mzp-t-neutral {
-        background-color: transparent;
-        border-color: $color-marketing-gray-30;
+.mzp-c-button.mzp-t-neutral {
+    background-color: transparent;
+    border-color: $color-marketing-gray-30;
+    color: $color-marketing-gray-70;
+
+    &:focus {
+        border-color: forms.$button-border-color-focus;
+    }
+
+    &:hover {
+        background-color: $color-marketing-gray-20;
+        border-color: $color-marketing-gray-40;
         color: $color-marketing-gray-70;
+    }
+
+    &:active {
+        background-color: $color-marketing-gray-20;
+        border-color: $color-marketing-gray-50;
+        color: $color-marketing-gray-70;
+    }
+
+    // dark
+    &.mzp-t-dark {
+        background-color: rgba($color-white, 0.1);
+        border-color: rgba($color-white, 0.6);
+        color: $color-white;
 
         &:focus {
             border-color: forms.$button-border-color-focus;
         }
 
         &:hover {
-            background-color: $color-marketing-gray-20;
-            border-color: $color-marketing-gray-40;
-            color: $color-marketing-gray-70;
+            background-color: rgba($color-white, 0.2);
+            border-color: rgba($color-white, 0.6);
+            color: $color-white;
         }
 
         &:active {
-            background-color: $color-marketing-gray-20;
-            border-color: $color-marketing-gray-50;
-            color: $color-marketing-gray-70;
-        }
-
-        // dark
-        &.mzp-t-dark {
-            background-color: rgba($color-white, 0.1);
-            border-color: rgba($color-white, 0.6);
+            background-color: rgba($color-white, 0.2);
+            border-color: rgba($color-white, 0.4);
             color: $color-white;
-
-            &:focus {
-                border-color: forms.$button-border-color-focus;
-            }
-
-            &:hover {
-                background-color: rgba($color-white, 0.2);
-                border-color: rgba($color-white, 0.6);
-                color: $color-white;
-            }
-
-            &:active {
-                background-color: rgba($color-white, 0.2);
-                border-color: rgba($color-white, 0.4);
-                color: $color-white;
-            }
         }
     }
 }

--- a/assets/sass/protocol/includes/mixins/_utils.scss
+++ b/assets/sass/protocol/includes/mixins/_utils.scss
@@ -223,61 +223,24 @@
 }
 
 // Light color links for dark backgrounds.
+// Prefer mzp-t-dark class in markup where possible
 @mixin light-links {
-    a:link {
-        color: themes.$link-color-inverse;
-    }
-
-    a:visited {
-        color: themes.$link-color-visited-inverse;
-    }
-
-    a:hover,
-    a:focus,
-    a:active {
-        color: themes.$link-color-hover-inverse;
-    }
-
-    a:visited:hover,
-    a:visited:focus,
-    a:visited:active {
-        color: themes.$link-color-visited-hover-inverse;
-    }
-
-    @supports (--css: variables) {
-        a:link {
-            color: var(--link-color-inverse);
-        }
-
-        a:visited {
-            color: var(--link-color-visited-inverse);
-        }
-
-        a:hover,
-        a:focus,
-        a:active {
-            color: var(--link-color-hover-inverse);
-        }
-
-        a:visited:hover,
-        a:visited:focus,
-        a:visited:active {
-            color: var(--link-color-visited-hover-inverse);
-        }
+    a {
+        --link-color: var(--link-color-inverse);
+        --link-color-hover: var(--link-color-hover-inverse);
+        --link-color-visited: var(--link-color-visited-inverse);
+        --link-color-visited-hover:var(--link-color-visited-hover-inverse);
     }
 }
 
 // White color links for dark backgrounds, when link colors are undesirable.
+// Prefer mzp-t-white-links class in markup where possible
 @mixin white-links {
-    a:link,
-    a:visited {
-        color: tokens.$color-white;
-
-        &:hover,
-        &:focus,
-        &:active {
-            color: tokens.$color-white;
-        }
+    a {
+        --link-color: #{tokens.$color-white};
+        --link-color-hover: #{tokens.$color-white};
+        --link-color-visited: #{tokens.$color-white};
+        --link-color-visited-hover: #{tokens.$color-white};
     }
 }
 

--- a/assets/sass/protocol/includes/themes/_firefox.scss
+++ b/assets/sass/protocol/includes/themes/_firefox.scss
@@ -25,7 +25,7 @@
     --link-color-hover: #{tokens.$color-link-hover};
     --link-color-inverse: #{tokens.$color-blue-10};
     --link-color-visited-hover-inverse: #{tokens.$color-violet-05};
-    --link-color-visited-hover: #{tokens.$color-link-hover};
+    --link-color-visited-hover: #{tokens.$color-link-visited-hover};
     --link-color-visited-inverse: #{tokens.$color-violet-10};
     --link-color-visited: #{tokens.$color-link-visited};
     --link-color: #{tokens.$color-link};

--- a/assets/sass/protocol/includes/themes/_mozilla.scss
+++ b/assets/sass/protocol/includes/themes/_mozilla.scss
@@ -30,7 +30,7 @@
     --link-color-hover: #{tokens.$color-link-hover};
     --link-color-inverse: #{tokens.$color-blue-10};
     --link-color-visited-hover-inverse: #{tokens.$color-violet-05};
-    --link-color-visited-hover: #{tokens.$color-link-hover};
+    --link-color-visited-hover: #{tokens.$color-link-visited-hover};
     --link-color-visited-inverse: #{tokens.$color-violet-10};
     --link-color-visited: #{tokens.$color-link-visited};
     --link-color: #{tokens.$color-link};


### PR DESCRIPTION
## Description

This is more a thought experiment than anything at this stage. The idea is to reduce base element link specificity so it is easily overridden by a single class

Base element specificity: 0 0 1
not visited
<img width="266" alt="Screenshot 2025-04-16 at 12 33 56 PM" src="https://github.com/user-attachments/assets/e2b8e613-21bc-4b3b-b2ef-b33de78e217a" />

visited
<img width="325" alt="Screenshot 2025-04-16 at 12 32 03 PM" src="https://github.com/user-attachments/assets/75a4a0d0-e74f-4c04-b35f-c449827b4816" />

Class specificity: 0 1 0

NOTE: the danger of custom properties is that they inherit all the way down the tree, so could be going further than desired if "donut scope" was intended

- [ ] I have documented this change in the design system.
- [ ] I have recorded this change in `CHANGELOG.md`.

### Issue

Add a link to a related GitHub issue if applicable.

### Testing

Enter helpful notes for whoever code reviews this change.
