### PR TITLE
Remove inline eslint globals in configs

### DIFF
--- a/webpack.docs.build.config.js
+++ b/webpack.docs.build.config.js
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/* eslint-env node, commonjs, es2017 */
-
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');

--- a/webpack.docs.static.config.js
+++ b/webpack.docs.static.config.js
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/* eslint-env node, commonjs, es2017 */
-
 const CopyPlugin = require('copy-webpack-plugin');
 const path = require('path');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');

--- a/webpack.package.build.config.js
+++ b/webpack.package.build.config.js
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/* eslint-env node, commonjs, es2017 */
-
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');

--- a/webpack.package.static.config.js
+++ b/webpack.package.static.config.js
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/* eslint-env node, commonjs, es2017 */
-
 const CopyPlugin = require('copy-webpack-plugin');
 const path = require('path');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');


### PR DESCRIPTION
## Description

These are defined in the new config since #935 and should no longer use the old format.

- ~I have documented this change in the design system.~
- ~I have recorded this change in `CHANGELOG.md`.~

### Issue

#1121

### Testing

CI pass on v9 should be enough to verify v10 compatibility of these removals.
