### PR TITLE
Add cover support to at2x() mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Introducing theme variables! CSS variables beginning with `--theme-` will adjust
 
 * To come in follow up PR.
 
+## Bug Fixes
+
+* **css:** at2x mixin doesn't support single keyword values (#751)
+
 ## Migration Tips
 
 See the [Migration Guide](https://protocol.mozilla.org/docs/usage/migration) for automated scripts (VS Code find/replace and terminal commands) to help with these changes.

--- a/assets/sass/protocol/includes/mixins/_at2x.scss
+++ b/assets/sass/protocol/includes/mixins/_at2x.scss
@@ -10,13 +10,16 @@
 //  example.png
 //  example-high-res.png
 // Usage:
-//  @include at2x('/media/img/foo.png', 100px, 100px);
+//  @include at2x('/media/img/example.png', 100px, 100px);
+//  @include at2x('/media/img/example.jpg', auto, 200px);
+//  @include at2x('/media/img/example.avif', 25%);
+//  @include at2x('/media/img/example.webp', contain);
 
 @mixin at2x($path, $w: auto, $h: auto) {
     $hr-suffix: '-high-res';
 
-    // Do not set height to auto if width is contain
-    @if $w == 'contain' {
+    // Do not set height if `contain` or `cover` is passed as the first param
+    @if $w == 'contain' or $w == 'cover' {
         $h: #{''};
     }
 
@@ -28,7 +31,7 @@
     // Loop through the image path and find the position of
     // the dot to determine the file extension.
     // Subtract from string length to make an end point that
-    // is always lower than the start point s the loop always
+    // is always lower than the start point so the loop always
     // increments (10 is an arbitrary number).
     @for $i from $length through $length - 10 {
         @if $position == -1 {


### PR DESCRIPTION
## Description

This special cases also the other keyword, missing in the logic, to avoid emitting invalid `cover auto` output.

Also updates the API doc strings to demonstrate single keyword use.

- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Resolves #751

### Testing

_SASS Playground_ running some mixin variant args: [https://t.ly/El0D4](https://sass-lang.com/playground/#eJytVt9v2zYQfvdfcXO1OU4tuw7aFwcFXGweEqBdCtsDtqeFtiiJi0SqJGXZC/y/7yP1I46bAHtYYCcSybv7+N13d5lO56Xh1DfMmJmxWsikf93r9SYTury8pPXN7Yrwmc6mtPjj08/rz3/Sr8u7L/R1SYbtOMVKk1E5pyD/RqZQKnZ2cDDPxV5IYvZqfxEUzKYjCqoZsdIqPKX105Aee4SfINWhKeNY7Gc0CFORpKHmZgAgbhdYflEklSXDLaUc25ZETPdbJS0T8p4AAi87ru9JGCpwFx4RM2RTIBTaWKxplntvc1gGFX38SIPGfuDsuyV4GTSwamgzevM4GByv/dKxg7QCFkZbVUrLNTEZUYIVFzHjMrEpgQr3JnKWcHIMjOu7FsoIK5ScUTitnQYg3h3A5d88erKOg2an9jWjOjXj+vWiNRhet2g+K1UgnFZlkp6F9dhigV9uvY0OeK2tW47ArlUUcVwmF5I31GWc+N5yaWAx7m5ebqxmW0uxVnmDrL00fOTsgSMmcUQslJCOFGZbY+SHZRU7GMpUBeKwJ30wY5m2jYFRNZHuUvXpzlxuNc+5tIYupu+8N4hMbwQQ6QPJMt9wPayhzp04A1HDDFqADUfte0hw85Rur46OIyginJ7s+pRsU6a7hJhMbHmXDyhbuG+Tl1OnzXmkgaMgnI8RDcaDoYtxHuJMJoF47u7Ye/50bMm5jani+Gjwv0HqkIxYJCVeVWmpSt2G47VLKfgbtcb+JrVEnGiQBgV9b5jhXkAuoZ0S6HfDfVYRorUvtIpKeCh1ZnxbiEQcIyLSGTkze4AidkIr6dM3firGju4fzugOXPRXqZ6OTkyRxhPSA0B9PUWd0VvvoxbCqbVrWn89FaRDccTfrkkdx3hDCFQpTS4R55DxDISFkTCO+DBzFWS2xkwilWVMhzumhd+BV1SYpMtJFw7cLXlS4lhTtI68XKFpGWgd1I27oxu2fUigXxmF/ujMsX3x1DROLnFy1Ih/cBINLkivT6PeNH32JGzber8PPc95JBhdoDmElYgcN9P3798V++GZeF/H2NH6DOh/Afu9zpk82NT1ncoJrIKqEmgezXtEf5e+35u6/SstEiFZVqta+9nR9IBagTyDlh//b4qPvePTFL1ZLBf0Cd/V3ZcFrRer9YrWd3T723qx/LpcrH2BbVVeuH5bCeDEZDIq83VboHRdarjWSptmum6gsAePeo6OmJURrydtf+KG8YTvWV5kfMx2Iu6PmqF79eHHoZ+oP73Nmf5Wcv7Y1OALHhjGLfrFuOKbAh78WPRX9xdr7F8EcOC2s2YF/p1ApV59gE6a2B76y5FPTS26hw/sR/SI+huVlKbfYfgXeruf9g==) 