### PR TITLE
Convert templates/ and nav/menu/footer family to logical properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ Introducing theme variables! CSS variables beginning with `--theme-` will adjust
   * Added status color variables (`--theme-color-success-*`, `--theme-color-error-*`, `--theme-color-warning-*`, `--theme-color-info-*`)
 * Removed Sass color variables from `_themes-sass.scss` (use CSS variables instead)
 
+### CSS Logical Properties
+
+* Started migrating physical directional properties (`margin-left`, `padding-right`, `text-align: left`, etc.) to their logical equivalents (`margin-inline-start`, `padding-inline-end`, `text-align: start`, etc.), which adapt to RTL languages automatically instead of needing a `[dir='rtl']` override or the internal `bidi()` Sass mixin. First pass covers `includes/mixins/_utils.scss`, `includes/mixins/_details.scss`, `includes/forms/index.scss`, and `base/elements/_forms.scss`, `_lists.scss`, `_links.scss`, `_tables.scss`, `_quotes.scss`, `_details.scss`, and `base/utilities/_rich-text.scss`. Components follow in subsequent PRs, ending with the removal of `bidi()` itself.
+* Where a property has no logical equivalent that's safe across the supported browser matrix (e.g. `background-position` for a decorative icon), kept the physical value with an explicit `[dir='rtl']` override rather than forcing an incomplete conversion.
+
 ## Component changes
 
 ### Feature Card

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Introducing theme variables! CSS variables beginning with `--theme-` will adjust
 
 ## Architecture changes
 
+### CSS Logical Properties
+
+* Continued migrating physical directional properties to their logical equivalents (see #1084) -- `templates/_card-layout.scss`, `templates/_main-with-sidebar.scss`, `_footer.scss`, `_navigation.scss`, `_menu.scss`, `_menu-item.scss`, `_menu-list.scss`, and `_sidebar-menu.scss`. 59 `bidi()` calls removed.
+* Where a property has no logical equivalent safe across the supported matrix (`background-position`, and a CSS `transform` that visually flips a directional glyph), kept the physical value with an explicit `[dir='rtl']` override instead.
+
 ### Browser Support
 
 * (breaking) Remove support for vendor prefixing (#957)

--- a/assets/sass/protocol/base/elements/_details.scss
+++ b/assets/sass/protocol/base/elements/_details.scss
@@ -17,7 +17,7 @@ details .is-summary button,
 
 // Override styling the native element when the polyfill is applied (issue #658)
 summary.is-summary {
-    @include bidi(((padding-right, 0, padding-left, 0),));
+    padding-inline: 0;
 
     &::before {
         display: none;

--- a/assets/sass/protocol/base/elements/_forms.scss
+++ b/assets/sass/protocol/base/elements/_forms.scss
@@ -114,7 +114,8 @@ label {
 
     &.mzp-u-inline {
         display: inline;
-        @include bidi(((padding, 0 $spacing-sm 0 0, 0 0 0 $spacing-sm),));
+        padding-block-end: 0;
+        padding-inline-end: $spacing-sm;
     }
 }
 
@@ -302,18 +303,21 @@ select {
     appearance: none;
     box-sizing: border-box;
     background-image: $url-image-caret-down-form, forms.$select-bg;
+    background-position: right 8px top 50%;
     background-repeat: no-repeat, repeat;
     background-size: 1em auto, 100%;
     display: block;
     font-weight: normal;
     max-width: 100%;
     min-width: forms.$field-min-width;
+    padding-block: forms.$field-padding;
+    padding-inline: forms.$field-padding forms.$symbol-spacing;
     text-overflow: ellipsis;
     @include forms.form-input;
-    @include bidi((
-        (background-position, right 8px top 50%, left 8px top 50%),
-        (padding, forms.$field-padding forms.$symbol-spacing forms.$field-padding forms.$field-padding, forms.$field-padding forms.$field-padding forms.$field-padding forms.$symbol-spacing),
-    ));
+
+    [dir='rtl'] & {
+        background-position: left 8px top 50%;
+    }
 
     // no down arrow on multi selects
     &[multiple] {

--- a/assets/sass/protocol/base/elements/_links.scss
+++ b/assets/sass/protocol/base/elements/_links.scss
@@ -84,11 +84,11 @@ a {
     }
 
     &-icon-start {
-        @include bidi(((margin-right, 0.5ch, 0), (margin-left, 0, 0.5ch),));
+        margin-inline: 0 0.5ch;
     }
 
     &-icon-end {
-        @include bidi(((margin-left, 0.5ch, 0), (margin-right, 0, 0.5ch),));
+        margin-inline: 0.5ch 0;
     }
 
 }

--- a/assets/sass/protocol/base/elements/_lists.scss
+++ b/assets/sass/protocol/base/elements/_lists.scss
@@ -14,7 +14,7 @@ ol {
 
 ul.mzp-u-list-styled {
     list-style: disc;
-    @include bidi(((margin-left, $layout-sm, margin-right, 0),));
+    margin-inline-start: $layout-sm;
 
     li {
         margin-bottom: 0.25em;
@@ -23,19 +23,19 @@ ul.mzp-u-list-styled {
     ul {
         list-style: circle;
         margin-bottom: 0;
-        @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+        margin-inline-start: $layout-xs;
     }
 
     ol {
         list-style: decimal;
         margin-bottom: 0;
-        @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+        margin-inline-start: $layout-xs;
     }
 }
 
 ol.mzp-u-list-styled {
     list-style: decimal;
-    @include bidi(((margin-left, $layout-sm, margin-right, 0),));
+    margin-inline-start: $layout-sm;
 
     li {
         margin-bottom: 0.25em;
@@ -44,13 +44,13 @@ ol.mzp-u-list-styled {
     ol {
         list-style: lower-alpha;
         margin-bottom: 0;
-        @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+        margin-inline-start: $layout-xs;
     }
 
     ul {
         list-style: disc;
         margin-bottom: 0;
-        @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+        margin-inline-start: $layout-xs;
     }
 }
 
@@ -62,13 +62,13 @@ dl.mzp-u-list-styled {
 
     dd {
         margin-bottom: 0.25em;
-        @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+        margin-inline-start: $layout-xs;
     }
 
     ul,
     ol {
         margin-bottom: 0;
-        @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+        margin-inline-start: $layout-xs;
     }
 
     ul {
@@ -79,13 +79,11 @@ dl.mzp-u-list-styled {
 /* !important required to trump specificity and print stylesheet overrides */
 .mzp-u-list-unstyled {
     list-style: none !important; /* stylelint-disable-line declaration-no-important */
-    margin-left: 0 !important; /* stylelint-disable-line declaration-no-important */
-    margin-right: 0 !important; /* stylelint-disable-line declaration-no-important */
+    margin-inline: 0 !important; /* stylelint-disable-line declaration-no-important */
 
     ul,
     ol {
         list-style: none !important; /* stylelint-disable-line declaration-no-important */
-        margin-left: 0 !important; /* stylelint-disable-line declaration-no-important */
-        margin-right: 0 !important; /* stylelint-disable-line declaration-no-important */
+        margin-inline: 0 !important; /* stylelint-disable-line declaration-no-important */
     }
 }

--- a/assets/sass/protocol/base/elements/_quotes.scss
+++ b/assets/sass/protocol/base/elements/_quotes.scss
@@ -6,13 +6,15 @@
 
 blockquote {
     @include text-heading-sm;
+    border-block-width: 0;
     border-color: $color-marketing-gray-20;
+    border-inline-end-width: 0;
+    border-inline-start-width: 5px;
     border-style: solid;
     color: var(--theme-heading-text-color);
     font-weight: bold;
     margin: $spacing-lg auto;
     padding: $spacing-sm $spacing-lg;
-    @include bidi(((border-width, 0 0 0 5px, 0 5px 0 0),));
 
     cite {
         @include text-heading-xs;

--- a/assets/sass/protocol/base/utilities/_rich-text.scss
+++ b/assets/sass/protocol/base/utilities/_rich-text.scss
@@ -55,7 +55,7 @@
 
     ul {
         list-style-type: disc;
-        @include bidi(((margin-left, $layout-sm, margin-right, 0),));
+        margin-inline-start: $layout-sm;
 
         ul {
             list-style-type: circle;
@@ -64,7 +64,7 @@
 
     ol {
         list-style-type: decimal;
-        @include bidi(((margin-left, $layout-sm, margin-right, 0),));
+        margin-inline-start: $layout-sm;
 
         ol {
             list-style-type: lower-roman;
@@ -75,7 +75,7 @@
         margin-bottom: 0.25em;
 
         ul, ol {
-            @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+            margin-inline-start: $layout-xs;
         }
     }
 
@@ -86,7 +86,7 @@
 
     dd {
         margin-bottom: 0.25em;
-        @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+        margin-inline-start: $layout-xs;
     }
 
     pre {

--- a/assets/sass/protocol/components/_footer.scss
+++ b/assets/sass/protocol/components/_footer.scss
@@ -105,11 +105,11 @@
 
         &:nth-child(odd) {
             clear: inline-start;
-            @include bidi(((padding, 0 ($layout-md * 0.5) 0 0, 0 0 0 ($layout-md * 0.5)),));
+            padding-inline-end: $layout-md * 0.5;
         }
 
         &:nth-child(even) {
-            @include bidi(((padding, 0 0 0 ($layout-md * 0.5), 0 ($layout-md * 0.5) 0 0),));
+            padding-inline-start: $layout-md * 0.5;
         }
     }
 }
@@ -120,11 +120,11 @@
         float: inline-start;
 
         &:first-child {
-            @include bidi(((padding, 0 ($layout-md * 0.5) 0 0, 0 0 0 ($layout-md * 0.5)),));
+            padding-inline-start: 0;
         }
 
         &:last-child {
-            @include bidi(((padding, 0 0 0 ($layout-md * 0.5), 0 ($layout-md * 0.5) 0 0),));
+            padding-inline-end: 0;
         }
     }
 
@@ -181,11 +181,11 @@
             transition: transform 100ms ease-in-out;
             content: '';
             height: 24px;
+            inset-inline-end: 8px;
             margin-top: -12px;
             position: absolute;
             top: 50%;
             width: 24px;
-            @include bidi(((right, 8px, left, auto),));
         }
 
         button[aria-expanded='true']::before {
@@ -267,8 +267,8 @@
 
     li {
         display: inline-block;
+        margin-inline-end: $spacing-md;
         vertical-align: bottom;
-        @include bidi(((margin, 0 $spacing-md 0 0, 0 0 0 $spacing-md),));
 
         a {
             @include image-replaced;
@@ -299,17 +299,16 @@
 
     @media #{$mq-md} {
         bottom: 0;
+        inset-inline-end: 0;
         margin-bottom: 0;
         max-width: 33%; // don't over lap with legal links
         position: absolute;
-        @include bidi(((right, 0, left, auto),));
         text-align: end;
 
         li {
-            @include bidi((
-                (padding, 0 0 $spacing-md $spacing-lg, 0 $spacing-lg $spacing-md 0),
-                (margin, 0 , 0),
-            ));
+            margin: 0;
+            padding-block-end: $spacing-md;
+            padding-inline-start: $spacing-lg;
         }
     }
 }
@@ -330,10 +329,10 @@
     @media #{$mq-md} {
         li {
             display: inline-block;
-            @include bidi(((padding, 0 $spacing-lg 0 0, 0 0 0 $spacing-lg),));
+            padding-inline-end: $spacing-lg;
 
             &:last-child {
-                @include bidi(((padding-right, 0, padding-left, 0),));
+                padding-inline: 0;
             }
         }
     }

--- a/assets/sass/protocol/components/_menu-item.scss
+++ b/assets/sass/protocol/components/_menu-item.scss
@@ -41,16 +41,16 @@ $icon-size: 24px;
     &.mzp-has-icon {
         .mzp-c-menu-item-head,
         .mzp-c-menu-item-link {
+            padding-inline-start: $icon-size + $spacing-lg;
             position: relative;
-            @include bidi(((padding-left, $icon-size + $spacing-lg, padding-right, 0),));
 
             .mzp-c-menu-item-icon {
                 height: $icon-size;
+                inset-inline-start: $spacing-sm;
                 margin: 0;
                 position: absolute;
                 top: $spacing-sm;
                 width: $icon-size;
-                @include bidi(((left, $spacing-sm, right, auto),));
             }
         }
     }
@@ -95,21 +95,19 @@ $icon-size: 24px;
                 float: inline-start;
 
                 &:nth-child(odd) {
-                    @include bidi((
-                        (clear, left, right),
-                        (padding-right, $spacing-sm, padding-left, 0),
-                    ));
+                    clear: inline-start;
+                    padding-inline-end: $spacing-sm;
                 }
 
                 &:nth-child(even) {
-                    @include bidi(((padding-left, $spacing-sm, padding-right, 0),));
+                    padding-inline-start: $spacing-sm;
                 }
             }
         }
     }
 
     &.mzp-has-icon .mzp-c-menu-item-list {
-        @include bidi(((margin-left, $icon-size + $spacing-lg, margin-right, 0),));
+        margin-inline-start: $icon-size + $spacing-lg;
     }
 
     @media #{$mq-md} {
@@ -124,7 +122,8 @@ $icon-size: 24px;
         }
 
         .mzp-c-menu-item-list {
-            @include bidi(((margin, $spacing-md 0 0 $spacing-sm, $spacing-md $spacing-sm 0 0),));
+            margin-block-start: $spacing-md;
+            margin-inline-start: $spacing-sm;
         }
     }
 }

--- a/assets/sass/protocol/components/_menu-list.scss
+++ b/assets/sass/protocol/components/_menu-list.scss
@@ -31,17 +31,17 @@
         text-decoration: none;
 
         .mzp-t-download & {
-            @include bidi(((padding-right, $spacing-sm * 2 + 14px, padding-left, $spacing-sm),));
+            padding-inline-end: $spacing-sm * 2 + 14px;
 
             &::after {
                 background-size: 20px, 20px;
                 bottom: $spacing-sm;
                 content: '';
                 display: block;
+                inset-inline-end: $spacing-sm;
                 position: absolute;
                 top: $spacing-sm;
                 width: 14px;
-                @include bidi(((right, $spacing-sm, left, auto),));
             }
         }
 
@@ -76,22 +76,23 @@
             font-family: inherit;
             font-size: inherit;
             font-weight: inherit;
+            padding-block: 0;
+            padding-inline: 0 (16px + $spacing-sm);
             position: relative;
             text-align: inherit;
             text-decoration: underline;
             width: 100%;
-            @include bidi(((padding, 0 (16px + $spacing-sm) 0 0, 0 0 0 (16px + $spacing-sm)),));
 
             &::after {
                 background: $url-image-caret-down-link center bottom no-repeat;
                 bottom: 1px;
                 content: '';
                 display: inline-block;
+                inset-inline-end: 0;
                 position: absolute;
                 top: 0;
                 width: 16px;
                 transition: transform 200ms ease-in-out;
-                @include bidi(((right, 0, left, auto),));
             }
 
             &[aria-expanded='true']::after {

--- a/assets/sass/protocol/components/_menu.scss
+++ b/assets/sass/protocol/components/_menu.scss
@@ -79,11 +79,11 @@
             transition: transform 100ms ease-in-out;
             content: '';
             height: 20px;
+            inset-inline-end: 8px;
             margin-top: -8px;
             position: absolute;
             top: 50%;
             width: 20px;
-            @include bidi(((right, 8px, left, auto),));
         }
     }
 
@@ -230,11 +230,11 @@
         }
 
         @media #{$mq-md} {
-            @include bidi(((right, $layout-lg, left, auto),));
+            inset-inline-end: $layout-lg;
         }
 
         @media #{$mq-lg} {
-            @include bidi(((right, $layout-xl, left, auto),));
+            inset-inline-end: $layout-xl;
         }
     }
 
@@ -290,11 +290,11 @@
                 float: inline-start;
 
                 &:first-child {
-                    @include bidi(((margin-right, $spacing-lg * 0.5, margin-left, 0),));
+                    margin-inline-end: $spacing-lg * 0.5;
                 }
 
                 &:last-child {
-                    @include bidi(((margin-left, $spacing-lg * 0.5, margin-right, 0),));
+                    margin-inline-start: $spacing-lg * 0.5;
                 }
 
                 & > li:last-child .mzp-c-menu-item {

--- a/assets/sass/protocol/components/_navigation.scss
+++ b/assets/sass/protocol/components/_navigation.scss
@@ -85,7 +85,8 @@
     }
 
     @media #{$mq-md} {
-        @include bidi(((margin, $spacing-lg ($spacing-sm * 2) $spacing-lg 0, $spacing-lg 0 $spacing-lg ($spacing-sm * 2)),));
+        margin-block: $spacing-lg;
+        margin-inline: 0 ($spacing-sm * 2);
 
         a {
             margin-top: $spacing-sm;
@@ -93,11 +94,13 @@
     }
 
     @media #{$mq-lg} {
-        @include bidi(((margin, $spacing-lg ($spacing-md * 2) $spacing-lg 0, $spacing-lg 0 $spacing-lg ($spacing-md * 2)),));
+        margin-block: $spacing-lg;
+        margin-inline: 0 ($spacing-md * 2);
     }
 
     @media #{$mq-xl} {
-        @include bidi(((margin, $spacing-lg ($spacing-lg * 2) $spacing-lg 0, $spacing-lg 0 $spacing-lg ($spacing-lg * 2)),));
+        margin-block: $spacing-lg;
+        margin-inline: 0 ($spacing-lg * 2);
     }
 
     .mzp-t-firefox & {
@@ -134,16 +137,16 @@
 
     @media #{$mq-md} {
         display: inline-block;
+        margin-inline-start: -$spacing-sm;
         width: auto;
-        @include bidi(((margin-left, -$spacing-sm, margin-right, 0),));
     }
 
     @media #{$mq-lg} {
-        @include bidi(((margin-left, -$spacing-md, margin-right, 0),));
+        margin-inline-start: -$spacing-md;
     }
 
     @media #{$mq-xl} {
-        @include bidi(((margin-left, -$spacing-lg, margin-right, 0),));
+        margin-inline-start: -$spacing-lg;
     }
 }
 
@@ -167,17 +170,17 @@
         display: block;
         float: inline-end;
         margin: $spacing-lg 0;
-        @include bidi((
-            (margin, $spacing-lg 0 $spacing-lg $spacing-sm, $spacing-lg $spacing-sm $spacing-lg 0),
-        ));
+        margin-inline-start: $spacing-sm;
     }
 
     @media #{$mq-lg} {
-        @include bidi(((margin, $spacing-lg 0 $spacing-lg $spacing-md, $spacing-lg $spacing-md $spacing-lg 0),));
+        margin-block: $spacing-lg;
+        margin-inline-start: $spacing-md;
     }
 
     @media #{$mq-xl} {
-        @include bidi(((margin, $spacing-lg 0 $spacing-lg $spacing-lg, $spacing-lg $spacing-lg $spacing-lg 0),));
+        margin-block: $spacing-lg;
+        margin-inline-start: $spacing-lg;
     }
 }
 
@@ -187,16 +190,19 @@
 .mzp-c-navigation-menu-button {
     background-color: transparent;
     background-image: url('#{$image-path}/icons/menu.svg');
+    background-position: right 6px center;
     background-repeat: no-repeat;
     border-radius: $border-radius-sm;
     border: none;
     display: none;
-    height: 32px;
     float: inline-end;
-    @include bidi((
-        (background-position, right 6px center, left 6px center ),
-        (padding, 0 32px 0 6px, 0 6px 0 32px)
-    ));
+    height: 32px;
+    padding-block: 0;
+    padding-inline: 6px 32px;
+
+    [dir='rtl'] & {
+        background-position: left 6px center;
+    }
 
     &:hover,
     &:active,
@@ -210,10 +216,8 @@
     cursor: pointer;
     width: 32px;
     @include image-replaced;
-    @include bidi((
-        (background-position, center center, center center ),
-        (padding, 0, 0),
-    ));
+    background-position: center center;
+    padding: 0;
 }
 
 .js .mzp-c-navigation-menu-button {

--- a/assets/sass/protocol/components/_sidebar-menu.scss
+++ b/assets/sass/protocol/components/_sidebar-menu.scss
@@ -23,17 +23,16 @@
     li {
         color: $color-marketing-gray-80;
         display: inline-block;
-        @include bidi((
-            (margin-right, $spacing-xs, margin-left, 0),
-        ));
+        margin-inline-end: $spacing-xs;
 
         &::after {
             content: '\25B8'; // right pointing triangle
             display: inline-block;
-            @include bidi((
-                (margin-left, $spacing-xs, margin-right, 0),
-                (transform, none, translateY(3px) rotate(180deg)),
-            ));
+            margin-inline-start: $spacing-xs;
+
+            [dir='rtl'] & {
+                transform: translateY(3px) rotate(180deg);
+            }
         }
 
         &:last-child::after {
@@ -78,23 +77,19 @@
 }
 
 .mzp-c-sidemenu-label {
+    padding-inline-end: $spacing-lg;
     position: relative;
     @include text-body-sm;
     @include font-base;
-    @include bidi((
-        (padding-right, $spacing-lg, padding-left, 0),
-    ));
 
     &::after {
         transform: rotate(90deg);
         color: $color-marketing-gray-80;
         content: none;
         font-size: 1.5em;
+        inset-inline-end: 0;
         position: absolute;
         top: 0;
-        @include bidi((
-            (right, 0, left, auto),
-        ));
     }
 }
 

--- a/assets/sass/protocol/includes/forms/index.scss
+++ b/assets/sass/protocol/includes/forms/index.scss
@@ -117,8 +117,8 @@ $line-height-shim: 0.15em; // two elements with text appear to have more space b
     bottom: 100%;
     content: '';
     height: 0;
+    inset-inline-start: 6px;
     position: absolute;
     width: 0;
     z-index: 1;
-    @include bidi(((left, 6px, right, auto),));
 }

--- a/assets/sass/protocol/includes/mixins/_details.scss
+++ b/assets/sass/protocol/includes/mixins/_details.scss
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @use '../tokens';
-@use 'bidi';
 @use 'images';
 
 @mixin details {
@@ -28,12 +27,13 @@
 }
 
 @mixin summary {
+    padding-inline-end: tokens.$layout-md;
     position: relative;
-    @include bidi.bidi(((padding-right, tokens.$layout-md, padding-left, 0),));
 
     &::before {
         background: images.$url-image-expand-black top left no-repeat;
         background-size: 20px, 20px;
+        inset-inline-end: 8px;
         transition: transform 100ms ease-in-out;
         content: '';
         height: 20px;
@@ -41,7 +41,6 @@
         position: absolute;
         top: 50%;
         width: 20px;
-        @include bidi.bidi(((right, 8px, left, auto),));
     }
 }
 

--- a/assets/sass/protocol/includes/mixins/_utils.scss
+++ b/assets/sass/protocol/includes/mixins/_utils.scss
@@ -81,11 +81,8 @@
     iframe,
     object,
     embed {
-        bottom: 0;
-        left: 0;
+        inset: 0;
         position: absolute;
-        right: 0;
-        top: 0;
     }
 }
 

--- a/assets/sass/protocol/templates/_card-layout.scss
+++ b/assets/sass/protocol/templates/_card-layout.scss
@@ -18,15 +18,11 @@
 
         .mzp-c-card {
             float: inline-start;
+            margin-inline: 0 var(--theme-spacing-between-inline);
             width: calc(50% - (var(--theme-spacing-between-inline) * 0.5));
-            @include bidi((
-                (margin-left, 0, var(--theme-spacing-between-inline)),
-                (margin-right, var(--theme-spacing-between-inline), 0),
-            ));
 
             &:nth-child(odd) {
-                margin-left: 0;
-                margin-right: 0;
+                margin-inline: 0;
             }
 
             &.mzp-c-card-large {
@@ -40,19 +36,16 @@
             width: calc(33.3% - (var(--theme-spacing-between-inline) - (var(--theme-spacing-between-inline) * 0.33)));
 
             &:nth-child(odd) {
-                @include bidi((
-                    (margin-left, 0, var(--theme-spacing-between-inline)),
-                    (margin-right, var(--theme-spacing-between-inline), 0),
-                ));
+                margin-inline: 0 var(--theme-spacing-between-inline);
             }
 
             &:nth-child(2),
             &:last-child {
-                @include bidi(((margin-right, 0, margin-left, 0),));
+                margin-inline-end: 0;
             }
 
             &:nth-child(3n) {
-                @include bidi(((clear, left, right),));
+                clear: inline-start;
             }
         }
 
@@ -73,40 +66,30 @@
 
         .mzp-c-card {
             float: inline-start;
+            margin-inline: 0 var(--theme-spacing-between-inline);
             width: calc(50% - (var(--theme-spacing-between-inline) * 0.5));
-            @include bidi((
-                (margin-left, 0, var(--theme-spacing-between-inline)),
-                (margin-right, var(--theme-spacing-between-inline), 0),
-            ));
 
             &:nth-child(even) {
-                margin-left: 0;
-                margin-right: 0;
+                margin-inline: 0;
             }
         }
     }
 
     @media #{$mq-lg} {
         .mzp-c-card {
+            margin-inline: 0 var(--theme-spacing-between-inline);
             width: calc(25% - (var(--theme-spacing-between-inline) - var(--theme-spacing-between-inline) * 0.25));
-            @include bidi((
-                (margin-left, 0, var(--theme-spacing-between-inline)),
-                (margin-right, var(--theme-spacing-between-inline), 0),
-            ));
 
             &:nth-child(even) {
-                @include bidi((
-                    (margin-left, 0, var(--theme-spacing-between-inline)),
-                    (margin-right, var(--theme-spacing-between-inline), 0),
-                ));
+                margin-inline: 0 var(--theme-spacing-between-inline);
             }
 
             &:nth-child(4n) {
-                @include bidi(((margin-right, 0, margin-left, 0),));
+                margin-inline-end: 0;
             }
 
             &:nth-child(4n+1) {
-                @include bidi(((clear, left, right),));
+                clear: inline-start;
             }
         }
     }
@@ -122,17 +105,12 @@
         @include clearfix;
 
         .mzp-c-card {
+            float: inline-start;
+            margin-inline: 0 var(--theme-spacing-between-inline);
             width: calc(50% - var(--theme-spacing-between-inline) * 0.5);
 
-            @include bidi((
-                (float, left, right),
-                (margin-left, 0, var(--theme-spacing-between-inline)),
-                (margin-right, var(--theme-spacing-between-inline), 0),
-            ));
-
             &:nth-child(even) {
-                margin-left: 0;
-                margin-right: 0;
+                margin-inline: 0;
             }
         }
     }
@@ -142,18 +120,15 @@
             width: calc(33.3% - (var(--theme-spacing-between-inline) - var(--theme-spacing-between-inline) * 0.33));
 
             &:nth-child(even) {
-                @include bidi((
-                    (margin-left, 0, var(--theme-spacing-between-inline)),
-                    (margin-right, var(--theme-spacing-between-inline), 0),
-                ));
+                margin-inline: 0 var(--theme-spacing-between-inline);
             }
 
             &:nth-child(3n) {
-                @include bidi(((margin-right, 0, margin-left, 0),));
+                margin-inline-end: 0;
             }
 
             &:nth-child(3n+1) {
-                @include bidi(((clear, left, right),));
+                clear: inline-start;
             }
         }
     }
@@ -168,19 +143,15 @@
         @include clearfix;
 
         .mzp-c-card {
-            @include bidi((
-                (float, left, right),
-                (margin-left, 0, var(--theme-spacing-between-inline)),
-                (margin-right, var(--theme-spacing-between-inline), 0),
-            ));
+            float: inline-start;
+            margin-inline: 0 var(--theme-spacing-between-inline);
 
             &:nth-child(2n) {
-                margin-left: 0;
-                margin-right: 0;
+                margin-inline: 0;
             }
 
             &:nth-child(2n+1) {
-                @include bidi(((clear, left, right),));
+                clear: inline-start;
             }
         }
     }

--- a/assets/sass/protocol/templates/_main-with-sidebar.scss
+++ b/assets/sass/protocol/templates/_main-with-sidebar.scss
@@ -17,37 +17,25 @@
 
         &.mzp-l-sidebar-left {
             .mzp-l-main {
-                @include bidi((
-                    (float, right, left),
-                    (padding-left, $spacing-md, 0),
-                    (padding-right, 0, $spacing-md)
-                ));
+                float: inline-end;
+                padding-inline-start: $spacing-md;
             }
 
             .mzp-l-sidebar {
-                @include bidi((
-                    (float, left, right),
-                    (padding-right, $spacing-md, 0),
-                    (padding-left, 0, $spacing-md)
-                ));
+                float: inline-start;
+                padding-inline-end: $spacing-md;
             }
         }
 
         &.mzp-l-sidebar-right {
             .mzp-l-main {
-                @include bidi((
-                    (float, left, right),
-                    (padding-right, $spacing-md, 0),
-                    (padding-left, 0, $spacing-md)
-                ));
+                float: inline-start;
+                padding-inline-end: $spacing-md;
             }
 
             .mzp-l-sidebar {
-                @include bidi((
-                    (float, right, left),
-                    (padding-left, $spacing-md, 0),
-                    (padding-right, 0, $spacing-md)
-                ));
+                float: inline-end;
+                padding-inline-start: $spacing-md;
             }
         }
     }


### PR DESCRIPTION
## Description

Second pass of the logical-properties migration.

  templates/_card-layout.scss    (15 -> 0)
  _navigation.scss               (11 -> 0)
  _footer.scss                   (10 -> 0)
  _menu-item.scss                (6 -> 0)
  _menu.scss                     (5 -> 0)
  _menu-list.scss                (4 -> 0)
  _sidebar-menu.scss             (4 -> 0)
  templates/_main-with-sidebar.scss (4 -> 0)

- [ ] ~I have documented this change in the design system.~
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Part of #1084.

### Testing

Enter helpful notes for whoever code reviews this change.
