### PR TITLE
Footer sections border and spacing tweaks (Fix #1061)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * **assets:** Update @mozilla-protocol/assets to 6.1.1
 
+## Bug Fixes
+
+* **css:** Footer bottom border and spacing changes tweaks (#1061)
+
 # 21.0.0
 
 ## Features

--- a/assets/sass/protocol/components/_footer.scss
+++ b/assets/sass/protocol/components/_footer.scss
@@ -66,13 +66,14 @@
 
 .mzp-c-footer-sections {
     @include clearfix;
+    border-bottom: 1px solid $color-marketing-gray-80;
+    padding-bottom: $layout-lg;
 
-    @media #{$mq-md} {
-        border-bottom: 1px solid $color-marketing-gray-80;
-        padding-bottom: $layout-lg;
+    @media #{$mq-sm} {
+        padding-bottom: $layout-sm;
     }
 
-    @media #{$mq-lg} {
+    @media #{$mq-xl} {
         padding-bottom: $layout-md;
     }
 }


### PR DESCRIPTION
## Description

Retains bottom border on footer-sections at all screen sizes. Tweaks spacing between footer sections and the border to match the spacing on the footer a bit more closely.

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #1061 

### Testing

The changes take affect at smaller screen sizes:

http://localhost:3000/components/detail/footer
