### PR TITLE
Fix typeof check for MzpSupports in navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Bug Fixes
 
 * **css:** Breadcrumbs are wider than other site content (#933)
+* **js:** `MzpNavigation` doesn't check for `MzpSupports` availability correctly (#1085)
 
 ## Migration Tips
 

--- a/assets/js/protocol/navigation.js
+++ b/assets/js/protocol/navigation.js
@@ -187,7 +187,10 @@ MzpNavigation.onClick = (e) => {
  */
 MzpNavigation.menuButtonVisible = (callback) => {
     // check if Intersection observer is supported
-    if (window.MzpSupports !== 'undefined' && window.MzpSupports.intersectionObserver) {
+    if (
+        typeof window.MzpSupports !== 'undefined' &&
+        window.MzpSupports.intersectionObserver
+    ) {
         const observer = new IntersectionObserver(
             (entries) => {
                 for (let index = 0; index < entries.length; index++) {
@@ -207,7 +210,10 @@ MzpNavigation.menuButtonVisible = (callback) => {
  * Set initial ARIA navigation states.
  */
 MzpNavigation.setAria = () => {
-    if (window.MzpSupports !== 'undefined' && window.MzpSupports.intersectionObserver) {
+    if (
+        typeof window.MzpSupports !== 'undefined' &&
+        window.MzpSupports.intersectionObserver
+    ) {
         MzpNavigation.menuButtonVisible((isVisible, menuButton) => {
             if (isVisible) {
                 // if the menu button is visible -  set the 'aria-expanded' role based on whether the menu is open or not


### PR DESCRIPTION
## Description

Adds forgotten `typeof` to make sure the support object is available.

- ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fixes #1085

### Testing

https://github.com/mozmeao/springfield/issues/380