### PR TITLE
Update breadcrumb component (Fix #1036, Fix #933)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# HEAD
+
+## Features
+
+* **component:** Update breadcrumb styles (#1036)
+
+## Bug Fixes
+
+* **css:** Breadcrumbs are wider than other site content (#933)
+
+## Migration Tips
+
+* Breadcrumb updates do not require any changes, however if you have local customizations double check them.
+
+
 # 21.1.0
 
 ## Features

--- a/assets/sass/protocol/components/_breadcrumb.scss
+++ b/assets/sass/protocol/components/_breadcrumb.scss
@@ -6,37 +6,49 @@
 
 .mzp-c-breadcrumb {
     background-color: $background-color-secondary;
+    padding: $spacing-md 0;
 
     .mzp-c-breadcrumb-list {
-        margin-bottom: 0;
-        padding: $spacing-sm $spacing-md;
-
-        .mzp-c-breadcrumb-item {
-            display: inline-block;
-
-            &:last-child {
-                font-weight: bold;
-            }
-
-            + .mzp-c-breadcrumb-item {
-                &::before {
-                    @include bidi(((content, '\2192', '\2190'),));
-                    font-weight: normal;
-                    margin: 0 0.25em;
-                }
-            }
-
-            a {
-                text-decoration: none;
-            }
-        }
+        margin: 0 auto;
+        max-width: $content-max;
+        padding: 0 $h-grid-xs;
 
         @media #{$mq-md} {
-            padding: $spacing-sm $layout-sm;
+            padding: 0 $h-grid-md;
         }
 
-        @media #{$mq-lg} {
-            padding: $spacing-sm $layout-xl - $spacing-md;
+        @media #{$mq-xl} {
+            padding: 0 $h-grid-xl;
+        }
+    }
+
+    .mzp-c-breadcrumb-item {
+        display: inline-block;
+        padding: $spacing-sm 0;
+
+        &:last-child {
+            font-weight: bold;
+        }
+
+        + .mzp-c-breadcrumb-item {
+            &::before {
+                @include bidi(((content, '\2192', '\2190'),));
+                font-weight: normal;
+                margin: 0 0.25em;
+            }
+        }
+
+        a {
+            &:link,
+            &:visited {
+                text-decoration: underline;
+            }
+
+            &:hover,
+            &:active,
+            &:focus {
+                text-decoration: none;
+            }
         }
     }
 

--- a/components/breadcrumb/breadcrumb.html
+++ b/components/breadcrumb/breadcrumb.html
@@ -1,10 +1,46 @@
-<nav aria-label="breadcrumb" class="mzp-c-breadcrumb">
+<nav aria-label="breadcrumbs" class="mzp-c-breadcrumb">
   <ol class="mzp-c-breadcrumb-list">
     <li class="mzp-c-breadcrumb-item">
       <a href="#">Parent page</a>
     </li>
     <li aria-current="page" class="mzp-c-breadcrumb-item">
       Child page
+    </li>
+  </ol>
+</nav>
+
+<p>&nbsp;</p>
+
+<nav class="mzp-c-breadcrumb">
+  <ol class="mzp-c-breadcrumb-list">
+    <li class="mzp-c-breadcrumb-item">
+      <a href="/en-US/">Mozilla</a>
+    </li>
+    <li class="mzp-c-breadcrumb-item">
+      <a href="/en-US/products/">Products</a>
+    </li>
+    <li class="mzp-c-breadcrumb-item">
+      <a href="/en-US/products/monitor/">Monitor</a>
+    </li>
+    <li aria-current="page" class="mzp-c-breadcrumb-item">
+      Digital footprint: What it is and how to manage it
+    </li>
+  </ol>
+</nav>
+
+
+<p>&nbsp;</p>
+
+<nav class="mzp-c-breadcrumb">
+  <ol class="mzp-c-breadcrumb-list">
+    <li class="mzp-c-breadcrumb-item">
+      <a href="/en-US/">Firefox</a>
+    </li>
+    <li class="mzp-c-breadcrumb-item">
+      <a href="/en-US/features/">Features</a>
+    </li>
+    <li aria-current="page" class="mzp-c-breadcrumb-item">
+      Private browsing mode
     </li>
   </ol>
 </nav>


### PR DESCRIPTION
## Description

- Updates the look of breadcrumbs to match mozilla/bedrock#15751
- Restricts max-width of breadcrumbs to match other site content

---

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix #1036
Fix #933

### Testing

I added some other test cases to help check wrapping on smaller screen sizes:
http://localhost:3000/components/detail/breadcrumb

The styles are intended to match http://www.mozilla.org/en-US/products/monitor/what-is-a-data-broker/ so I used dev tools to apply the update locally and compare.