### PR TITLE
Standardize form-element focus states on :focus-visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Introducing theme variables! CSS variables beginning with `--theme-` will adjust
 ### Accessibility
 
 * (breaking) Standardized interactive component states on `:focus-visible` instead of `:focus`, so the focus ring only shows for keyboard/assistive-tech focus rather than every mouse click. Affects Breadcrumb, Button, Card, Footer, Menu, Menu Item, Menu List, Modal, Navigation, Notification Bar, Sidebar Menu, and Sticky Promo. Text inputs keep `:focus` -- see the next entry.
+* (breaking) Did the same in form styles for checkboxes, radio buttons, `<select>`, and the `color`/`file` input types (click/pick-driven controls, not text entry). Text-like inputs and `<textarea>` keep `:focus` -- `:focus-visible` doesn't reliably match mouse-focused text fields across engines, and losing the ring on click there would be a real accessibility regression, not an improvement.
 ## Component changes
 
 ### Feature Card

--- a/assets/sass/protocol/base/elements/_forms.scss
+++ b/assets/sass/protocol/base/elements/_forms.scss
@@ -258,7 +258,7 @@ input[type='file'] {
         border-color: var(--theme-field-border-color-hover);
     }
 
-    &:focus {
+    &:focus-visible {
         border-color: var(--theme-field-border-color-focus);
         box-shadow: var(--theme-field-focus-ring);
         outline: none;
@@ -272,7 +272,7 @@ input[type='file'] {
             border-color: var(--theme-field-border-color-error-hover);
         }
 
-        &:focus {
+        &:focus-visible {
             border-color: var(--theme-form-red);
             box-shadow: var(--theme-field-focus-ring-error);
         }
@@ -284,7 +284,7 @@ input[type='file'] {
         border-color: var(--theme-field-border-color-disabled);
         color: var(--theme-form-text-color-inactive);
 
-        &:focus {
+        &:focus-visible {
             border-color: var(--theme-field-border-color-disabled-focus);
         }
     }
@@ -319,7 +319,7 @@ select {
     &[multiple] {
         &,
         &:hover,
-        &:focus {
+        &:focus-visible {
             background: var(--theme-background-color);
             padding: forms.$field-padding;
         }
@@ -334,7 +334,7 @@ select {
         background-image: $url-image-caret-down-link-hover, forms.$select-bg;
     }
 
-    &:focus {
+    &:focus-visible {
         border-color: var(--theme-field-border-color-focus);
         background-image: $url-image-caret-down-link, forms.$select-bg;
         box-shadow: var(--theme-field-focus-ring);
@@ -354,7 +354,7 @@ select {
             border-color: var(--theme-field-border-color-error-hover);
         }
 
-        &:focus {
+        &:focus-visible {
             border-color: var(--theme-form-red);
             box-shadow: var(--theme-field-focus-ring-error);
         }
@@ -370,7 +370,7 @@ select {
             border-color: var(--theme-field-border-color-disabled);
         }
 
-        &:focus {
+        &:focus-visible {
             border-color: var(--theme-field-border-color-disabled-focus);
         }
     }

--- a/assets/sass/protocol/components/forms/_choice.scss
+++ b/assets/sass/protocol/components/forms/_choice.scss
@@ -146,13 +146,13 @@
 
         // focus
 
-        &[type='checkbox']:focus + label::before,
-        &[type='radio']:focus + label::before {
+        &[type='checkbox']:focus-visible + label::before,
+        &[type='radio']:focus-visible + label::before {
             border-color: var(--theme-field-border-color-hover);
             box-shadow: var(--theme-field-focus-ring);
         }
 
-        &[type='radio']:checked:focus + label::before {
+        &[type='radio']:checked:focus-visible + label::before {
             border-color: var(--theme-field-border-color-hover);
             box-shadow: inset 0 0 0 0.25em var(--theme-background-color), var(--theme-field-focus-ring);
         }
@@ -180,13 +180,13 @@
             }
 
             // focus
-            &[type='checkbox']:focus + label::before,
-            &[type='radio']:focus + label::before {
+            &[type='checkbox']:focus-visible + label::before,
+            &[type='radio']:focus-visible + label::before {
                 border-color: var(--theme-field-border-color-error-hover);
                 box-shadow: var(--theme-field-focus-ring-error);
             }
 
-            &[type='radio']:checked:focus + label::before {
+            &[type='radio']:checked:focus-visible + label::before {
                 box-shadow: inset 0 0 0 0.25em var(--theme-background-color), var(--theme-field-focus-ring-error);
             }
         }
@@ -222,13 +222,13 @@
         }
 
         // disabled focus
-        &[type='checkbox'][disabled]:focus + label::before,
-        &[type='radio'][disabled]:focus + label::before {
+        &[type='checkbox'][disabled]:focus-visible + label::before,
+        &[type='radio'][disabled]:focus-visible + label::before {
             border-color: var(--theme-field-border-color-disabled);
             box-shadow: var(--theme-field-focus-ring-error);
         }
 
-        &[type='radio'][disabled]:checked:focus + label::before {
+        &[type='radio'][disabled]:checked:focus-visible + label::before {
             box-shadow: inset 0 0 0 0.25em var(--theme-background-color), var(--theme-field-focus-ring);
         }
     }

--- a/assets/sass/protocol/components/forms/_status.scss
+++ b/assets/sass/protocol/components/forms/_status.scss
@@ -6,10 +6,8 @@
 @use '../../includes/forms';
 
 input[list],
-input[type='color'],
 input[type='date'],
 input[type='email'],
-input[type='file'],
 input[type='number'],
 input[type='password'],
 input[type='search'],
@@ -17,7 +15,6 @@ input[type='tel'],
 input[type='text'],
 input[type='time'],
 input[type='url'],
-select,
 textarea {
     .mzp-is-error & {
         border-color: var(--theme-field-border-color-error);
@@ -33,6 +30,28 @@ textarea {
         }
 
         &:focus:hover {
+            border-color: var(--theme-field-border-color-error-hover);
+        }
+    }
+}
+
+input[type='color'],
+input[type='file'],
+select {
+    .mzp-is-error & {
+        border-color: var(--theme-field-border-color-error);
+        box-shadow: none;
+
+        &:hover {
+            border-color: var(--theme-field-border-color-error-hover);
+        }
+
+        &:focus-visible {
+            border-color: var(--theme-field-border-color-error);
+            box-shadow: var(--theme-field-focus-ring-error);
+        }
+
+        &:focus-visible:hover {
             border-color: var(--theme-field-border-color-error-hover);
         }
     }


### PR DESCRIPTION
## Description

- Updated `:focus` selectors in form related CSS.
- Click/pick form components migrated to :focus-visible
- Input/entry form components remain as :focus to give mouse users the benefit as well.
- [x] I have documented this change in the design system.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Part of #1084

### Testing

There's a page that includes all form controls. Tab around and mouse around to see if they are focusing as expected. Remember that buttons are form elements :) 

http://localhost:3000/components/detail/example-form